### PR TITLE
fix(gui): preserve queued downloads across pause resume

### DIFF
--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -91,6 +91,7 @@ class BackgroundWorker:
         self._download_queue: list = []
         self._active_downloads: int = 0
         self._max_concurrent_downloads = 2
+        self._paused: bool = False
         self._lock = threading.Lock()
         self._cancel_flags: Dict[str, threading.Event] = {}
         # Each call to search_manga() bumps _search_seq. Every event the
@@ -345,7 +346,7 @@ class BackgroundWorker:
         }
 
         with self._lock:
-            paused = getattr(self, "_paused", False)
+            paused = self._paused
             if (not paused) and self._active_downloads < self._max_concurrent_downloads:
                 self._active_downloads += 1
                 self._safe_submit(self._run_download, item)
@@ -375,6 +376,10 @@ class BackgroundWorker:
                 "task_id": item["task_id"], "error": f"Import error: {e}",
                 "title": item["manga"]["title"], "chapter": "?",
             })
+            # Release the slot this job held — bailing without it would
+            # leak a concurrency slot and eventually stall the queue.
+            self._cancel_flags.pop(item["task_id"], None)
+            self._start_next_download()
             return
         task_id = item["task_id"]
         manga = item["manga"]
@@ -449,24 +454,40 @@ class BackgroundWorker:
             self._start_next_download()
 
     def _start_next_download(self):
-        """Finish current download and start next queued one if capacity allows.
+        """Release the finished download's slot, then refill from the queue.
 
-        While paused (``pause_all()``) the queue holds — no new jobs are
-        dequeued. In-flight jobs continue until completion. ``resume_all()``
-        kicks this method again to drain the queue.
+        Called exactly once per finished job (from ``_run_download``'s
+        finally block) — the decrement here is the job giving its slot
+        back. While paused (``pause_all()``) the queue holds — no new
+        jobs are dequeued. In-flight jobs continue until completion.
+        ``resume_all()`` refills the freed slots via
+        ``_fill_download_slots``.
         """
-        next_item = None
         with self._lock:
             self._active_downloads = max(0, self._active_downloads - 1)
-            if getattr(self, "_paused", False):
+        self._fill_download_slots()
+
+    def _fill_download_slots(self):
+        """Dequeue queued jobs until the concurrency cap is reached.
+
+        No-op while paused. Never touches the slot counter for jobs it
+        didn't start, so it's safe to call from anywhere — job
+        completion, ``resume_all``, repeated pause/resume toggles —
+        without dropping queued items or breaching
+        ``_max_concurrent_downloads``.
+        """
+        to_start = []
+        with self._lock:
+            if self._paused:
                 # Don't dequeue anything while paused.
                 return
-            if self._download_queue and self._active_downloads < self._max_concurrent_downloads:
-                next_item = self._download_queue.pop(0)
+            while (self._download_queue
+                   and self._active_downloads < self._max_concurrent_downloads):
                 self._active_downloads += 1
+                to_start.append(self._download_queue.pop(0))
         # Submit outside lock to avoid deadlock
-        if next_item:
-            self._safe_submit(self._run_download, next_item)
+        for item in to_start:
+            self._safe_submit(self._run_download, item)
 
     # ------------------------------------------------------------------
     # Search
@@ -794,7 +815,7 @@ class BackgroundWorker:
         return dict(self._cancel_flags)
 
     def is_paused(self) -> bool:
-        return getattr(self, "_paused", False)
+        return self._paused
 
     def pause_all(self):
         """Stop dequeuing new downloads. In-flight jobs continue (Playwright
@@ -808,5 +829,7 @@ class BackgroundWorker:
         with self._lock:
             self._paused = False
         self._events.publish("downloads_resumed", {})
-        # Kick the queue.
-        self._start_next_download()
+        # Refill every free download slot from the held queue. (Not
+        # _start_next_download — that would release a slot no job ever
+        # held, breaching the concurrency cap on each pause/resume.)
+        self._fill_download_slots()

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -12,6 +12,7 @@ If any of these go red, a previously-fixed bug has come back.
 | #20 | "Download from chapter X" downloaded all chapters |
 | #21 | No pan/drag when zoomed in reader |
 | #23 | Non-image format downloads written to root, not <dir>/<title>/ |
+| #40 | Pause All / Resume All dropped queued downloads |
 """
 
 from __future__ import annotations
@@ -247,3 +248,73 @@ def test_issue_23_all_formats_under_manga_subfolder(fmt, tmp_path,
     from pathlib import Path
     path = Path(download_chapter(manga, chapter, out, fmt, S()))
     assert path.relative_to(out).parts[0] == "Bleach"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #40 — Pause All / Resume All keeps the queue and the Active tab
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_issue_40_pause_resume_keeps_queue(app_window, qapp, monkeypatch):
+    """Pause All must hold queued downloads; Resume All must refill every
+    free slot. Resume used to release a slot no job ever held, so each
+    toggle dequeued an item past the concurrency cap (where pause could
+    no longer hold it) while a clean resume restarted only one job.
+    """
+    import time
+    import types
+    import memanga.downloader as dl
+
+    # Gated fake downloader: jobs stay "in flight" until released.
+    gates: dict[str, threading.Event] = {}
+
+    def fake_download_chapter(manga, chapter, output_dir, output_format,
+                               state, progress_callback=None,
+                               naming_template=None, cancel_event=None):
+        gates[f"{manga['title']}:{chapter.number}"].wait(timeout=10)
+        return None
+
+    monkeypatch.setattr(dl, "download_chapter", fake_download_chapter)
+    # Force the optimistic online path so download_chapter queues
+    # instead of erroring on runners without network.
+    monkeypatch.setattr(app_window.worker, "network", None)
+
+    def pump(predicate, timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            app_window.events.poll()
+            qapp.processEvents()
+            if predicate():
+                return True
+            time.sleep(0.02)
+        return predicate()
+
+    worker = app_window.worker
+    page = app_window._pages["downloads"]
+
+    # Queue 4 chapters: 2 start (max concurrent), 2 wait in the queue.
+    for i in range(1, 5):
+        tid = f"M:{i}"
+        gates[tid] = threading.Event()
+        worker.download_chapter({"title": "M"},
+                                 types.SimpleNamespace(number=str(i)),
+                                 "/tmp", "pdf", None)
+    assert pump(lambda: len(page._active_items) == 4)
+
+    # Pause All, then let the 2 in-flight finish — the queue must hold
+    # and the queued rows must stay visible in the Active tab.
+    page._toggle_pause_all()
+    gates["M:1"].set()
+    gates["M:2"].set()
+    assert pump(lambda: worker._active_downloads == 0)
+    assert [it["task_id"] for it in worker._download_queue] == ["M:3", "M:4"]
+    assert "M:3" in page._active_items and "M:4" in page._active_items
+
+    # Resume All — BOTH free slots must refill, draining the queue.
+    page._toggle_pause_all()
+    assert pump(lambda: worker._active_downloads == 2)
+    assert len(worker._download_queue) == 0
+
+    gates["M:3"].set()
+    gates["M:4"].set()
+    assert pump(lambda: worker._active_downloads == 0)

--- a/tests/unit/gui/test_workers.py
+++ b/tests/unit/gui/test_workers.py
@@ -39,6 +39,138 @@ class TestPauseResume:
         assert worker.is_paused() is False
 
 
+class TestPauseResumeQueue:
+    """Issue #40 — Pause All / Resume All must hold the queue and then
+    refill every free slot, without dropping queued items or breaching
+    `_max_concurrent_downloads`.
+    """
+
+    @pytest.fixture
+    def gated_downloads(self, monkeypatch):
+        """Patch the downloader with a fake that blocks until released,
+        so tests can hold jobs "in flight" and observe real concurrency.
+        """
+        import time
+        import memanga.downloader as dl
+
+        class Harness:
+            def __init__(self):
+                self.gates: dict[str, threading.Event] = {}
+                self.running: set[str] = set()
+                self.max_running = 0
+                self._lock = threading.Lock()
+
+            def release(self, *task_ids):
+                for tid in task_ids:
+                    self.gates[tid].set()
+
+            def release_all(self):
+                for gate in self.gates.values():
+                    gate.set()
+
+            def wait_for(self, predicate, timeout=5.0):
+                deadline = time.monotonic() + timeout
+                while time.monotonic() < deadline:
+                    if predicate():
+                        return True
+                    time.sleep(0.02)
+                return predicate()
+
+        h = Harness()
+
+        def fake_download_chapter(manga, chapter, output_dir, output_format,
+                                   state, progress_callback=None,
+                                   naming_template=None, cancel_event=None):
+            tid = f"{manga['title']}:{chapter.number}"
+            with h._lock:
+                h.running.add(tid)
+                h.max_running = max(h.max_running, len(h.running))
+            h.gates[tid].wait(timeout=10)
+            with h._lock:
+                h.running.discard(tid)
+            return None
+
+        monkeypatch.setattr(dl, "download_chapter", fake_download_chapter)
+        return h
+
+    def _queue(self, worker, harness, n):
+        """Queue chapters M:1..M:n through the public API."""
+        import types
+        for i in range(1, n + 1):
+            tid = f"M:{i}"
+            harness.gates[tid] = threading.Event()
+            worker.download_chapter(
+                {"title": "M"}, types.SimpleNamespace(number=str(i)),
+                "/tmp/out", "pdf", None,
+            )
+
+    def test_resume_refills_all_free_slots(self, worker, gated_downloads):
+        # Everything queued while paused; resume must start a full
+        # `_max_concurrent_downloads` batch, not just one job.
+        worker.pause_all()
+        self._queue(worker, gated_downloads, 4)
+        assert len(worker._download_queue) == 4
+
+        worker.resume_all()
+        assert gated_downloads.wait_for(
+            lambda: len(gated_downloads.running) == 2)
+        assert len(worker._download_queue) == 2
+        assert worker._active_downloads == 2
+        gated_downloads.release_all()
+
+    def test_toggle_while_in_flight_keeps_queue_and_cap(
+            self, worker, gated_downloads):
+        # Pause/resume while jobs are running used to release a slot no
+        # job ever held — each toggle dequeued one extra item past the
+        # concurrency cap, where a later Pause All could no longer hold
+        # it ("the queue drops").
+        self._queue(worker, gated_downloads, 6)
+        assert gated_downloads.wait_for(
+            lambda: len(gated_downloads.running) == 2)
+
+        for _ in range(3):
+            worker.pause_all()
+            worker.resume_all()
+
+        # Nothing new may start while both slots are taken.
+        assert not gated_downloads.wait_for(
+            lambda: len(gated_downloads.running) > 2, timeout=0.3)
+        assert len(worker._download_queue) == 4
+        assert worker._active_downloads == 2
+
+        gated_downloads.release_all()
+        assert gated_downloads.wait_for(
+            lambda: len(worker._download_queue) == 0
+            and worker._active_downloads == 0)
+        assert gated_downloads.max_running == 2
+
+    def test_pause_resume_drains_everything(self, worker, event_bus,
+                                             gated_downloads):
+        # Full reported flow: queue, pause, let in-flight finish,
+        # resume — every chapter must still complete exactly once.
+        completed = []
+        event_bus.subscribe("download_complete",
+                            lambda d: completed.append(d["task_id"]))
+        self._queue(worker, gated_downloads, 5)
+        assert gated_downloads.wait_for(
+            lambda: len(gated_downloads.running) == 2)
+
+        worker.pause_all()
+        gated_downloads.release("M:1", "M:2")
+        assert gated_downloads.wait_for(
+            lambda: worker._active_downloads == 0)
+        assert len(worker._download_queue) == 3  # queue held, not dropped
+
+        worker.resume_all()
+        gated_downloads.release_all()
+        assert gated_downloads.wait_for(
+            lambda: len(worker._download_queue) == 0
+            and worker._active_downloads == 0)
+        event_bus.poll()
+        assert sorted(completed) == [f"M:{i}" for i in range(1, 6)]
+        assert gated_downloads.max_running == 2
+
+
 class TestCancelFlags:
     def test_active_tasks_starts_empty(self, worker):
         assert worker.active_tasks == {}


### PR DESCRIPTION
## Summary

Pause All held the queued rows visually, but Resume All reused `_start_next_download()` as its queue kick. That method is meant for a completed download giving back a slot, so calling it from resume released a slot no job held. Repeated pause/resume toggles could then dequeue extra jobs past the concurrency cap, and a clean resume only restarted one queued download instead of filling every available slot.

This separates slot release from queue refill:

- `_start_next_download()` now only releases a finished job slot, then asks the queue filler to start more work.
- `_fill_download_slots()` drains queued downloads up to `_max_concurrent_downloads` without changing slots for jobs it did not start.
- `resume_all()` refills all available slots directly, preserving queued items and the concurrency cap across repeated toggles.
- the import-error path now releases its held slot before returning, avoiding a stalled queue if a worker exits early.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally (`tests/unit/gui/test_workers.py`: 26 passed; `tests/integration/test_issue_regressions.py`: passed targeted issue regression run)
- [x] New behaviour has tests (or notes saying why not) — `TestPauseResumeQueue` covers resume refilling all free slots, repeated toggles preserving the queue and cap, and the full pause/resume drain flow; the #40 integration regression covers the Downloads page active items staying visible
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once — N/A, no scraper touched

## Related issues

Closes #40