### PR TITLE
fix(downloads): queue explicit Download All/from for manual-mode manga

### DIFF
--- a/memanga/gui/pages/detail.py
+++ b/memanga/gui/pages/detail.py
@@ -1023,7 +1023,8 @@ class DetailPage(BasePage):
             self.app.app_state.set_last_chapter(title, str(from_ch - 0.001))
 
         self.app.worker.check_updates(
-            [self._manga], self.app.app_state, self.app.config, force=True,
+            [self._manga], self.app.app_state, self.app.config,
+            force=True, queue_all=True,
         )
         self.app.show_page("downloads")
         ch_display = int(from_ch) if from_ch == int(from_ch) else from_ch

--- a/memanga/gui/pages/downloads.py
+++ b/memanga/gui/pages/downloads.py
@@ -503,18 +503,30 @@ class DownloadsPage(BasePage):
 
     def _on_check_complete(self, data):
         results = data.get("results", [])
+        # Set by an explicit "Download All" / "Download from chapter" action.
+        # Such a request must queue the resolved chapters regardless of mode;
+        # the background sweep only auto-queues auto-mode manga.
+        queue_all = data.get("queue_all", False)
 
-        # Filter to auto-mode manga that actually have new chapters to queue.
         # Manual-mode manga surface their badge + per-chapter Download buttons
-        # on the Detail page; we never auto-queue for them.
-        auto_results = [
-            r for r in results
-            if r["manga"].get("mode", "auto") == "auto" and r.get("chapters")
-        ]
+        # on the Detail page and are not auto-queued by the background sweep —
+        # but an explicit download request (queue_all) does queue them.
+        if queue_all:
+            to_queue = [r for r in results if r.get("chapters")]
+        else:
+            to_queue = [
+                r for r in results
+                if r["manga"].get("mode", "auto") == "auto" and r.get("chapters")
+            ]
 
-        if not auto_results:
-            # Nothing to queue. Show an informational toast distinguishing
-            # "nothing found" from "found, but waiting for user action".
+        if not to_queue:
+            if queue_all:
+                # Explicit request resolved nothing to download (e.g. every
+                # chapter is already on disk).
+                Toast(self, "No chapters to download", kind="info")
+                return
+            # Background sweep: distinguish "nothing found" from "found, but
+            # waiting for the user to download from the Detail page".
             manual_with_new = sum(
                 len(r["chapters"]) for r in results
                 if r["manga"].get("mode", "auto") == "manual" and r.get("chapters")
@@ -529,14 +541,14 @@ class DownloadsPage(BasePage):
                 Toast(self, "No new chapters found", kind="info")
             return
 
-        total = sum(len(r["chapters"]) for r in auto_results)
+        total = sum(len(r["chapters"]) for r in to_queue)
         Toast(self, f"Found {total} new chapter(s), downloading...", kind="success")
 
         global_kindle = self.app.config.delivery_mode == "email" and self.app.config.email_enabled
         naming_template = self.app.config.get("delivery.naming_template")
 
         skipped = 0
-        for r in auto_results:
+        for r in to_queue:
             manga = r["manga"]
             m_title = manga.get("title", "")
             for ch in r["chapters"]:

--- a/memanga/gui/pages/library.py
+++ b/memanga/gui/pages/library.py
@@ -557,7 +557,8 @@ class LibraryPage(BasePage):
         title = manga.get("title", "")
         self.app.app_state.set_last_chapter(title, None)
         self.app.worker.check_updates(
-            [manga], self.app.app_state, self.app.config, force=True,
+            [manga], self.app.app_state, self.app.config,
+            force=True, queue_all=True,
         )
         self.app.show_page("downloads")
 

--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -207,7 +207,8 @@ class BackgroundWorker:
     # Chapter checking
     # ------------------------------------------------------------------
 
-    def check_updates(self, manga_list: list, state, config, force: bool = False):
+    def check_updates(self, manga_list: list, state, config,
+                      force: bool = False, queue_all: bool = False):
         """Check for new chapters across a list of manga.
 
         The library-wide sweep only checks manga whose status is
@@ -216,6 +217,12 @@ class BackgroundWorker:
         page's "Check updates" button, a context-menu check, a download
         request) pass ``force=True`` so the requested manga is always
         checked regardless of its status.
+
+        ``queue_all`` marks the check as an explicit download request
+        ("Download All" / "Download from chapter"). It is echoed on the
+        ``check_complete`` event so the Downloads page queues the resolved
+        chapters for every manga regardless of mode — manual-mode manga
+        are otherwise only surfaced, never auto-queued.
         """
         import sys as _sys
         # Short-circuit when we know we're offline. Every per-manga
@@ -295,7 +302,9 @@ class BackgroundWorker:
                         "title": title, "error": str(e),
                     })
             print(f"[Check] Done. Total results: {len(results)} manga with new chapters", flush=True)
-            self._events.publish("check_complete", {"results": results})
+            self._events.publish("check_complete", {
+                "results": results, "queue_all": queue_all,
+            })
 
         self._safe_submit(_task)
 

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -283,6 +283,72 @@ class TestDetailPage:
             sample_manga["title"]) == "4.999"
 
 
+class TestDownloadsQueueing:
+    """Issue #50: an explicit "Download All" / "Download from chapter"
+    must queue the resolved chapters even for manual-mode manga, which
+    the background sweep deliberately does not auto-queue."""
+
+    def _result(self, manga, *numbers):
+        import types
+        chapters = [
+            types.SimpleNamespace(
+                number=n, title="", url=f"https://x/c/{n}",
+                source=manga.get("source", "x"), is_backup=False,
+            )
+            for n in numbers
+        ]
+        return {"manga": manga, "chapters": chapters, "all_chapters": chapters}
+
+    def test_explicit_download_queues_manual_manga(self, app_window, qapp,
+                                                   sample_manga):
+        assert sample_manga.get("mode") == "manual"
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+
+        queued = []
+        app_window.worker.download_chapter = (
+            lambda **kw: queued.append(str(kw["chapter"].number))
+        )
+        page._on_check_complete({
+            "results": [self._result(sample_manga, "1", "2")],
+            "queue_all": True,
+        })
+        assert queued == ["1", "2"]
+
+    def test_background_sweep_does_not_queue_manual_manga(self, app_window,
+                                                          qapp, sample_manga):
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+
+        queued = []
+        app_window.worker.download_chapter = (
+            lambda **kw: queued.append(str(kw["chapter"].number))
+        )
+        # No queue_all flag → background-sweep semantics; manual manga is
+        # surfaced, not queued.
+        page._on_check_complete({
+            "results": [self._result(sample_manga, "1", "2")],
+        })
+        assert queued == []
+
+    def test_explicit_download_skips_already_downloaded(self, app_window, qapp,
+                                                        sample_manga):
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+        app_window.app_state.add_downloaded_chapter(sample_manga["title"], "1")
+
+        queued = []
+        app_window.worker.download_chapter = (
+            lambda **kw: queued.append(str(kw["chapter"].number))
+        )
+        page._on_check_complete({
+            "results": [self._result(sample_manga, "1", "2")],
+            "queue_all": True,
+        })
+        # Chapter 1 is already on disk; only 2 is queued.
+        assert queued == ["2"]
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Reader
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

"Download All" (and "Download from chapter") did nothing for manual-mode
manga — no chapters queued, no feedback. Both actions resolve chapters via
`check_updates(force=True)` and rely on the Downloads page's `check_complete`
handler to queue them, but that handler only auto-queues **auto-mode** manga
(manual-mode manga are intentionally surfaced via a badge, not auto-queued by
the background sweep). So an explicit download request on a manual-mode manga
resolved its chapters and then dropped them.

This carries the explicit-download intent through the event, mirroring the
`force` flag from #30: `check_updates` gains a `queue_all` flag that is echoed
on `check_complete`, and the Downloads handler queues the resolved chapters
for every mode when it's set. The Detail "Download from" action and the
library "Download All" context action pass it; plain checks ("Check updates",
context-menu check, post-add auto-check) do not, so nothing starts
downloading unexpectedly. Already-on-disk chapters are still skipped.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally (88 passed across workers/pages/integration; 3 new tests)
- [x] New behaviour has tests (or notes saying why not) — `TestDownloadsQueueing`
      covers explicit-download queues a manual manga, background sweep does
      not, and already-downloaded chapters are skipped
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once — N/A,
      no scraper touched

## Related issues

Closes #50