### PR TITLE
fix(gui): open folder buttons via os.startfile instead of hidden explorer

### DIFF
--- a/memanga/gui/_subprocess.py
+++ b/memanga/gui/_subprocess.py
@@ -2,26 +2,29 @@
 Subprocess helpers for the GUI app.
 
 PyInstaller's `console=False` builds (the release exe) lose their parent
-console, so every `subprocess.run`/`subprocess.Popen` call would get
-Windows to allocate a fresh `cmd.exe` window for the child — even when
-the child is `explorer.exe` or the headless Playwright driver. The
-window flashes for a frame and disappears, but it's noticeable enough
-to look broken to a normal user.
-
-This module exports `no_window_kwargs()` which returns the right
-kwargs to pass to `subprocess.*` so no console pops:
+console, so a `subprocess.run`/`subprocess.Popen` call for a console
+child (e.g. `schtasks`, `crontab`) makes Windows allocate a fresh
+`cmd.exe` window that flashes for a frame. `no_window_kwargs()` returns
+the kwargs that suppress that:
 
     >>> import subprocess
     >>> from memanga.gui._subprocess import no_window_kwargs
-    >>> subprocess.run(["explorer", "C:/Users"], **no_window_kwargs())
+    >>> subprocess.run(["schtasks", "/query"], **no_window_kwargs())
 
-On every non-Windows platform it returns `{}` — no-op.
+Those flags must NOT be used to launch a GUI process such as Windows
+Explorer: the same `SW_HIDE`/`CREATE_NO_WINDOW` that hides a console
+also suppresses Explorer's own window, so the folder never opens. To
+reveal a folder in the OS file manager use `open_in_file_manager()`.
+
+On every non-Windows platform `no_window_kwargs()` returns `{}` — no-op.
 """
 
 from __future__ import annotations
 
 import os
 import subprocess
+import sys
+from pathlib import Path
 
 
 def no_window_kwargs() -> dict:
@@ -40,3 +43,37 @@ def no_window_kwargs() -> dict:
     si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
     si.wShowWindow = 0  # SW_HIDE
     return {"creationflags": flags, "startupinfo": si}
+
+
+def open_in_file_manager(directory) -> bool:
+    """Open ``directory`` in the OS file manager.
+
+    The directory is created when missing so the action isn't a silent
+    no-op on a download folder that hasn't been written to yet. Callers
+    that hold a file path should pass its parent.
+
+    Windows uses ``os.startfile`` rather than launching ``explorer`` as
+    a subprocess: spawning Explorer with the console-hiding flags from
+    ``no_window_kwargs()`` suppresses its window, which is why the
+    folder buttons did nothing in the windowed release exe.
+
+    Returns ``True`` if the file manager was invoked, ``False`` if the
+    target couldn't be created or opened.
+    """
+    target = Path(directory)
+    try:
+        target.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        pass
+    if not target.is_dir():
+        return False
+    try:
+        if sys.platform == "win32":
+            os.startfile(str(target))  # type: ignore[attr-defined]
+        elif sys.platform == "darwin":
+            subprocess.run(["open", str(target)], check=False)
+        else:
+            subprocess.run(["xdg-open", str(target)], check=False)
+        return True
+    except Exception:
+        return False

--- a/memanga/gui/pages/downloads.py
+++ b/memanga/gui/pages/downloads.py
@@ -2,8 +2,6 @@
 Downloads page - Active/Completed/History with tab navigation.
 """
 
-import subprocess
-import sys
 from pathlib import Path
 from PySide6.QtWidgets import (
     QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QFrame,
@@ -420,22 +418,9 @@ class DownloadsPage(BasePage):
 
     def _open_download_folder(self):
         """Open the download directory in the OS file manager."""
-        import platform, subprocess
-        from pathlib import Path
-        from .._subprocess import no_window_kwargs
-        path = Path(self.app.config.download_dir)
-        path.mkdir(parents=True, exist_ok=True)
-        try:
-            # no_window_kwargs() prevents a cmd window from flashing
-            # on Windows when launching explorer from the release exe.
-            if platform.system() == "Darwin":
-                subprocess.run(["open", str(path)])
-            elif platform.system() == "Windows":
-                subprocess.run(["explorer", str(path)], **no_window_kwargs())
-            else:
-                subprocess.run(["xdg-open", str(path)])
-        except Exception:
-            pass
+        from .._subprocess import open_in_file_manager
+        if not open_in_file_manager(self.app.config.download_dir):
+            Toast(self, "Couldn't open the download folder", kind="error")
 
     def _cancel_all(self):
         # Order matters: set cancel flags on every queued item AND clear
@@ -504,17 +489,10 @@ class DownloadsPage(BasePage):
         self._update_empty_state()
 
     def _open_folder(self, path):
-        from .._subprocess import no_window_kwargs
-        try:
-            folder = str(Path(path).parent)
-            if sys.platform == "darwin":
-                subprocess.Popen(["open", folder])
-            elif sys.platform == "win32":
-                subprocess.Popen(["explorer", folder], **no_window_kwargs())
-            else:
-                subprocess.Popen(["xdg-open", folder])
-        except Exception:
-            pass
+        # `path` is a chapter file; reveal its containing manga folder.
+        from .._subprocess import open_in_file_manager
+        if not open_in_file_manager(Path(path).parent):
+            Toast(self, "Couldn't open the folder", kind="error")
 
     # ── Check event handlers ──
 

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -645,23 +645,12 @@ class SettingsPage(BasePage):
         """Open the user config dir (where state.json + logs live) in the
         OS file manager.
         """
-        import platform, subprocess
-        from pathlib import Path
-        from .._subprocess import no_window_kwargs
-        path = Path(self.app.config.config_dir)
-        path.mkdir(parents=True, exist_ok=True)
-        try:
-            # no_window_kwargs() prevents a cmd window from flashing
-            # when launching explorer from the windowed release exe.
-            if platform.system() == "Darwin":
-                subprocess.run(["open", str(path)])
-            elif platform.system() == "Windows":
-                subprocess.run(["explorer", str(path)], **no_window_kwargs())
-            else:
-                subprocess.run(["xdg-open", str(path)])
+        from .._subprocess import open_in_file_manager
+        path = self.app.config.config_dir
+        if open_in_file_manager(path):
             Toast(self, f"Opened {path}", kind="info")
-        except Exception as e:
-            Toast(self, f"Couldn't open folder: {e}", kind="error")
+        else:
+            Toast(self, "Couldn't open the logs folder", kind="error")
 
     # ── Actions ──
 

--- a/tests/unit/gui/test_subprocess.py
+++ b/tests/unit/gui/test_subprocess.py
@@ -1,0 +1,62 @@
+"""Tests for memanga.gui._subprocess.
+
+open_in_file_manager is the cross-platform "reveal this folder" helper
+behind the Downloads/Settings folder buttons (issue #39). The Windows
+path must use os.startfile rather than launching Explorer with the
+console-hiding flags, which suppressed Explorer's window.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import memanga.gui._subprocess as sp
+from memanga.gui._subprocess import open_in_file_manager
+
+
+class TestOpenInFileManager:
+    def test_opens_existing_dir_linux(self, tmp_path, monkeypatch):
+        calls = []
+        monkeypatch.setattr(sp.sys, "platform", "linux")
+        monkeypatch.setattr(sp.subprocess, "run",
+                            lambda *a, **k: calls.append(a[0]))
+        assert open_in_file_manager(tmp_path) is True
+        assert calls == [["xdg-open", str(tmp_path)]]
+
+    def test_opens_dir_macos(self, tmp_path, monkeypatch):
+        calls = []
+        monkeypatch.setattr(sp.sys, "platform", "darwin")
+        monkeypatch.setattr(sp.subprocess, "run",
+                            lambda *a, **k: calls.append(a[0]))
+        assert open_in_file_manager(tmp_path) is True
+        assert calls == [["open", str(tmp_path)]]
+
+    def test_windows_uses_startfile_not_explorer_subprocess(self, tmp_path,
+                                                             monkeypatch):
+        seen = []
+        monkeypatch.setattr(sp.sys, "platform", "win32")
+        monkeypatch.setattr(os, "startfile", lambda p: seen.append(p),
+                            raising=False)
+        # Any subprocess launch on the Windows path would be the bug.
+        def _no_subprocess(*a, **k):
+            raise AssertionError("must not spawn a subprocess on Windows")
+        monkeypatch.setattr(sp.subprocess, "run", _no_subprocess)
+        assert open_in_file_manager(tmp_path) is True
+        assert seen == [str(tmp_path)]
+
+    def test_creates_missing_directory(self, tmp_path, monkeypatch):
+        target = tmp_path / "downloads" / "MeManga"
+        monkeypatch.setattr(sp.sys, "platform", "linux")
+        monkeypatch.setattr(sp.subprocess, "run", lambda *a, **k: None)
+        assert open_in_file_manager(target) is True
+        assert target.is_dir()
+
+    def test_returns_false_when_opener_raises(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(sp.sys, "platform", "linux")
+
+        def _boom(*a, **k):
+            raise OSError("no file manager")
+
+        monkeypatch.setattr(sp.subprocess, "run", _boom)
+        assert open_in_file_manager(tmp_path) is False


### PR DESCRIPTION
## Summary

The "Open folder" buttons (Downloads page folder + per-item, Settings "Open
logs folder") did nothing in the Windows release exe. All three launched
Explorer with `subprocess.run(["explorer", …], **no_window_kwargs())`, and
`no_window_kwargs()` sets `CREATE_NO_WINDOW` + a `STARTUPINFO` with `SW_HIDE`.
Those flags are right for hiding a console child but Explorer is a GUI
process, so they suppressed its window and the folder never opened.

Adds `open_in_file_manager(directory)` in `gui/_subprocess.py`: `os.startfile`
on Windows (the reliable reveal call, unaffected by the hide flags), `open`
on macOS, `xdg-open` on Linux. It creates the directory when missing so the
button is never a silent no-op, and returns a success flag the callers use to
show an error toast. The three buttons now use it; the legitimate
console-child uses of `no_window_kwargs()` (Playwright install, schtasks /
crontab) are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally (183 passed in the GUI suite; 5 new tests)
- [x] New behaviour has tests (or notes saying why not) — `test_subprocess.py`
      covers Linux/macOS dispatch, Windows `os.startfile` (and asserts no
      subprocess is spawned), missing-directory creation, and failure → False
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once — N/A,
      no scraper touched

## Related issues

Closes #39