### PR TITLE
fix(reader): handle arrow key navigation

### DIFF
--- a/memanga/gui/pages/reader.py
+++ b/memanga/gui/pages/reader.py
@@ -183,8 +183,41 @@ class ReaderPage(BasePage):
             self._go_next_chapter()
         elif key == Qt.Key.Key_P:
             self._go_prev_chapter()
+        elif key == Qt.Key.Key_Down:
+            self._scroll_vertical(+1)
+        elif key == Qt.Key.Key_Up:
+            self._scroll_vertical(-1)
+        elif key == Qt.Key.Key_Right:
+            self._arrow_horizontal(+1)
+        elif key == Qt.Key.Key_Left:
+            self._arrow_horizontal(-1)
         else:
             super().keyPressEvent(event)
+
+    # ── Arrow-key navigation (issue #43) ──────────────────────────────
+    # The page itself holds keyboard focus (StrongFocus + setFocus in
+    # on_show), so the QScrollArea never sees arrow keys natively —
+    # they must be handled here alongside the other shortcuts.
+
+    def _scroll_vertical(self, direction: int):
+        """Up/Down: scroll half a viewport per press."""
+        if self._scroll is None:
+            return
+        bar = self._scroll.verticalScrollBar()
+        bar.setValue(bar.value() + direction * max(40, bar.pageStep() // 2))
+
+    def _arrow_horizontal(self, direction: int):
+        """Left/Right: pan when zoomed content overflows horizontally,
+        otherwise jump to the prev/next chapter (mirrors P/N)."""
+        if self._scroll is not None:
+            bar = self._scroll.horizontalScrollBar()
+            if bar.maximum() > 0:
+                bar.setValue(bar.value() + direction * max(40, bar.pageStep() // 2))
+                return
+        if direction > 0:
+            self._go_next_chapter()
+        else:
+            self._go_prev_chapter()
 
     def _zoom_in(self):
         if self._zoom_level < self.ZOOM_MAX:

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -13,6 +13,7 @@ If any of these go red, a previously-fixed bug has come back.
 | #21 | No pan/drag when zoomed in reader |
 | #23 | Non-image format downloads written to root, not <dir>/<title>/ |
 | #40 | Pause All / Resume All dropped queued downloads |
+| #43 | Arrow keys dead in the reader |
 | #55 | Detail page blank when Email to Kindle delivery selected |
 """
 
@@ -319,6 +320,78 @@ def test_issue_40_pause_resume_keeps_queue(app_window, qapp, monkeypatch):
     gates["M:3"].set()
     gates["M:4"].set()
     assert pump(lambda: worker._active_downloads == 0)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #43 — Arrow keys navigate the reader
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _open_reader(app_window, qapp, sample_manga, make_cbz, chapters=("1",),
+                 pages=1):
+    """Download fake chapters and open the reader on the first one."""
+    from pathlib import Path
+    app_window.config.set("manga", [sample_manga])
+    dl = Path(app_window.config.download_dir) / sample_manga["title"]
+    dl.mkdir(parents=True, exist_ok=True)
+    for ch in chapters:
+        (dl / f"{sample_manga['title']} - Chapter {ch}.cbz").write_bytes(
+            make_cbz(pages=pages, name=f"ch{ch}.cbz").read_bytes())
+        app_window.app_state.add_downloaded_chapter(sample_manga["title"], ch)
+    app_window.show_page("reader", manga=sample_manga, chapter=chapters[0])
+    qapp.processEvents()
+    return app_window._pages["reader"]
+
+
+def _press(reader, key):
+    from PySide6.QtCore import QEvent, Qt
+    from PySide6.QtGui import QKeyEvent
+    reader.keyPressEvent(
+        QKeyEvent(QEvent.Type.KeyPress, key, Qt.KeyboardModifier.NoModifier))
+
+
+def test_issue_43_down_up_arrows_scroll(app_window, qapp, sample_manga,
+                                          make_cbz):
+    from PySide6.QtCore import Qt
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=3)
+    bar = reader._scroll.verticalScrollBar()
+    assert bar.maximum() > 0, "test needs content taller than the viewport"
+    assert bar.value() == 0
+
+    _press(reader, Qt.Key.Key_Down)
+    assert bar.value() > 0
+    _press(reader, Qt.Key.Key_Up)
+    assert bar.value() == 0
+
+
+def test_issue_43_left_right_arrows_change_chapter(app_window, qapp,
+                                                     sample_manga, make_cbz):
+    from PySide6.QtCore import Qt
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz,
+                          chapters=("1", "2"))
+    assert reader._scroll.horizontalScrollBar().maximum() == 0
+
+    _press(reader, Qt.Key.Key_Right)
+    qapp.processEvents()
+    assert str(reader._chapter) == "2"
+    _press(reader, Qt.Key.Key_Left)
+    qapp.processEvents()
+    assert str(reader._chapter) == "1"
+
+
+def test_issue_43_right_arrow_pans_when_zoomed(app_window, qapp,
+                                                 sample_manga, make_cbz):
+    from PySide6.QtCore import Qt
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz,
+                          chapters=("1", "2"))
+    # The offscreen platform never lays out wide-enough content, so give
+    # the scrollbar the range a zoomed-in page would have.
+    hbar = reader._scroll.horizontalScrollBar()
+    hbar.setRange(0, 500)
+
+    _press(reader, Qt.Key.Key_Right)
+    assert hbar.value() > 0          # panned…
+    assert str(reader._chapter) == "1"  # …without switching chapters
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Arrow keys were ignored in the reader because the reader page owns keyboard focus while the scroll area never receives native key events. This handles the arrow keys alongside the existing reader shortcuts:

- Up/Down scroll vertically by half a viewport.
- Left/Right pan horizontally when zoomed content overflows.
- Left/Right fall back to previous/next chapter when horizontal panning is not available.

Regression coverage exercises the focused reader page path from #43.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally (`tests/integration/test_issue_regressions.py`: 20 passed; full integration suite: 30 passed)
- [x] New behaviour has tests (or notes saying why not) — added #43 reader arrow-key regressions
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once — N/A, no scraper touched

## Related issues

Closes #43
