### PR TITLE
fix(playwright): start driver in windowed exe (CREATE_NO_WINDOW + valid handles)

### DIFF
--- a/memanga/gui/__main__.py
+++ b/memanga/gui/__main__.py
@@ -14,7 +14,7 @@ def _config_dir() -> Path:
     return Path.home() / ".config" / "memanga"
 
 
-def _ensure_valid_std_streams() -> None:
+def _ensure_valid_std_streams() -> bool:
     """Guarantee real, file-descriptor-backed standard streams.
 
     A PyInstaller ``console=False`` (windowed) build starts with
@@ -30,15 +30,18 @@ def _ensure_valid_std_streams() -> None:
          wires the child's stderr to ``sys.stderr.fileno()``. With
          ``sys.stderr`` set to ``None`` it instead lets the child
          inherit the parent's stderr handle, which does not exist in a
-         windowed process. The driver fails to start, so every
-         Playwright-backed scraper raises during ``search()`` and is
-         silently dropped from the results — while HTTP-only sources,
-         which never spawn the driver, keep working.
+         windowed process.
 
     Pointing the missing streams at a real, writable log file restores a
-    valid file descriptor and leaves a diagnostic trail for bug reports.
-    Builds that already have working streams (the console dev build, or
-    running from source) are detected and left untouched.
+    valid file descriptor and leaves a diagnostic trail for bug reports —
+    the scraper layer's ``print``/traceback output then lands in
+    ``runtime.log`` instead of vanishing, which is what makes a frozen
+    Playwright failure diagnosable at all.
+
+    Returns ``True`` when streams had to be repaired (i.e. this is the
+    windowed build), ``False`` when they were already usable (the console
+    dev build, or running from source), so the caller can apply the other
+    windowed-only workarounds.
     """
     def _is_usable(stream) -> bool:
         if stream is None:
@@ -53,7 +56,7 @@ def _ensure_valid_std_streams() -> None:
     need_err = not _is_usable(sys.stderr)
     need_in = not _is_usable(sys.stdin)
     if not (need_out or need_err or need_in):
-        return
+        return False
 
     if need_out or need_err:
         log = None
@@ -77,19 +80,78 @@ def _ensure_valid_std_streams() -> None:
                 sys.stdout = log
             if need_err:
                 sys.stderr = log
+            # Also point the process's OS-level standard handles at the
+            # log. Playwright's Node driver is a child process: on
+            # Windows a windowed build leaves the real stdout/stderr
+            # handles invalid, and a child that inherits those handles
+            # — rather than reading ``sys.stderr.fileno()`` — gets broken
+            # ones and the driver fails to start. ``dup2`` makes the
+            # inherited descriptors valid too.
+            try:
+                _fd = log.fileno()
+                if need_out:
+                    os.dup2(_fd, 1)
+                if need_err:
+                    os.dup2(_fd, 2)
+            except (OSError, ValueError, AttributeError):
+                pass
 
     if need_in:
         try:
-            sys.stdin = open(os.devnull, "r", encoding="utf-8")
+            _devnull_in = open(os.devnull, "r", encoding="utf-8")
+            sys.stdin = _devnull_in
+            try:
+                os.dup2(_devnull_in.fileno(), 0)
+            except (OSError, ValueError, AttributeError):
+                pass
         except OSError:
             pass
+
+    return True
+
+
+def _install_windowed_subprocess_defaults() -> None:
+    """Spawn child processes without a console in the windowed build.
+
+    A ``console=False`` (GUI-subsystem) process has no console to share
+    with its children. When it spawns a console program such as
+    Playwright's Node driver, Windows allocates a fresh console for the
+    child; combined with the ``SW_HIDE`` startup flag Playwright already
+    sets, that allocation is what stops the driver from coming up in the
+    release exe — so every Playwright source fails (no search results,
+    zero chapters, page-fetch errors) while the console dev build, whose
+    children inherit its console, works from the identical bundle.
+
+    ``CREATE_NO_WINDOW`` tells Windows not to allocate a console for the
+    child, which is exactly what a background driver wants — its stdio
+    already travel over the pipes Playwright sets up. Default it on every
+    ``subprocess.Popen`` (the API asyncio uses under the hood to spawn the
+    driver) that doesn't already request creation flags, so the existing
+    ``no_window_kwargs()`` callers are left as-is.
+    """
+    if os.name != "nt":
+        return
+    import subprocess
+    flags = getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+    _orig_popen_init = subprocess.Popen.__init__
+
+    def _popen_init(self, *args, **kwargs):
+        if not kwargs.get("creationflags"):
+            kwargs["creationflags"] = flags
+        _orig_popen_init(self, *args, **kwargs)
+
+    subprocess.Popen.__init__ = _popen_init
 
 
 if getattr(sys, 'frozen', False):
     # Must run before anything else in the frozen build: a windowed
     # (console=False) exe has null std streams, and Playwright's driver
     # reads sys.stderr.fileno() the moment a scraper starts.
-    _ensure_valid_std_streams()
+    _windowed = _ensure_valid_std_streams()
+    if _windowed:
+        # Windowed build only: keep Windows from allocating a console for
+        # the Playwright Node driver, which otherwise fails to start.
+        _install_windowed_subprocess_defaults()
 
     bundle_dir = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(sys.executable)))
 

--- a/memanga/scrapers/mangafire.py
+++ b/memanga/scrapers/mangafire.py
@@ -181,20 +181,53 @@ class VRFGenerator:
         self._initialized = True
 
     def _ensure_browser_in_thread(self):
-        """Ensure browser is running in the current thread. Must be called from executor thread."""
+        """Ensure the thread-local Firefox is running. Executor-thread only.
+
+        Atomic, mirroring ``PlaywrightScraper._get_browser_in_thread``: a
+        failed ``firefox.launch()`` must not leave ``_vrf_thread_local``
+        with ``playwright`` set but no ``page``. The old code set
+        ``_vrf_thread_local.playwright`` first, so a launch failure left a
+        half-initialised thread-local — and the next call skipped the init
+        block and raised ``AttributeError`` on ``_vrf_thread_local.page``,
+        masking the real launch error (this is the "'thread_local'"
+        download failure in the frozen build). Build everything in locals,
+        roll the Playwright start back on failure, and commit at once.
+        """
         if not PLAYWRIGHT_AVAILABLE:
             raise RuntimeError("Playwright not available")
 
-        if not hasattr(_vrf_thread_local, 'playwright'):
-            print("[MangaFire] Starting Firefox browser (bypasses bot detection)...")
-            _vrf_thread_local.playwright = sync_playwright().start()
-            _vrf_thread_local.browser = _vrf_thread_local.playwright.firefox.launch(headless=True)
-            _vrf_thread_local.context = _vrf_thread_local.browser.new_context(
+        if (hasattr(_vrf_thread_local, 'playwright')
+                and hasattr(_vrf_thread_local, 'browser')
+                and hasattr(_vrf_thread_local, 'context')
+                and hasattr(_vrf_thread_local, 'page')):
+            return _vrf_thread_local.page
+
+        # Drop any half-initialised state from a previous failed attempt
+        # so sync_playwright().start() doesn't raise "already started".
+        self._close_in_thread()
+
+        print("[MangaFire] Starting Firefox browser (bypasses bot detection)...")
+        pw = sync_playwright().start()
+        try:
+            browser = pw.firefox.launch(headless=True)
+            context = browser.new_context(
                 user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:121.0) Gecko/20100101 Firefox/121.0',
                 viewport={'width': 1920, 'height': 1080}
             )
-            _vrf_thread_local.page = _vrf_thread_local.context.new_page()
+            page = context.new_page()
+        except Exception:
+            # Roll back so the next call retries cleanly and surfaces the
+            # real error instead of a masking AttributeError.
+            try:
+                pw.stop()
+            except Exception:
+                pass
+            raise
 
+        _vrf_thread_local.playwright = pw
+        _vrf_thread_local.browser = browser
+        _vrf_thread_local.context = context
+        _vrf_thread_local.page = page
         return _vrf_thread_local.page
 
     def _get_chapter_pages_in_thread(self, chapter_url: str) -> Tuple[List[str], List[int]]:

--- a/tests/unit/scrapers/test_mangafire.py
+++ b/tests/unit/scrapers/test_mangafire.py
@@ -95,3 +95,71 @@ class TestMangaFireGetChapters:
 
         assert scraper.session.calls == 2
         assert [ch.number for ch in chapters] == ["1"]
+
+
+class TestVRFBrowserInitAtomicity:
+    """Issue #28: a failed firefox.launch() must surface the real error,
+    not a masking AttributeError on a half-initialised thread-local.
+
+    The frozen release exe could not launch Firefox; the original
+    non-atomic init left `_vrf_thread_local.playwright` set, so the retry
+    skipped init and raised `'thread_local' object has no attribute
+    'page'` — hiding the actual launch failure and making the bug
+    undiagnosable.
+    """
+
+    class _FakeFirefox:
+        def launch(self, **kwargs):
+            raise RuntimeError("Executable doesn't exist: firefox")
+
+    class _FakePlaywright:
+        def __init__(self):
+            self.firefox = TestVRFBrowserInitAtomicity._FakeFirefox()
+            self.stopped = False
+
+        def stop(self):
+            self.stopped = True
+
+    class _FakeContextManager:
+        def __init__(self, started):
+            self._started = started
+
+        def start(self):
+            return self._started
+
+    def _patch(self, monkeypatch):
+        from memanga.scrapers import mangafire as mf
+        # Clear any thread-local state from earlier tests in this thread.
+        mf.VRFGenerator().close()
+        for attr in ("playwright", "browser", "context", "page"):
+            if hasattr(mf._vrf_thread_local, attr):
+                delattr(mf._vrf_thread_local, attr)
+        started = self._FakePlaywright()
+        monkeypatch.setattr(mf, "PLAYWRIGHT_AVAILABLE", True)
+        monkeypatch.setattr(
+            mf, "sync_playwright",
+            lambda: self._FakeContextManager(started),
+        )
+        return mf, started
+
+    def test_launch_failure_surfaces_real_error(self, monkeypatch):
+        mf, started = self._patch(monkeypatch)
+        gen = mf.VRFGenerator()
+        with pytest.raises(RuntimeError, match="Executable doesn't exist"):
+            gen._ensure_browser_in_thread()
+        # Playwright start was rolled back; no half-initialised state left.
+        assert started.stopped is True
+        assert not hasattr(mf._vrf_thread_local, "playwright")
+        assert not hasattr(mf._vrf_thread_local, "page")
+
+    def test_retry_still_surfaces_real_error_not_attribute_error(self,
+                                                                 monkeypatch):
+        mf, _ = self._patch(monkeypatch)
+        gen = mf.VRFGenerator()
+        # First attempt fails…
+        with pytest.raises(RuntimeError, match="Executable doesn't exist"):
+            gen._ensure_browser_in_thread()
+        # …and so does the retry, with the SAME real error — never an
+        # AttributeError about a missing 'page' on the thread-local.
+        with pytest.raises(RuntimeError, match="Executable doesn't exist"):
+            gen._ensure_browser_in_thread()


### PR DESCRIPTION
## Summary

Playwright sources work from source and in the console dev exe but failed in
the windowed release exe (no search results, 0 chapters, a `'thread_local'`
download error). Research into the Playwright + PyInstaller `--windowed`
issue shows two documented root causes, and 0.2.1 only fixed one:

1. `sys.stderr` is `None` in a windowed build (playwright-python #1148) —
   fixed in 0.2.1 by redirecting std streams to a real log file.
2. Playwright stopped passing `CREATE_NO_WINDOW` to its driver subprocess in
   v1.30+ (#1778, #1801). In a GUI-subsystem process with no console, that
   stops the Node driver from starting — never addressed until now.

This adds the missing pieces, windowed-build only (the console dev build,
detected by its already-valid streams, is left untouched):

- `os.dup2` the log fd onto fd 0/1/2 so a child that inherits the OS-level
  standard handles (not just `sys.stderr.fileno()`) gets valid ones.
- Default `CREATE_NO_WINDOW` on `subprocess.Popen` (the call asyncio uses to
  spawn the driver), leaving the existing `no_window_kwargs()` callers as-is.

It also makes MangaFire's `VRFGenerator` init atomic, mirroring
`PlaywrightScraper._get_browser_in_thread`: a failed `firefox.launch()` left
`_vrf_thread_local.playwright` set, so the retry raised a masking
`AttributeError` on `.page` (the `'thread_local'` toast) that hid the real
error. The real launch error now surfaces in the download toast,
`search_source_failed`, and `runtime.log`.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally (627 passed; 2 new VRF atomicity tests)
- [x] New behaviour has tests (or notes saying why not) — VRF atomicity is
      covered; the windowed std-handle/CREATE_NO_WINDOW setup is frozen-/
      Windows-only and can't run on a non-Windows CI host, so it's verified by
      a windowed-exe run rather than a unit test
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once — N/A

## Related issues

Closes #28