### PR TITLE
fix(state): relax source-health warning threshold to 2500 ms

### DIFF
--- a/memanga/state.py
+++ b/memanga/state.py
@@ -18,6 +18,13 @@ class State:
     Call flush() explicitly when you need the file written immediately.
     """
 
+    # Latency above which a successful probe is flagged "warning" instead
+    # of "ok". Healthy sites on an ordinary connection routinely answer in
+    # 500-2000 ms, so a lower bound paints almost every source yellow. This
+    # threshold reserves the warning tier for responses that are genuinely
+    # sluggish.
+    SLOW_LATENCY_MS = 2500
+
     def __init__(self, config_dir: Optional[Path] = None):
         if config_dir:
             self.config_dir = Path(config_dir)
@@ -581,8 +588,8 @@ class State:
         if success:
             health["last_success"] = now
             health["error_count"] = 0
-            # "slow" badge if response was sluggish (>500ms is plenty).
-            if latency_ms is not None and latency_ms > 500:
+            # Flag only genuinely slow responses; see SLOW_LATENCY_MS.
+            if latency_ms is not None and latency_ms > self.SLOW_LATENCY_MS:
                 health["status"] = "warning"
             else:
                 health["status"] = "ok"

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -255,8 +255,18 @@ class TestSourceHealth:
         assert h["status"] == "ok"
         assert h["latency_ms"] == 120
 
+    def test_moderate_latency_stays_ok(self, state):
+        # Sub-threshold responses are normal network variance, not a
+        # problem — they must not be flagged. Regression test for the
+        # old 500 ms threshold that painted healthy sources "warning".
+        for latency in (589, 635, 711, state.SLOW_LATENCY_MS):
+            state.update_source_health("ok.test", True, latency_ms=latency)
+            assert state.get_source_health("ok.test")["status"] == "ok"
+
     def test_slow_latency_flagged_warning(self, state):
-        state.update_source_health("slow.test", True, latency_ms=900)
+        state.update_source_health(
+            "slow.test", True, latency_ms=state.SLOW_LATENCY_MS + 1,
+        )
         assert state.get_source_health("slow.test")["status"] == "warning"
 
     def test_repeated_failures_escalate_to_error(self, state):


### PR DESCRIPTION
## Summary

After a Sources → Re-check health pass, almost every source ended up
"warning" — even ones responding well under a second. `update_source_health`
flagged any successful probe above 500 ms as slow, but healthy sites on a
normal connection routinely answer in 500-2000 ms, so the Sources page
turned into a sea of yellow dots with nothing actually wrong.

This raises the threshold via a tunable `State.SLOW_LATENCY_MS` (2500 ms),
so the warning tier is reserved for genuinely sluggish responses. Verified
against the latencies from the report: MangaPill 711 ms, WeebCentral 635 ms,
MangaFire 589 ms now read "ok"; MangaDex 5414 ms stays "warning".

I kept the existing two-tier ok/warning model rather than adding a third
"slow" status — that would need a new theme token plus changes across three
UI colour-map sites for an explicitly-optional enhancement. The named
constant leaves the door open to a third tier later.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally (103 passed across the health-touching suites)
- [x] New behaviour has tests (or notes saying why not) — updated
      `test_slow_latency_flagged_warning` to track the constant and added
      `test_moderate_latency_stays_ok` as a regression test for the
      reported latencies
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once — N/A,
      no scraper touched (`memanga/state.py` + its test)

## Related issues

Closes #29