### PR TITLE
fix(reader): mark chapters read near the end

### DIFF
--- a/memanga/gui/pages/reader.py
+++ b/memanga/gui/pages/reader.py
@@ -12,7 +12,7 @@ from PySide6.QtWidgets import (
     QScrollArea, QWidget,
 )
 from PySide6.QtGui import QPixmap, QImage, QKeyEvent, QShortcut
-from PySide6.QtCore import Qt, QByteArray, QBuffer, QEvent, QObject
+from PySide6.QtCore import Qt, QByteArray, QBuffer, QEvent, QObject, QTimer
 
 from .base import BasePage
 from .. import theme as T
@@ -103,6 +103,11 @@ class ReaderPage(BasePage):
     ZOOM_MAX = 2.5
     ZOOM_STEP = 0.25
     DEFAULT_MAX_WIDTH = 800
+    # Issue #45: scroll ratio at which a chapter counts as read. The
+    # slack below 1.0 covers the spacing + "Next chapter" button row
+    # appended after the last page, so finishing the final page is
+    # enough without having to pixel-perfectly hit the bottom.
+    READ_THRESHOLD = 0.98
 
     def __init__(self, parent, app):
         super().__init__(parent, app)
@@ -119,6 +124,9 @@ class ReaderPage(BasePage):
         self._image_layout = None
         self._page_indicator = None
         self._dual_btn = None
+        # Issue #45: set once the current chapter has been marked read,
+        # so the scroll handler only fires the state write + event once.
+        self._read_marked = False
 
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
@@ -151,16 +159,11 @@ class ReaderPage(BasePage):
             self._load_chapter()
             title = self._manga.get("title", "")
             if title:
-                # Cursor (most-recent) tracking + per-chapter read set
-                # (issue #18). The per-chapter set powers the Library's
-                # "X/N read" sub-line and the Detail chapter row badge.
+                # Cursor (most-recent) tracking (issue #18). The
+                # per-chapter read set is only updated once the user
+                # scrolls to the end of the chapter (issue #45) — see
+                # _mark_current_read.
                 self.app.app_state.set_reading_progress(title, str(self._chapter))
-                self.app.app_state.mark_chapter_read(title, str(self._chapter))
-                # Tell other pages (Library, Detail) to repaint without
-                # waiting for the next navigation.
-                self.app.events.publish("chapter_read", {
-                    "title": title, "chapter": str(self._chapter),
-                })
         self.setFocus()
 
     def on_hide(self):
@@ -455,8 +458,43 @@ class ReaderPage(BasePage):
             self._progress_pct.setText(f"{int(ratio * 100)}%")
             if self._page_indicator:
                 self._page_indicator.setText(f"{page_n} / {len(self._images)}")
+            # Issue #45: only flip the chapter to read once the user has
+            # actually scrolled (or jumped) to the end of it.
+            if sb.maximum() > 0 and ratio >= self.READ_THRESHOLD:
+                self._mark_current_read()
         except Exception:
             pass
+
+    def _mark_current_read(self):
+        """Mark the current chapter read (issue #45: only called when the
+        user reaches the end). The per-chapter set powers the Library's
+        "X/N read" sub-line and the Detail chapter row badge (issue #18).
+        """
+        if self._read_marked or not self._manga or not self._chapter:
+            return
+        title = self._manga.get("title", "")
+        if not title:
+            return
+        self._read_marked = True
+        self.app.app_state.mark_chapter_read(title, str(self._chapter))
+        # Tell other pages (Library, Detail) to repaint without
+        # waiting for the next navigation.
+        self.app.events.publish("chapter_read", {
+            "title": title, "chapter": str(self._chapter),
+        })
+
+    def _mark_read_if_unscrollable(self):
+        """A chapter that fits entirely in the viewport never scrolls, so
+        the end-of-scroll threshold can't fire — but the user is already
+        seeing all of it, which is as "finished" as it gets."""
+        if self._read_marked or self._scroll is None or not self._images:
+            return
+        viewport_h = self._scroll.viewport().height()
+        content = self._scroll.widget()
+        if viewport_h <= 0 or content is None:
+            return
+        if content.sizeHint().height() <= viewport_h:
+            self._mark_current_read()
 
     def _render_images(self):
         # Total width the spread is allowed to occupy.
@@ -528,6 +566,10 @@ class ReaderPage(BasePage):
         if self._content:
             self._content.deleteLater()
             self._content = None
+
+        # Issue #45: each chapter load starts with an unread gate, even
+        # when navigating Prev/Next within the reader.
+        self._read_marked = False
 
         self._content = QWidget()
         content_layout = QVBoxLayout(self._content)
@@ -749,6 +791,10 @@ class ReaderPage(BasePage):
         sb.valueChanged.connect(self._on_scroll)
         # Initial paint.
         self._on_scroll(0)
+        # Issue #45: after the layout settles, a chapter short enough to
+        # fit the viewport whole is immediately fully visible — the
+        # scroll threshold can never fire for it.
+        QTimer.singleShot(0, self._mark_read_if_unscrollable)
 
     def _find_and_load_chapter(self) -> List[QImage]:
         title = self._manga.get("title", "")

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -14,6 +14,7 @@ If any of these go red, a previously-fixed bug has come back.
 | #23 | Non-image format downloads written to root, not <dir>/<title>/ |
 | #40 | Pause All / Resume All dropped queued downloads |
 | #43 | Arrow keys dead in the reader |
+| #45 | Chapter marked read before reaching the end |
 | #49 | "Next chapter" button label invisible |
 | #55 | Detail page blank when Email to Kindle delivery selected |
 """
@@ -393,6 +394,37 @@ def test_issue_43_right_arrow_pans_when_zoomed(app_window, qapp,
     _press(reader, Qt.Key.Key_Right)
     assert hbar.value() > 0          # panned…
     assert str(reader._chapter) == "1"  # …without switching chapters
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #45 — Reader only marks read near the end
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_issue_45_reader_does_not_mark_middle_as_read(app_window, qapp,
+                                                       sample_manga, make_cbz):
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=8)
+    title = sample_manga["title"]
+    bar = reader._scroll.verticalScrollBar()
+    assert bar.maximum() > 0, "test needs scrollable reader content"
+
+    bar.setValue(bar.maximum() // 2)
+    qapp.processEvents()
+
+    assert not app_window.app_state.is_chapter_read(title, "1")
+
+
+def test_issue_45_reader_marks_read_at_end(app_window, qapp, sample_manga,
+                                            make_cbz):
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=8)
+    title = sample_manga["title"]
+    bar = reader._scroll.verticalScrollBar()
+    assert bar.maximum() > 0, "test needs scrollable reader content"
+
+    bar.setValue(bar.maximum())
+    qapp.processEvents()
+
+    assert app_window.app_state.is_chapter_read(title, "1")
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Delays reader read-state updates until the current chapter reaches the end-of-scroll threshold, while keeping continue-reading progress updated on chapter open.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [ ] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #45