### PR TITLE
fix(gui): jump concurrent slider to clicked position

### DIFF
--- a/memanga/gui/components/slider.py
+++ b/memanga/gui/components/slider.py
@@ -1,0 +1,52 @@
+"""
+JumpSlider: QSlider that jumps to the absolute clicked position.
+
+A stock QSlider treats a click on the groove as a *page step*
+(default 10). On short ranges like 1..8 a single page step saturates
+at the minimum or maximum, so clicking only produces the
+extremes. This subclass moves the handle to the clicked position
+instead, then hands the event to QSlider so dragging keeps working.
+"""
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QSlider, QStyle, QStyleOptionSlider
+
+
+class JumpSlider(QSlider):
+    """QSlider whose groove clicks set the value at the click point."""
+
+    def __init__(self, orientation=Qt.Orientation.Horizontal, parent=None):
+        super().__init__(orientation, parent)
+        # Keep keyboard PageUp/PageDown sane on short ranges too.
+        self.setPageStep(1)
+
+    def mousePressEvent(self, event):
+        if event.button() == Qt.MouseButton.LeftButton:
+            opt = QStyleOptionSlider()
+            self.initStyleOption(opt)
+            style = self.style()
+            handle = style.subControlRect(
+                QStyle.ComplexControl.CC_Slider, opt,
+                QStyle.SubControl.SC_SliderHandle, self,
+            )
+            pos = event.position().toPoint()
+            if not handle.contains(pos):
+                groove = style.subControlRect(
+                    QStyle.ComplexControl.CC_Slider, opt,
+                    QStyle.SubControl.SC_SliderGroove, self,
+                )
+                if self.orientation() == Qt.Orientation.Horizontal:
+                    offset = pos.x() - groove.x() - handle.width() // 2
+                    span = groove.width() - handle.width()
+                else:
+                    offset = pos.y() - groove.y() - handle.height() // 2
+                    span = groove.height() - handle.height()
+                self.setValue(
+                    QStyle.sliderValueFromPosition(
+                        self.minimum(), self.maximum(),
+                        offset, max(1, span), opt.upsideDown,
+                    )
+                )
+                # The handle is now under the cursor, so the default
+                # handler below starts a drag instead of a page step.
+        super().mousePressEvent(event)

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -325,8 +325,10 @@ class SettingsPage(BasePage):
         format_row.addWidget(hint, 1)
         f.addLayout(format_row)
 
-        # Concurrent downloads slider (1..8).
-        from PySide6.QtWidgets import QSlider
+        # Concurrent downloads slider (1..8). JumpSlider so a groove
+        # click sets the clicked value instead of page-stepping to an
+        # extreme (#46).
+        from ..components.slider import JumpSlider
         self._section(f, "Concurrent Downloads")
         slider_row = QHBoxLayout()
         slider_row.setSpacing(14)
@@ -334,7 +336,7 @@ class SettingsPage(BasePage):
         slider_hint.setProperty("role", "hint")
         slider_row.addWidget(slider_hint)
 
-        self._concurrent_slider = QSlider(Qt.Orientation.Horizontal)
+        self._concurrent_slider = JumpSlider(Qt.Orientation.Horizontal)
         self._concurrent_slider.setMinimum(1)
         self._concurrent_slider.setMaximum(8)
         self._concurrent_slider.setSingleStep(1)

--- a/tests/unit/gui/components/test_components.py
+++ b/tests/unit/gui/components/test_components.py
@@ -339,3 +339,76 @@ class TestIcons:
         from memanga.gui.assets.icons import icon
         i = icon(name, "#666666", size=24)
         assert not i.isNull(), f"{name} failed to render"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# JumpSlider
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestJumpSlider:
+    """Regression for #46: clicking the groove of a short-range slider
+    page-stepped (default pageStep=10) straight to the minimum or
+    maximum instead of the clicked position."""
+
+    def _make(self, theme, qtbot):
+        from memanga.gui.components.slider import JumpSlider
+        s = JumpSlider()
+        s.setMinimum(1)
+        s.setMaximum(8)
+        s.resize(280, 24)
+        qtbot.addWidget(s)
+        s.show()
+        return s
+
+    def _click_at(self, slider, x):
+        from PySide6.QtCore import Qt, QPointF
+        from PySide6.QtGui import QMouseEvent
+        pos = QPointF(x, slider.height() / 2)
+        for etype in (QMouseEvent.Type.MouseButtonPress,
+                      QMouseEvent.Type.MouseButtonRelease):
+            ev = QMouseEvent(etype, pos, pos,
+                             Qt.MouseButton.LeftButton,
+                             Qt.MouseButton.LeftButton,
+                             Qt.KeyboardModifier.NoModifier)
+            if etype == QMouseEvent.Type.MouseButtonPress:
+                slider.mousePressEvent(ev)
+            else:
+                slider.mouseReleaseEvent(ev)
+
+    def test_page_step_is_one(self, theme, qtbot):
+        s = self._make(theme, qtbot)
+        assert s.pageStep() == 1
+
+    def test_click_center_sets_middle_value(self, theme, qtbot):
+        s = self._make(theme, qtbot)
+        s.setValue(1)
+        self._click_at(s, s.width() / 2)
+        assert s.value() in (4, 5), (
+            f"center click gave {s.value()}, expected mid-range"
+        )
+
+    def test_click_does_not_saturate_to_extremes(self, theme, qtbot):
+        s = self._make(theme, qtbot)
+        s.setValue(4)
+        # Click ~3/4 of the way along the groove: a stock QSlider would
+        # page-step (by 10) and slam to the maximum.
+        self._click_at(s, s.width() * 0.75)
+        assert s.value() not in (1, 8), (
+            f"groove click saturated to {s.value()}"
+        )
+        assert s.value() > 4
+
+    def test_click_left_quarter_lowers_value(self, theme, qtbot):
+        s = self._make(theme, qtbot)
+        s.setValue(8)
+        self._click_at(s, s.width() * 0.25)
+        assert 1 < s.value() < 4
+
+    def test_click_at_ends_reaches_extremes(self, theme, qtbot):
+        s = self._make(theme, qtbot)
+        s.setValue(4)
+        self._click_at(s, 1)
+        assert s.value() == 1
+        self._click_at(s, s.width() - 1)
+        assert s.value() == 8

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -234,6 +234,14 @@ class TestSettingsPage:
         page._refresh_filename_preview()
         assert "1" in page._filename_preview.text()
 
+    def test_concurrent_slider_jumps_to_click(self, app_window, qapp):
+        # Regression for #46: a stock QSlider's groove click page-steps
+        # (default pageStep=10), saturating the 1..8 range to an extreme.
+        from memanga.gui.components.slider import JumpSlider
+        page = app_window._pages["settings"]
+        assert isinstance(page._concurrent_slider, JumpSlider)
+        assert page._concurrent_slider.pageStep() == 1
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Detail (requires a manga in config)


### PR DESCRIPTION
## Summary

- Add a reusable slider component that maps groove clicks to the clicked value instead of Qt's default page-step behavior.
- Use it for the concurrent-downloads setting so intermediate groove clicks select intermediate values.
- Cover the slider behavior and settings-page wiring with focused GUI tests.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

Targeted local tests:
- `timeout 180 venv/bin/python -m pytest tests/unit/gui/components/test_components.py::TestJumpSlider tests/unit/gui/pages/test_pages.py::TestSettingsPage::test_concurrent_slider_jumps_to_click -q`

Additional local check:
- `timeout 240 venv/bin/python -m pytest tests/unit/gui/components/test_components.py tests/unit/gui/pages/test_pages.py -q` timed out after 240s while still printing passing dots and no failure summary.

Scraper live probe not run; this change does not touch scraper code.

## Related issues

Closes #46
