### PR TITLE
fix(workers): force per-manga update checks to bypass reading-only filter

### DIFF
--- a/memanga/gui/pages/add_manga.py
+++ b/memanga/gui/pages/add_manga.py
@@ -291,8 +291,11 @@ class AddMangaDialog(ModalDialog):
 
             threading.Thread(target=_fetch_cover, daemon=True).start()
 
-            # Auto-check for chapters
-            self.app.worker.check_updates([entry], self.app.app_state, self.app.config)
+            # Auto-check for chapters. A freshly added manga is an explicit
+            # per-manga action, so check it regardless of its starting status.
+            self.app.worker.check_updates(
+                [entry], self.app.app_state, self.app.config, force=True,
+            )
         # When offline, the worker's check_updates() would already
         # short-circuit; skip both calls here to keep the add flow snappy.
 

--- a/memanga/gui/pages/detail.py
+++ b/memanga/gui/pages/detail.py
@@ -956,7 +956,9 @@ class DetailPage(BasePage):
     def _check_updates(self):
         if not self._manga:
             return
-        self.app.worker.check_updates([self._manga], self.app.app_state, self.app.config)
+        self.app.worker.check_updates(
+            [self._manga], self.app.app_state, self.app.config, force=True,
+        )
         # For auto-mode manga we follow the user to the Downloads page since
         # something will start queueing. For manual mode we stay put — the
         # Detail page will refresh its chapter list when check_complete fires.
@@ -1010,7 +1012,9 @@ class DetailPage(BasePage):
             # subtract 0.001 to make from_ch itself qualify.
             self.app.app_state.set_last_chapter(title, str(from_ch - 0.001))
 
-        self.app.worker.check_updates([self._manga], self.app.app_state, self.app.config)
+        self.app.worker.check_updates(
+            [self._manga], self.app.app_state, self.app.config, force=True,
+        )
         self.app.show_page("downloads")
         ch_display = int(from_ch) if from_ch == int(from_ch) else from_ch
         Toast(self, f"Downloading from chapter {ch_display}...", kind="info")

--- a/memanga/gui/pages/library.py
+++ b/memanga/gui/pages/library.py
@@ -543,7 +543,9 @@ class LibraryPage(BasePage):
         ContextMenu(self, x, y, items)
 
     def _ctx_check(self, manga):
-        self.app.worker.check_updates([manga], self.app.app_state, self.app.config)
+        self.app.worker.check_updates(
+            [manga], self.app.app_state, self.app.config, force=True,
+        )
         self.app.show_page("downloads")
 
     def _ctx_download_all(self, manga):
@@ -554,7 +556,9 @@ class LibraryPage(BasePage):
         # skips anything `is_chapter_downloaded` already covers.
         title = manga.get("title", "")
         self.app.app_state.set_last_chapter(title, None)
-        self.app.worker.check_updates([manga], self.app.app_state, self.app.config)
+        self.app.worker.check_updates(
+            [manga], self.app.app_state, self.app.config, force=True,
+        )
         self.app.show_page("downloads")
 
     def _ctx_set_status(self, manga, status):

--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -207,8 +207,16 @@ class BackgroundWorker:
     # Chapter checking
     # ------------------------------------------------------------------
 
-    def check_updates(self, manga_list: list, state, config):
-        """Check for new chapters across manga list."""
+    def check_updates(self, manga_list: list, state, config, force: bool = False):
+        """Check for new chapters across a list of manga.
+
+        The library-wide sweep only checks manga whose status is
+        ``reading`` — there's no point polling something that is on hold,
+        dropped or completed. Explicit per-manga actions (the Detail
+        page's "Check updates" button, a context-menu check, a download
+        request) pass ``force=True`` so the requested manga is always
+        checked regardless of its status.
+        """
         import sys as _sys
         # Short-circuit when we know we're offline. Every per-manga
         # check_for_updates() would otherwise burn 30 s × 3 retries
@@ -240,7 +248,7 @@ class BackgroundWorker:
             _sys.stdout.flush()
             for i, manga in enumerate(manga_list):
                 status = manga.get("status", "reading")
-                if status != "reading":
+                if not force and status != "reading":
                     print(f"[Check] Skipping '{manga.get('title')}' — status={status}", flush=True)
                     continue
                 title = manga.get("title", "")

--- a/tests/unit/gui/test_workers.py
+++ b/tests/unit/gui/test_workers.py
@@ -177,6 +177,52 @@ class TestCountChapters:
         assert seen == []
 
 
+class TestCheckUpdates:
+    """Issue #30: explicit per-manga checks must bypass the reading-only
+    filter that the library-wide sweep applies to non-reading manga."""
+
+    def _run_check(self, worker, event_bus, state, monkeypatch,
+                   manga_list, force):
+        import time
+        import memanga.downloader as downloader
+        checked = []
+
+        def _fake_check(manga, _state, return_all=False):
+            checked.append(manga.get("title"))
+            return ([], []) if return_all else []
+
+        monkeypatch.setattr(downloader, "check_for_updates", _fake_check)
+
+        done = []
+        event_bus.subscribe("check_complete", lambda d: done.append(d))
+        worker.check_updates(manga_list, state, config=None, force=force)
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and not done:
+            event_bus.poll()
+            time.sleep(0.02)
+        event_bus.poll()
+        assert done, "check_complete never fired"
+        return checked
+
+    def test_sweep_skips_non_reading(self, worker, event_bus, state,
+                                     monkeypatch):
+        checked = self._run_check(worker, event_bus, state, monkeypatch, [
+            {"title": "Reading one", "status": "reading",
+             "source": "mock.test", "url": "u"},
+            {"title": "Plan one", "status": "plan",
+             "source": "mock.test", "url": "u"},
+        ], force=False)
+        assert checked == ["Reading one"]
+
+    def test_force_checks_non_reading(self, worker, event_bus, state,
+                                      monkeypatch):
+        checked = self._run_check(worker, event_bus, state, monkeypatch, [
+            {"title": "Plan one", "status": "plan",
+             "source": "mock.test", "url": "u"},
+        ], force=True)
+        assert checked == ["Plan one"]
+
+
 class TestSearchRelevanceFilter:
     """Regression for the 'searching Blue Lock returns Beastars, Tokyo
     Ghoul, …' bug. Single-manga aggregators (TGManga, BeastarsManga,


### PR DESCRIPTION
## Summary

`check_updates` skipped any manga whose status wasn't "reading". That filter
is right for the library-wide sweep, but it also silently swallowed explicit
per-manga actions: clicking "Check updates" on the Detail page of a manga
set to plan / on-hold / completed / dropped did nothing — the chapter list
stayed empty with no toast or error.

This adds a `force` flag to `check_updates`. The status filter now only
applies to the library-wide sweep and the periodic auto-check; explicit
per-manga actions pass `force=True` so the requested manga is always checked
regardless of status:

- Detail page: "Check updates" and "Download from"
- Library context menu: "Check now" and "Download All"
- Post-add auto-check

I implemented the explicit-intent approach (option 1 in the issue) rather
than the skip-toast (option 2): since these actions now run instead of
skipping, there's nothing to surface. The library sweep skipping non-reading
manga is intended background behaviour and is unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally (611 passed)
- [x] New behaviour has tests (or notes saying why not) — added
      `TestCheckUpdates`: the sweep skips a non-reading manga (`force=False`)
      and `force=True` checks it anyway
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once — N/A,
      no scraper touched

## Related issues

Closes #30