### PR TITLE
fix(gui): fetch MangaPill covers with referer

### DIFF
--- a/memanga/gui/app.py
+++ b/memanga/gui/app.py
@@ -42,6 +42,9 @@ class MeMangaApp(QMainWindow):
         except Exception:
             pass
         self.cover_cache = CoverCache(self.config.config_dir, self.events)
+        # Cover URLs we already tried to replace after a failed fetch —
+        # once per URL per session, see _on_cover_load_failed.
+        self._cover_fallback_attempted: set = set()
 
         # Centralised network status — probes connectivity in a daemon
         # thread, publishes `network_online` / `network_offline` events.
@@ -56,6 +59,7 @@ class MeMangaApp(QMainWindow):
 
         # Wire up event handlers
         self.events.subscribe("cover_fetch_request", self._on_cover_fetch_request)
+        self.events.subscribe("cover_loaded", self._on_cover_load_failed)
         self.events.subscribe("download_complete", self._on_download_complete)
         self.events.subscribe("download_error", self._on_download_error)
         self.events.subscribe("check_complete", self._on_check_complete)
@@ -209,6 +213,51 @@ class MeMangaApp(QMainWindow):
 
     def _on_cover_fetch_request(self, data):
         self.worker.fetch_cover(data["url"], data.get("size", (170, 210)), self.cover_cache)
+
+    def _on_cover_load_failed(self, data):
+        """A stored cover URL no longer downloads (dead CDN link,
+        hotlink block we can't satisfy, non-image response). Try to
+        replace it via the MangaDex fallback so the card doesn't keep
+        a permanent placeholder — `_backfill_missing_covers` only
+        handles entries with no URL at all. Tried at most once per
+        URL per session; repeated paints of the same broken cover
+        shouldn't re-query MangaDex.
+        """
+        if not data.get("error") or data.get("offline"):
+            return
+        url = data.get("url") or ""
+        if not url or url in self._cover_fallback_attempted:
+            return
+        self._cover_fallback_attempted.add(url)
+        titles = [
+            m.get("title") for m in self.config.get("manga", [])
+            if m.get("title") and m.get("cover_url") == url
+        ]
+        if not titles:
+            return  # transient cover (search result) — nothing to repair
+
+        def _task():
+            from .cover_fallback import fetch_mangadex_cover
+            for t in titles:
+                try:
+                    cover = fetch_mangadex_cover(t)
+                except Exception:
+                    cover = None
+                if not cover or cover == url:
+                    continue
+
+                def _mutate(entry, _cover=cover):
+                    if entry.get("cover_url") != url:
+                        return False  # someone else already replaced it
+                    entry["cover_url"] = _cover
+                    return True
+
+                if self.config.update_manga(t, _mutate):
+                    self.events.publish(
+                        "library_updated", {"title": t, "action": "cover"}
+                    )
+
+        self.worker.submit_task(_task)
 
     def _on_download_complete(self, data):
         title = data.get("title", "")

--- a/memanga/gui/cache.py
+++ b/memanga/gui/cache.py
@@ -51,7 +51,14 @@ class CoverCache:
         disk_path = self._disk_path(url)
         if disk_path.exists():
             try:
-                return self._load_and_cache(url, disk_path, size)
+                pm = self._load_and_cache(url, disk_path, size)
+                if pm is not None:
+                    return pm
+                # Cached bytes don't decode as an image (e.g. an HTML
+                # block page saved before fetch responses were
+                # validated) — drop them and fall through to a fresh
+                # fetch request.
+                disk_path.unlink()
             except Exception:
                 pass
 
@@ -77,10 +84,13 @@ class CoverCache:
             self._loading.discard(url)
             self._failed.add(url)
 
-    def _load_and_cache(self, url: str, disk_path: Path, size: Tuple[int, int]) -> QPixmap:
+    def _load_and_cache(self, url: str, disk_path: Path,
+                        size: Tuple[int, int]) -> Optional[QPixmap]:
+        """Decode the cached file into a scaled QPixmap, or ``None``
+        when the bytes aren't a decodable image."""
         img = QImage(str(disk_path))
         if img.isNull():
-            return self.get_placeholder(size)
+            return None
         pm = QPixmap.fromImage(img).scaled(
             size[0], size[1], Qt.AspectRatioMode.KeepAspectRatioByExpanding,
             Qt.TransformationMode.SmoothTransformation,

--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -72,6 +72,66 @@ from ..scrapers import POPULAR_SOURCES as SOURCE_POPULARITY  # noqa: E402
 _POPULARITY_RANK = {d: i for i, d in enumerate(SOURCE_POPULARITY)}
 
 
+# ─────────────────────────────────────────────────────────────────────
+# Cover fetch helpers — some cover CDNs hotlink-protect their images:
+# they refuse the request (or answer 200 with an HTML block page)
+# unless it carries the source site's Referer. Scrapers send these
+# headers in their own download_image(), but the GUI fetches covers
+# straight from the stored URL, outside any scraper — so the worker
+# needs its own marker → referer table. Keyed on a stable URL
+# fragment: MangaPill's CDN hostname rotates
+# (cdn.readdetectiveconan.com at the time of writing) but the
+# /file/mangapill/ path prefix does not.
+# ─────────────────────────────────────────────────────────────────────
+
+
+_COVER_REFERERS = (
+    ("/file/mangapill/", "https://mangapill.com/"),
+    ("mangapill.com", "https://mangapill.com/"),
+)
+
+_COVER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+
+
+def cover_request_headers(url: str) -> Dict[str, str]:
+    """Headers for a cover fetch, with a Referer for CDNs known to
+    require one."""
+    headers = {"User-Agent": _COVER_USER_AGENT}
+    for marker, referer in _COVER_REFERERS:
+        if marker in url:
+            headers["Referer"] = referer
+            break
+    return headers
+
+
+_IMAGE_MAGIC_PREFIXES = (
+    b"\xff\xd8\xff",        # JPEG
+    b"\x89PNG\r\n\x1a\n",   # PNG
+    b"GIF87a",              # GIF
+    b"GIF89a",
+    b"BM",                  # BMP
+)
+
+
+def looks_like_image(content: bytes, content_type: str = "") -> bool:
+    """True when a response body is plausibly an image.
+
+    Caching a non-image body (an HTML block page served with 200)
+    would leave the cover permanently blank — the disk cache file
+    exists, so the URL is never refetched. Magic bytes first; the
+    Content-Type header is only a fallback for formats we don't
+    sniff (AVIF, SVG, …).
+    """
+    if not content:
+        return False
+    if content.startswith(_IMAGE_MAGIC_PREFIXES):
+        return True
+    if content.startswith(b"RIFF") and content[8:12] == b"WEBP":
+        return True
+    ctype = (content_type or "").split(";")[0].strip().lower()
+    return ctype.startswith("image/")
+
+
 def source_rank(domain: str) -> int:
     """Lower = more popular. Unranked sources sort after named ones."""
     return _POPULARITY_RANK.get(domain, 999)
@@ -191,10 +251,12 @@ class BackgroundWorker:
 
         def _task():
             try:
-                resp = requests.get(url, timeout=15, headers={
-                    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
-                })
+                resp = requests.get(url, timeout=15,
+                                    headers=cover_request_headers(url))
                 resp.raise_for_status()
+                if not looks_like_image(
+                        resp.content, resp.headers.get("Content-Type", "")):
+                    raise ValueError("response body is not an image")
                 if cache:
                     cache.save_to_disk(url, resp.content)
             except Exception:

--- a/tests/unit/gui/test_app_cover_fallback.py
+++ b/tests/unit/gui/test_app_cover_fallback.py
@@ -1,0 +1,109 @@
+"""Issue #48 — when a stored cover URL fails to download (dead CDN
+link, hotlink block, non-image response), the app must try to replace
+it via the MangaDex fallback instead of leaving a permanent
+placeholder. `_backfill_missing_covers` only covers entries with no
+URL at all, so the failure path needs its own hook.
+
+The handler is exercised unbound on a stub app object — constructing a
+full MeMangaApp window per test is slow and none of the widgets are
+involved.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+
+_DEAD_URL = "https://cdn.readdetectiveconan.com/file/mangapill/i/580.webp"
+_FALLBACK_URL = "https://uploads.mangadex.org/covers/abc/def.512.jpg"
+
+
+@pytest.fixture
+def worker(event_bus):
+    from memanga.gui.workers import BackgroundWorker
+    w = BackgroundWorker(event_bus)
+    yield w
+    w.shutdown()
+
+
+@pytest.fixture
+def stub_app(config, event_bus, worker):
+    return SimpleNamespace(
+        config=config,
+        events=event_bus,
+        worker=worker,
+        _cover_fallback_attempted=set(),
+    )
+
+
+def _handle(stub, data):
+    from memanga.gui.app import MeMangaApp
+    MeMangaApp._on_cover_load_failed(stub, data)
+
+
+def _wait_for(predicate, timeout=3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
+
+
+class TestCoverLoadFailedFallback:
+    def test_dead_library_url_replaced(self, stub_app, config, event_bus,
+                                       monkeypatch):
+        config.set("manga", [{
+            "title": "Blue Lock",
+            "source": "mangapill.com",
+            "url": "https://mangapill.com/manga/580/blue-lock",
+            "cover_url": _DEAD_URL,
+        }])
+        import memanga.gui.cover_fallback as cf
+        monkeypatch.setattr(cf, "fetch_mangadex_cover",
+                            lambda title: _FALLBACK_URL)
+
+        updated = []
+        event_bus.subscribe("library_updated", lambda d: updated.append(d))
+
+        _handle(stub_app, {"url": _DEAD_URL, "error": True})
+
+        assert _wait_for(
+            lambda: config.get("manga")[0].get("cover_url") == _FALLBACK_URL)
+        event_bus.poll()
+        assert updated and updated[0]["title"] == "Blue Lock"
+
+    def test_attempted_once_per_url(self, stub_app, config, monkeypatch):
+        config.set("manga", [{"title": "Blue Lock", "cover_url": _DEAD_URL}])
+        calls = []
+        import memanga.gui.cover_fallback as cf
+        monkeypatch.setattr(cf, "fetch_mangadex_cover",
+                            lambda title: calls.append(title) or None)
+
+        _handle(stub_app, {"url": _DEAD_URL, "error": True})
+        assert _wait_for(lambda: len(calls) == 1)
+        # The same broken cover repainting must not re-query MangaDex.
+        _handle(stub_app, {"url": _DEAD_URL, "error": True})
+        time.sleep(0.2)
+        assert calls == ["Blue Lock"]
+
+    def test_url_not_in_library_is_noop(self, stub_app, config, monkeypatch):
+        # Search-result covers also flow through cover_loaded; a failed
+        # one has no library entry to repair.
+        config.set("manga", [{"title": "Other", "cover_url": "https://x/y.jpg"}])
+        calls = []
+        import memanga.gui.cover_fallback as cf
+        monkeypatch.setattr(cf, "fetch_mangadex_cover",
+                            lambda title: calls.append(title) or None)
+
+        _handle(stub_app, {"url": _DEAD_URL, "error": True})
+        time.sleep(0.2)
+        assert calls == []
+
+    def test_success_and_offline_events_ignored(self, stub_app):
+        _handle(stub_app, {"url": _DEAD_URL})  # no error flag
+        _handle(stub_app, {"url": _DEAD_URL, "error": True, "offline": True})
+        assert stub_app._cover_fallback_attempted == set()

--- a/tests/unit/gui/test_cache.py
+++ b/tests/unit/gui/test_cache.py
@@ -6,7 +6,9 @@ import pytest
 
 
 @pytest.fixture
-def cover_cache(isolated_home, event_bus):
+def cover_cache(qapp, isolated_home, event_bus):
+    # qapp: QPixmap construction aborts without a QGuiApplication, so
+    # the cache needs one even though no widget is shown.
     from memanga.gui.cache import CoverCache
     return CoverCache(isolated_home / ".config" / "memanga", event_bus)
 
@@ -31,3 +33,37 @@ class TestGetCover:
     def test_marks_failed(self, cover_cache):
         cover_cache.mark_failed("https://broken.test/x.jpg")
         assert "https://broken.test/x.jpg" in cover_cache._failed
+
+    def test_loads_valid_image_from_disk(self, cover_cache):
+        from PIL import Image
+        url = "https://covers.test/good.jpg"
+        Image.new("RGB", (200, 300), "white").save(
+            cover_cache._disk_path(url), format="PNG")
+
+        pm = cover_cache.get_cover(url, (50, 60))
+        assert pm.width() == 50 and pm.height() == 60
+        assert pm is not cover_cache.get_placeholder((50, 60))
+
+
+class TestCorruptDiskCache:
+    """Issue #48 — cached bytes that don't decode as an image (e.g. an
+    HTML block page saved by an older build) must be dropped and the
+    URL refetched, not returned as a permanent placeholder.
+    """
+
+    def test_bad_cached_bytes_dropped_and_refetched(self, cover_cache,
+                                                    event_bus):
+        url = "https://cdn.covers.test/blocked.webp"
+        disk_path = cover_cache._disk_path(url)
+        disk_path.write_bytes(b"<!DOCTYPE html><html>blocked</html>")
+
+        requested = []
+        event_bus.subscribe("cover_fetch_request",
+                            lambda d: requested.append(d))
+
+        pm = cover_cache.get_cover(url, (50, 60))
+
+        assert not pm.isNull()        # placeholder while refetching
+        assert not disk_path.exists()  # corrupt file dropped
+        event_bus.poll()
+        assert requested and requested[0]["url"] == url

--- a/tests/unit/gui/test_workers.py
+++ b/tests/unit/gui/test_workers.py
@@ -309,6 +309,118 @@ class TestCountChapters:
         assert seen == []
 
 
+class _RecordingCache:
+    """Stand-in for CoverCache that records calls instead of touching
+    disk or QPixmap."""
+
+    def __init__(self):
+        self.saved = {}
+        self.failed = []
+
+    def save_to_disk(self, url, content):
+        self.saved[url] = content
+
+    def mark_failed(self, url):
+        self.failed.append(url)
+
+
+class TestCoverFetch:
+    """Issue #48 — MangaPill covers live on a hotlink-protected CDN
+    that answers 403 (or an HTML block page) unless the request carries
+    the site's Referer. The generic cover fetch must send the right
+    Referer and must refuse to cache non-image bodies.
+    """
+
+    _CDN_URL = "https://cdn.readdetectiveconan.com/file/mangapill/i/580.webp"
+    _WEBP_BYTES = b"RIFF\x24\x00\x00\x00WEBPVP8 " + b"\x00" * 16
+
+    def test_mangapill_cdn_url_gets_referer(self):
+        from memanga.gui.workers import cover_request_headers
+        headers = cover_request_headers(self._CDN_URL)
+        assert headers["Referer"] == "https://mangapill.com/"
+
+    def test_unknown_host_gets_no_referer(self):
+        from memanga.gui.workers import cover_request_headers
+        headers = cover_request_headers(
+            "https://uploads.mangadex.org/covers/abc/def.512.jpg")
+        assert "Referer" not in headers
+        assert "User-Agent" in headers
+
+    def test_looks_like_image_accepts_magic_bytes(self):
+        from memanga.gui.workers import looks_like_image
+        assert looks_like_image(b"\xff\xd8\xff" + b"\x00" * 16)          # JPEG
+        assert looks_like_image(b"\x89PNG\r\n\x1a\n" + b"\x00" * 16)     # PNG
+        assert looks_like_image(self._WEBP_BYTES)                        # WEBP
+
+    def test_looks_like_image_content_type_fallback(self):
+        from memanga.gui.workers import looks_like_image
+        # Format we don't sniff — trust the Content-Type header.
+        assert looks_like_image(b"\x00\x00\x00 ftypavif", "image/avif")
+
+    def test_looks_like_image_rejects_html_and_empty(self):
+        from memanga.gui.workers import looks_like_image
+        assert not looks_like_image(b"<!DOCTYPE html><html>blocked",
+                                    "text/html; charset=UTF-8")
+        assert not looks_like_image(b"")
+
+    def _run_fetch(self, worker, event_bus, monkeypatch, body, ctype):
+        """Drive fetch_cover against a faked requests.get; return the
+        (recording cache, captured request headers, error events)."""
+        import time
+        import requests
+
+        captured = {}
+
+        class _Resp:
+            content = body
+            headers = {"Content-Type": ctype}
+
+            def raise_for_status(self):
+                pass
+
+        def _fake_get(url, timeout=None, headers=None):
+            captured.update(headers or {})
+            return _Resp()
+
+        monkeypatch.setattr(requests, "get", _fake_get)
+
+        errors = []
+        event_bus.subscribe(
+            "cover_loaded",
+            lambda d: errors.append(d) if d.get("error") else None)
+
+        cache = _RecordingCache()
+        worker.fetch_cover(self._CDN_URL, cache=cache)
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and not (cache.saved or cache.failed):
+            event_bus.poll()
+            time.sleep(0.02)
+        event_bus.poll()
+        return cache, captured, errors
+
+    def test_image_response_saved_with_referer(self, worker, event_bus,
+                                               monkeypatch):
+        cache, captured, errors = self._run_fetch(
+            worker, event_bus, monkeypatch,
+            self._WEBP_BYTES, "image/webp")
+        assert captured.get("Referer") == "https://mangapill.com/"
+        assert cache.saved == {self._CDN_URL: self._WEBP_BYTES}
+        assert cache.failed == []
+        assert errors == []
+
+    def test_html_block_page_marks_failed(self, worker, event_bus,
+                                          monkeypatch):
+        # 200 + HTML must not reach the disk cache — a cached non-image
+        # is never refetched and leaves the cover permanently blank.
+        cache, _captured, errors = self._run_fetch(
+            worker, event_bus, monkeypatch,
+            b"<!DOCTYPE html><html>blocked</html>",
+            "text/html; charset=UTF-8")
+        assert cache.saved == {}
+        assert cache.failed == [self._CDN_URL]
+        assert errors and errors[0]["url"] == self._CDN_URL
+
+
 class TestCheckUpdates:
     """Issue #30: explicit per-manga checks must bypass the reading-only
     filter that the library-wide sweep applies to non-reading manga."""


### PR DESCRIPTION
## Summary

- Fetch MangaPill cover CDN URLs with the MangaPill referer header.
- Reject non-image cover responses and evict stale non-image cache files so covers can retry.
- Fall back to MangaDex once when a stored library cover URL fails to load.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

Targeted local tests:
- `timeout 90 venv/bin/python -m pytest tests/unit/gui/test_cache.py tests/unit/gui/test_workers.py tests/unit/gui/test_app_cover_fallback.py tests/unit/gui/test_network_status.py -q`
- `venv/bin/python -m py_compile memanga/gui/app.py memanga/gui/cache.py memanga/gui/workers.py tests/unit/gui/test_cache.py tests/unit/gui/test_workers.py tests/unit/gui/test_app_cover_fallback.py`

Scraper live probe not run; this change is in GUI cover fetching and fallback, not scraper parsing.

## Related issues

Closes #48