### PR TITLE
fix(rename): move downloaded files when a manga is renamed

### DIFF
--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -354,6 +354,13 @@ def cmd_update(args):
         if old_title in manga_state:
             manga_state[args.title] = manga_state.pop(old_title)
             state.set("manga", manga_state)
+        # Move already-downloaded files so they stay reachable under the
+        # new title (folder + filenames are keyed by title).
+        from .downloader import rename_manga_downloads
+        try:
+            rename_manga_downloads(config.download_dir, old_title, args.title)
+        except Exception:
+            pass
         changes.append(f"Title → {args.title}")
 
     if not changes:

--- a/memanga/downloader.py
+++ b/memanga/downloader.py
@@ -775,6 +775,61 @@ def _sanitize_filename(name: str) -> str:
     return name.strip()[:100]  # Limit length
 
 
+def rename_manga_downloads(download_dir, old_title: str, new_title: str) -> bool:
+    """Move a manga's downloaded files when the manga is renamed.
+
+    Downloads live under ``<download_dir>/<sanitized title>/`` and the
+    default naming template embeds the title in each file
+    (``{title} - Chapter N``). The reader derives both the folder and the
+    file name from the manga's current title, so a rename leaves the old
+    files unreachable — the chapter shows as downloaded but "Read" finds
+    nothing.
+
+    This moves the per-manga folder to the new title and rewrites the
+    title prefix on any contained file or folder name so the reader's
+    lookup matches again. Existing files at the destination are left
+    untouched rather than overwritten.
+
+    Returns ``True`` if anything was moved, ``False`` if there was nothing
+    to migrate (no prior downloads, or the sanitized title is unchanged).
+    """
+    old_safe = _sanitize_filename(old_title)
+    new_safe = _sanitize_filename(new_title)
+    if not old_safe or not new_safe or old_safe == new_safe:
+        return False
+
+    base = Path(download_dir)
+    old_dir = base / old_safe
+    if not old_dir.is_dir():
+        return False
+
+    new_dir = base / new_safe
+    new_dir.mkdir(parents=True, exist_ok=True)
+
+    moved = False
+    for entry in list(old_dir.iterdir()):
+        name = entry.name
+        # Swap the leading title prefix (e.g. "Old - Chapter 5.cbz" ->
+        # "New - Chapter 5.cbz"). Names that don't start with the title
+        # (e.g. image-format "Chapter 5" folders) are moved as-is.
+        if name.startswith(old_safe):
+            name = new_safe + name[len(old_safe):]
+        target = new_dir / name
+        if target.exists():
+            continue
+        shutil.move(str(entry), str(target))
+        moved = True
+
+    # Drop the old folder if it's now empty; leave it if collisions
+    # forced some files to stay behind.
+    try:
+        old_dir.rmdir()
+    except OSError:
+        pass
+
+    return moved
+
+
 def _format_chapter_number(chapter_num: str) -> str:
     """
     Format chapter number for proper alphabetical sorting.

--- a/memanga/gui/pages/detail.py
+++ b/memanga/gui/pages/detail.py
@@ -914,6 +914,16 @@ class DetailPage(BasePage):
                     if old_state:
                         self.app.app_state._data.setdefault("manga", {})[new_title] = old_state
                         self.app.app_state.remove_manga(old_title)
+                    # Move already-downloaded files to the new title so the
+                    # reader can still find them (state migrates above, but
+                    # the on-disk folder/filenames are keyed by title too).
+                    from ...downloader import rename_manga_downloads
+                    try:
+                        rename_manga_downloads(
+                            self.app.config.download_dir, old_title, new_title,
+                        )
+                    except Exception:
+                        pass
 
                 self._manga = m
                 break

--- a/tests/unit/test_downloader_pipeline.py
+++ b/tests/unit/test_downloader_pipeline.py
@@ -395,3 +395,79 @@ class TestRestartBrowsers:
         live Playwright browsers."""
         from memanga.downloader import restart_browsers
         restart_browsers()  # must not raise
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Rename migration — keep downloaded files reachable after a manga rename
+# (issue #41). The reader derives the folder and file names from the
+# manga's current title, so a rename must move both.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestRenameMangaDownloads:
+    def test_moves_folder_and_rewrites_title_prefix(self, tmp_path):
+        from memanga.downloader import rename_manga_downloads
+        old_dir = tmp_path / "Old Title"
+        old_dir.mkdir()
+        (old_dir / "Old Title - Chapter 1.cbz").write_text("a")
+        (old_dir / "Old Title - Chapter 2.cbz").write_text("b")
+
+        assert rename_manga_downloads(tmp_path, "Old Title", "New Title") is True
+
+        new_dir = tmp_path / "New Title"
+        assert not old_dir.exists()
+        assert (new_dir / "New Title - Chapter 1.cbz").read_text() == "a"
+        assert (new_dir / "New Title - Chapter 2.cbz").read_text() == "b"
+
+    def test_moves_non_title_prefixed_entries_as_is(self, tmp_path):
+        # Image-format downloads use "Chapter N" folders with no title.
+        from memanga.downloader import rename_manga_downloads
+        old_dir = tmp_path / "Old"
+        (old_dir / "Chapter 1").mkdir(parents=True)
+        (old_dir / "Chapter 1" / "001.jpg").write_text("img")
+
+        assert rename_manga_downloads(tmp_path, "Old", "New") is True
+        assert (tmp_path / "New" / "Chapter 1" / "001.jpg").read_text() == "img"
+
+    def test_no_downloads_returns_false(self, tmp_path):
+        from memanga.downloader import rename_manga_downloads
+        assert rename_manga_downloads(tmp_path, "Missing", "New") is False
+
+    def test_unchanged_sanitized_title_is_noop(self, tmp_path):
+        # The sanitizer strips characters like ':' — titles that collapse
+        # to the same safe name must not move anything.
+        from memanga.downloader import rename_manga_downloads
+        d = tmp_path / "Title"
+        d.mkdir()
+        assert rename_manga_downloads(tmp_path, "Title", "Title:") is False
+        assert d.exists()
+
+    def test_does_not_clobber_existing_destination(self, tmp_path):
+        from memanga.downloader import rename_manga_downloads
+        old_dir = tmp_path / "Old"
+        old_dir.mkdir()
+        (old_dir / "Old - Chapter 1.cbz").write_text("new-source")
+        new_dir = tmp_path / "New"
+        new_dir.mkdir()
+        (new_dir / "New - Chapter 1.cbz").write_text("keep-me")
+
+        rename_manga_downloads(tmp_path, "Old", "New")
+
+        # Existing destination file is preserved; the colliding source is
+        # left behind in the old folder rather than overwritten.
+        assert (new_dir / "New - Chapter 1.cbz").read_text() == "keep-me"
+        assert (old_dir / "Old - Chapter 1.cbz").read_text() == "new-source"
+
+    def test_merges_into_existing_new_folder(self, tmp_path):
+        from memanga.downloader import rename_manga_downloads
+        old_dir = tmp_path / "Old"
+        old_dir.mkdir()
+        (old_dir / "Old - Chapter 2.cbz").write_text("two")
+        new_dir = tmp_path / "New"
+        new_dir.mkdir()
+        (new_dir / "New - Chapter 1.cbz").write_text("one")
+
+        assert rename_manga_downloads(tmp_path, "Old", "New") is True
+        assert (new_dir / "New - Chapter 1.cbz").read_text() == "one"
+        assert (new_dir / "New - Chapter 2.cbz").read_text() == "two"
+        assert not old_dir.exists()


### PR DESCRIPTION
## Summary

Renaming a manga migrated its state entry (so the chapter still showed a
"Read" button) but left the downloaded files in a folder named after the old
title, with filenames embedding the old title. The reader resolves
`download_dir/<title>/<title> - Chapter N.ext` from the *current* title and
returns early when that folder doesn't exist, so "Read" errored with
"couldn't find the chapter".

This adds `downloader.rename_manga_downloads()`, which moves the per-manga
folder to the new sanitized title and rewrites the title prefix on contained
file/folder names so the reader's lookup matches again. It merges into an
existing destination, never overwrites existing files, and is a no-op when
there's nothing to move or the sanitized title is unchanged. It's wired into
both rename paths: the GUI Edit save and the CLI `edit --title` command.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally (104 passed across the affected suites; 6 new
      rename-migration tests)
- [x] New behaviour has tests (or notes saying why not) — `TestRenameMangaDownloads`
      covers move + prefix rewrite, non-title-prefixed entries, no-op when
      nothing to move, no-op on unchanged sanitized title, collision-safety,
      and merge into an existing folder
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once — N/A,
      no scraper touched

## Related issues

Closes #41