### PR TITLE
Fix download-all option and Windows script paths

### DIFF
--- a/Guide.md
+++ b/Guide.md
@@ -54,13 +54,13 @@ py setup.py
 
 Alternatively, use the provided batch script:
 ```
-scripts\windows\setup.bat
+.\scripts\windows\setup.bat
 ```
 
 ### Verify Installation
 
 ```
-scripts\windows\run.bat --help
+.\scripts\windows\run.bat --help
 ```
 
 You should see the help output with available commands.
@@ -70,15 +70,15 @@ You should see the help output with available commands.
 From now on, launch MeManga with:
 
 ```
-scripts\windows\run.bat
+.\scripts\windows\run.bat
 ```
 
 This opens the interactive TUI. For specific commands:
 
 ```
-scripts\windows\run.bat list
-scripts\windows\run.bat add -i
-scripts\windows\run.bat check
+.\scripts\windows\run.bat list
+.\scripts\windows\run.bat add -i
+.\scripts\windows\run.bat check
 ```
 
 Or run directly through the virtual environment:
@@ -246,7 +246,7 @@ Or run directly through the virtual environment:
 ## Your First Manga
 
 > In all examples below, `run` means the launcher for your platform:
-> - **Windows:** `scripts\windows\run.bat`
+> - **Windows:** `.\scripts\windows\run.bat`
 > - **macOS / Linux:** `./scripts/run.sh`
 
 ### Interactive mode (recommended)
@@ -676,7 +676,7 @@ run update 1 -u "https://new-source.com/one-piece"
 Install a daily scheduled task:
 
 ```
-scripts\windows\run.bat cron install
+.\scripts\windows\run.bat cron install
 ```
 
 You'll be asked what time to run (default: 06:00):
@@ -689,13 +689,13 @@ Check time (HH:MM): 07:30
 Check if it's active:
 
 ```
-scripts\windows\run.bat cron status
+.\scripts\windows\run.bat cron status
 ```
 
 Remove it:
 
 ```
-scripts\windows\run.bat cron remove
+.\scripts\windows\run.bat cron remove
 ```
 
 The task is named `MeManga_AutoCheck` and can also be seen in Windows Task Scheduler (`taskschd.msc`).
@@ -832,7 +832,7 @@ python setup.py
 Or:
 
 ```
-scripts\windows\setup.bat
+.\scripts\windows\setup.bat
 ```
 
 ### Playwright browsers fail to launch

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then:
 ./scripts/run.sh             # Launch interactive TUI
 ```
 
-> **Windows:** Use `scripts\windows\run.bat` instead of `./scripts/run.sh`
+> **Windows:** Use `.\scripts\windows\run.bat` instead of `./scripts/run.sh`
 
 ## 🌐 Popular Sources
 

--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -386,11 +386,15 @@ def cmd_check(args):
             return
     
     from_chapter = getattr(args, 'from_chapter', None)
+    if getattr(args, 'all', False):
+        from_chapter = 0
     dry_run = getattr(args, 'dry_run', False)
 
     if dry_run:
         console.print(Panel("[bold]🔍 Dry Run — Checking for New Chapters[/bold]", border_style="yellow"))
-    elif from_chapter:
+    elif from_chapter is not None and from_chapter == 0:
+        console.print(Panel("[bold]📥 Downloading All Chapters[/bold]", border_style="green"))
+    elif from_chapter is not None:
         console.print(Panel(f"[bold]📥 Downloading from Chapter {from_chapter}[/bold]", border_style="green"))
     else:
         console.print(Panel("[bold]🔍 Checking for New Chapters[/bold]", border_style="blue"))
@@ -1013,11 +1017,13 @@ def cmd_tui(args):
 
                 # Start from chapter?
                 from_input = Prompt.ask(
-                    "Start from chapter? (Enter for latest, or type a number)",
+                    "Start from chapter? (Enter for latest, 0 or 'all' for all chapters, or type a number)",
                     default="",
                 )
                 from_chapter = None
-                if from_input.strip():
+                if from_input.strip().lower() == "all":
+                    from_chapter = 0
+                elif from_input.strip():
                     try:
                         from_chapter = float(from_input)
                     except ValueError:
@@ -1132,6 +1138,7 @@ Examples:
     p_check = subparsers.add_parser("check", help="Check for new chapters")
     p_check.add_argument("-t", "--title", help="Check specific manga only")
     p_check.add_argument("-f", "--from", dest="from_chapter", type=float, help="Start from chapter N (for fresh downloads)")
+    p_check.add_argument("--all", action="store_true", help="Download all chapters from the beginning")
     p_check.add_argument("-a", "--auto", action="store_true", help="Auto-download without prompts")
     p_check.add_argument("-y", "--yes", action="store_true", help="Say yes to all prompts")
     p_check.add_argument("-q", "--quiet", action="store_true", help="Minimal output (for cron)")


### PR DESCRIPTION
- Fix falsy-zero bug where --from 0 was silently ignored (0 is falsy in Python)
- Add --all CLI flag to download all chapters from the beginning
- Add 'all' and 0 as valid inputs in TUI "Start from chapter?" prompt
- Show "Downloading All Chapters" panel when downloading everything
- Fix all Windows script paths in README.md and Guide.md to use .\ prefix (PowerShell requires .\ for relative paths)