### PR TITLE
fix(gui): render detail page with email delivery enabled

### DIFF
--- a/memanga/config.py
+++ b/memanga/config.py
@@ -171,7 +171,9 @@ class Config:
     
     @property
     def email_enabled(self):
-        return self.delivery_mode == "email" and self.get("email.kindle_email")
+        # bool() matters: `and` would otherwise leak the kindle_email
+        # string, which Qt setters like setChecked() reject (issue #55).
+        return self.delivery_mode == "email" and bool(self.get("email.kindle_email"))
     
     @property
     def output_format(self):

--- a/memanga/gui/pages/detail.py
+++ b/memanga/gui/pages/detail.py
@@ -260,7 +260,7 @@ class DetailPage(BasePage):
         manga_kindle = manga.get("send_to_kindle", True)
         kindle_row = QHBoxLayout()
         self._kindle_check = QCheckBox("Send to Kindle after download")
-        self._kindle_check.setChecked(manga_kindle and global_email_on)
+        self._kindle_check.setChecked(bool(manga_kindle and global_email_on))
         self._kindle_check.stateChanged.connect(self._on_kindle_toggle)
         kindle_row.addWidget(self._kindle_check)
         if not global_email_on:

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -13,6 +13,7 @@ If any of these go red, a previously-fixed bug has come back.
 | #21 | No pan/drag when zoomed in reader |
 | #23 | Non-image format downloads written to root, not <dir>/<title>/ |
 | #40 | Pause All / Resume All dropped queued downloads |
+| #55 | Detail page blank when Email to Kindle delivery selected |
 """
 
 from __future__ import annotations
@@ -318,3 +319,44 @@ def test_issue_40_pause_resume_keeps_queue(app_window, qapp, monkeypatch):
     gates["M:3"].set()
     gates["M:4"].set()
     assert pump(lambda: worker._active_downloads == 0)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #55 — Detail page blank when Email to Kindle delivery is selected
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_issue_55_detail_renders_with_email_delivery(app_window, qapp,
+                                                     sample_manga):
+    """Config.email_enabled returned the kindle_email *string*, which the
+    detail page passed straight into QCheckBox.setChecked(). PySide6
+    rejects non-bool arguments with a TypeError, aborting _rebuild()
+    mid-way and leaving the page blank except for the back button.
+    """
+    app_window.config.set("delivery.mode", "email")
+    app_window.config.set("email.kindle_email", "reader@kindle.com")
+    app_window.config.set("manga", [sample_manga])
+
+    app_window.show_page("detail", manga=sample_manga)
+    qapp.processEvents()
+
+    page = app_window._pages["detail"]
+    assert app_window._current_page == "detail"
+    assert page._kindle_check.isChecked() is True
+    # The page actually rendered past the back button.
+    assert page._layout.count() > 1
+
+
+def test_issue_55_email_enabled_is_bool(config):
+    """email_enabled must be a real bool in every config state, never the
+    kindle_email string leaking through `and` short-circuiting."""
+    assert config.email_enabled is False  # default: local mode
+
+    config.set("delivery.mode", "email")
+    assert config.email_enabled is False  # email mode, no address yet
+
+    config.set("email.kindle_email", "reader@kindle.com")
+    assert config.email_enabled is True
+
+    config.set("delivery.mode", "local")
+    assert config.email_enabled is False


### PR DESCRIPTION
## Summary

Opening a manga with Email to Kindle delivery enabled could leave the Detail page almost blank: the navigation completed, but `_rebuild()` aborted after adding only the back link. The root cause was `Config.email_enabled` returning the configured Kindle email string instead of a real boolean when delivery mode was `email` and an address was set. That string flowed into `QCheckBox.setChecked()`, and PySide6 rejects non-bool arguments.

This keeps the email-delivery state boolean before it reaches Qt:

- `Config.email_enabled` now always returns `True` or `False`.
- the Detail page also coerces the manga/global Kindle checkbox state before passing it to `setChecked()`.
- the #55 regression covers rendering the Detail page with Email to Kindle enabled and verifies `email_enabled` stays boolean across config states.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally (`tests/integration/test_issue_regressions.py::test_issue_55_detail_renders_with_email_delivery`, `tests/integration/test_issue_regressions.py::test_issue_55_email_enabled_is_bool`, and `tests/unit/gui/pages/test_pages.py::TestDetailPage`: 6 passed)
- [x] New behaviour has tests (or notes saying why not) — added #55 regression coverage for Email to Kindle Detail page rendering and boolean config state
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once — N/A, no scraper touched

## Notes

A broader `tests/unit/gui/pages/test_pages.py -q` run was attempted with a 180s timeout and did not finish in this local environment after six progress dots, so verification was narrowed to the directly affected DetailPage tests plus the new issue regression.

## Related issues

Closes #55