### PR TITLE
feat(cli): add manga search command

### DIFF
--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -23,6 +23,7 @@ from .config import Config, get_app_password, set_app_password
 from .state import State
 from .downloader import check_for_updates, download_chapter, get_supported_sources, DownloaderError, ChapterWithSource, restart_browsers, _find_chapter_on_backup, _get_sources_from_manga
 from .scrapers import get_scraper
+from .search import compute_search_sources, probe_chapter_counts, sweep
 from .emailer import send_to_kindle, EmailError
 
 console = Console()
@@ -903,6 +904,191 @@ def cmd_sources(args):
     console.print(f"[dim]Total: {len(sources)} sources • All tested and working![/dim]")
 
 
+def _add_search_result(result, status=None):
+    """Add one search result to the tracked manga list.
+
+    Returns (ok, message). Printing is left to the caller so the JSON
+    output path can stay machine-readable.
+    """
+    manga_list = config.get("manga", [])
+    for m in manga_list:
+        if m["title"].lower() == result.title.lower():
+            return False, f"'{result.title}' already exists"
+
+    entry = {
+        "title": result.title,
+        "source": result.source,
+        "url": result.url,
+    }
+    if result.cover_url:
+        entry["cover_url"] = result.cover_url
+    if status:
+        entry["status"] = status
+
+    manga_list.append(entry)
+    config.set("manga", manga_list)
+    config.save()
+    return True, f"Added: {result.title} ({result.source})"
+
+
+def cmd_search(args):
+    """Search enabled sources for a manga by title."""
+    query = args.query.strip()
+    if not query:
+        console.print("[red]Error:[/red] empty search query")
+        return 1
+    if args.limit is not None and args.limit < 1:
+        console.print("[red]Error:[/red] --limit must be at least 1")
+        return 1
+
+    # Resolve the source list: one source with --source, otherwise the
+    # same enabled-aggregators + library sweep the GUI Search page runs.
+    if args.source:
+        source = args.source.lower()
+        if source.startswith("www."):
+            source = source[4:]
+        try:
+            get_scraper(source)
+        except ValueError:
+            console.print(f"[red]Unknown source:[/red] {source}")
+            console.print("[dim]Use 'memanga sources' to see supported sources.[/dim]")
+            return 1
+        sources = [source]
+    else:
+        sources = compute_search_sources(config)
+
+    if not sources:
+        console.print("[yellow]No searchable sources enabled.[/yellow]")
+        return 1
+
+    quiet = args.json  # keep stdout machine-readable for --json
+
+    if not quiet:
+        console.print(f'Searching {len(sources)} sources for [cyan]"{query}"[/cyan]...')
+
+    if quiet:
+        results, failures = sweep(query, sources, limit=args.limit)
+        if results and not args.no_chips:
+            probe_chapter_counts(results)
+    else:
+        progress = {"done": 0, "found": 0}
+
+        with console.status(f"[dim]0/{len(sources)} sources[/dim]") as status:
+            def _tick(extra_found=0):
+                progress["done"] += 1
+                progress["found"] += extra_found
+                status.update(
+                    f"[dim]{progress['done']}/{len(sources)} sources · "
+                    f"{progress['found']} results[/dim]"
+                )
+
+            results, failures = sweep(
+                query, sources, limit=args.limit,
+                on_source_done=lambda src, count: _tick(count),
+                on_source_failed=lambda src, err: _tick(),
+            )
+            if results and not args.no_chips:
+                status.update(f"[dim]Fetching chapter counts for {len(results)} results...[/dim]")
+                probe_chapter_counts(results)
+
+    # ── Output ──
+    if args.json:
+        add_ok = None
+        payload = {
+            "query": query,
+            "sources_searched": len(sources),
+            "results": [
+                {
+                    "n": i,
+                    "title": r.title,
+                    "source": r.source,
+                    "url": r.url,
+                    "cover_url": r.cover_url,
+                    "chapters": r.chapter_count,
+                }
+                for i, r in enumerate(results, 1)
+            ],
+            "failed": [{"source": f.source, "error": f.error} for f in failures],
+        }
+        if args.add is not None:
+            if 1 <= args.add <= len(results):
+                add_ok, message = _add_search_result(
+                    results[args.add - 1], args.status
+                )
+            else:
+                add_ok, message = False, f"invalid result number: {args.add}"
+            payload["added"] = {"ok": add_ok, "message": message}
+        print(json.dumps(payload, indent=2))
+        if args.add is not None:
+            return 0 if add_ok else 1
+        return 0 if results else 1
+
+    summary = f"{len(sources) - len(failures)} / {len(sources)} sources done"
+    if failures:
+        first = failures[0]
+        summary += f" · {len(failures)} failed ({first.source}: {first.error})"
+
+    if not results:
+        console.print(f"[yellow]No results for \"{query}\".[/yellow]")
+        console.print(f"[dim]{summary}[/dim]")
+        return 1
+
+    table = Table(box=box.SIMPLE)
+    table.add_column("#", style="dim", justify="right")
+    table.add_column("Source", style="green")
+    table.add_column("Title", style="cyan bold")
+    table.add_column("Chapters", style="yellow", justify="right")
+    for i, r in enumerate(results, 1):
+        table.add_row(
+            str(i),
+            r.source,
+            r.title,
+            str(r.chapter_count) if r.chapter_count is not None else "—",
+        )
+    console.print(table)
+    console.print(f"[dim]{summary}[/dim]")
+
+    # ── Selection ──
+    if args.add is not None:
+        if not (1 <= args.add <= len(results)):
+            console.print(f"[red]Invalid result number:[/red] {args.add} (valid: 1-{len(results)})")
+            return 1
+        ok, message = _add_search_result(results[args.add - 1], args.status)
+        if ok:
+            console.print(f"[green]✅ {message}[/green]")
+            return 0
+        console.print(f"[yellow]⚠️  {message}[/yellow]")
+        return 1
+
+    # Interactive prompt — only when someone is actually at the
+    # terminal. Piped/cron invocations just get the table.
+    if not sys.stdin.isatty():
+        return 0
+
+    console.print()
+    choice = Prompt.ask("Add which? ([cyan]number[/cyan] to add, [cyan]q[/cyan] to quit)", default="q")
+    choice = choice.strip().lower()
+    if choice in ("q", ""):
+        return 0
+    # Accept both "3" and "a 3".
+    if choice.startswith("a ") or choice.startswith("a\t"):
+        choice = choice[1:].strip()
+    try:
+        n = int(choice)
+    except ValueError:
+        console.print(f"[red]Not a result number:[/red] {choice}")
+        return 1
+    if not (1 <= n <= len(results)):
+        console.print(f"[red]Invalid result number:[/red] {n} (valid: 1-{len(results)})")
+        return 1
+    ok, message = _add_search_result(results[n - 1], args.status)
+    if ok:
+        console.print(f"[green]✅ {message}[/green]")
+        return 0
+    console.print(f"[yellow]⚠️  {message}[/yellow]")
+    return 1
+
+
 def cmd_export(args):
     """Export manga list and download state to JSON."""
     manga_list = config.get("manga", [])
@@ -1286,6 +1472,7 @@ Examples:
   memanga list                          # Show tracked manga
   memanga add -i                        # Add manga interactively
   memanga add -t "Solo Leveling" -u URL # Add manga directly
+  memanga search "Blue Lock"            # Find a manga across sources
   memanga check                         # Check for new chapters
   memanga check --auto                  # Auto-download new chapters
   memanga cron install                  # Set up daily checks
@@ -1362,6 +1549,17 @@ Examples:
     # sources
     p_sources = subparsers.add_parser("sources", help="List supported sources")
     p_sources.set_defaults(func=cmd_sources)
+
+    # search
+    p_search = subparsers.add_parser("search", help="Search sources for a manga by title")
+    p_search.add_argument("query", help="Manga title to search for")
+    p_search.add_argument("--json", action="store_true", help="Machine-readable JSON output")
+    p_search.add_argument("--source", help="Search a single source only (e.g. mangadex.org)")
+    p_search.add_argument("--limit", type=int, metavar="N", help="Cap results per source")
+    p_search.add_argument("--add", type=int, metavar="N", help="Add result #N without prompting")
+    p_search.add_argument("--status", choices=VALID_STATUSES, help="Status for the added manga (with --add or the prompt)")
+    p_search.add_argument("--no-chips", action="store_true", help="Skip chapter-count probes (faster)")
+    p_search.set_defaults(func=cmd_search)
 
     # export
     p_export = subparsers.add_parser("export", help="Export manga list and state to JSON")

--- a/memanga/gui/pages/search.py
+++ b/memanga/gui/pages/search.py
@@ -12,118 +12,16 @@ from .. import theme as T
 from ..components.search_result import SearchResultRow
 from ..components.toast import Toast
 
-
-# Sources known to be broken or dead — skipped in search so a worker
-# slot doesn't wait out the full timeout. Re-run tests/scrapers/live/
-# against a candidate domain before re-enabling it here.
-#
-# Reasons:
-#   - SHUTDOWN:     site shows a "shutdown" page (mangasee123)
-#   - DEAD_DNS:     domain resolves nowhere, every request times out
-#   - REPLACED:     domain forwards to an unrelated site (mangakakalot →
-#                   spinzywheel.com gambling page)
-#   - NEEDS_JS_API: site has an SPA + client-side search API that the
-#                   plain HTML doesn't expose (asurascans, mgeko.cc)
-BROKEN_SEARCH_SOURCES = {
-    # SHUTDOWN
-    "mangasee123.com",            # serves a "shutdown" image
-    # DEAD_DNS / unreachable
-    "mangareader.to",
-    "chapmanganato.to",
-    "readmanganato.com",
-    "manganato.com",
-    "mangakakalot.com",           # → spinzywheel.com
-    "mangakakalot.to",
-    "manga4life.com",             # ex-mangasee mirror, also dead
-    "mangalife.us",
-    # REPLACED / regional block / chronic timeout
-    "mangatown.com", "www.mangatown.com",
-    "manhwa18.cc",
-    "mangafreak.me", "mangafreak.ws", "ww2.mangafreak.me",
-    "bato.to", "batoto.to",
-    # NEEDS_JS_API — static HTML returns 0 hits, real search is client-side
-    "asuracomic.net", "asurascans.com", "asuratoon.com",
-    "mgeko.cc",
-    "mangabolt.com",
-    "truemanga.com", "mangamonk.com",
-    "mangahub.us",                # search endpoint requires headless JS
-    "hivetoons.org", "hivetoon.com",
-    "isekaiscan.com",
-    "zinmanga.com",
-    "kunmanga.com",
-    "flamecomics.xyz",            # SPA, search via API only
-    # Strong Cloudflare interactive challenge — even cloudscraper gets a
-    # 403. Would need a real headless browser. Drops them from search;
-    # user can still add manga from these by URL.
-    "manhuafast.com",
-    "manhuaus.org",
-    # Manganato.gg also serves the Cloudflare "Just a moment..." page
-    # to plain requests + Playwright without a deep wait. Its existing
-    # Playwright scraper times out at the 60s mark in practice.
-    "manganato.gg",
-}
+# Broken-source list and source-selection logic are shared with the
+# CLI's `memanga search` — single source of truth in memanga.search.
+# BROKEN_SEARCH_SOURCES stays importable from here for callers that
+# historically used this module.
+from memanga.search import BROKEN_SEARCH_SOURCES, compute_search_sources  # noqa: F401
 
 
 def _compute_search_sources(app) -> list[str]:
-    """Build the source list for the search worker.
-
-    The previous behaviour searched every supported source (~290), most
-    of which are template-based single-manga sites (dddmanga.com,
-    chainsawdevil.com, …). Their `search()` is hard-wired to their one
-    manga's keywords, so searching "Blue Lock" against them is pure
-    wasted network. We now restrict by default to:
-
-      1. Real aggregators (general-purpose sources, hand-curated list).
-      2. Every source the user has in their library — they've proven
-         useful for this user already.
-      3. Minus anything disabled on the Sources page.
-      4. Minus sites that are known dead / not searchable from plain
-         HTML (BROKEN_SEARCH_SOURCES — verified against the live
-         probe; updating that set is the supported way to re-enable a
-         source once its scraper is fixed).
-    """
-    from memanga.scrapers import SCRAPERS
-    try:
-        from memanga.scrapers.registry import TEMPLATE_SCRAPERS
-    except Exception:
-        TEMPLATE_SCRAPERS = {}
-
-    disabled = set(app.config.get("sources.disabled", []) or [])
-    library: set[str] = set()
-    for m in app.config.get("manga", []):
-        for s in m.get("sources", []) or []:
-            d = s.get("source", "")
-            if d:
-                library.add(d)
-        d = m.get("source", "")
-        if d:
-            library.add(d)
-
-    # Real aggregators: anything in SCRAPERS that's NOT a template-based
-    # single-manga site. Template scrapers' search() only matches their
-    # configured keywords, so we'd just be probing the network for no
-    # reason.
-    template_domains = set(TEMPLATE_SCRAPERS.keys())
-    aggregators = {d for d in SCRAPERS.keys() if d not in template_domains}
-
-    # De-dupe canonical hostnames — many aliases map to the same scraper
-    # class (e.g. tcbscans.com / tcbscans.me / tcbonepiecechapters.com
-    # all hit the same TCBScansScraper). We can just collapse via
-    # set-of-classes lookup keyed on identity.
-    canonical: dict = {}
-    for d in (library | aggregators):
-        if d in disabled:
-            continue
-        if d in BROKEN_SEARCH_SOURCES:
-            continue
-        cls = SCRAPERS.get(d)
-        if cls is None:
-            continue
-        key = id(cls)
-        # Prefer library domain over alias domain when both exist.
-        if key not in canonical or d in library:
-            canonical[key] = d
-    return sorted(canonical.values())
+    """Build the source list for the search worker (shared engine)."""
+    return compute_search_sources(app.config)
 
 
 class SearchPage(BasePage):

--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -3,7 +3,6 @@ Background worker for long-running operations.
 Wraps ThreadPoolExecutor; publishes events to the EventBus.
 """
 
-import re
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Dict, List, Optional
@@ -13,63 +12,16 @@ import requests
 from .events import EventBus
 
 
-# ─────────────────────────────────────────────────────────────────────
-# Search relevance filter — many "single-manga" scrapers in the
-# registry (BeastarsManga, TGManga, AjimeNoIppo, …) hard-code
-# `search()` to return their one manga regardless of the query
-# string. Without this filter, searching "Blue Lock" returns Beastars,
-# Tokyo Ghoul, Hajime no Ippo, etc. We compare the returned title
-# against the query tokens and drop everything that's obviously
-# unrelated. Cheap and idempotent — scrapers that already do
-# server-side search (MangaDex API, etc.) pass through unchanged.
-# ─────────────────────────────────────────────────────────────────────
-
-
-_WORD_RE = re.compile(r"[a-z0-9]+")
-
-
-def _result_matches_query(title: str, query: str) -> bool:
-    """Decide whether `title` is a plausible match for `query`.
-
-    Rules:
-      - Empty query → everything passes.
-      - Whole query substring in title → pass.
-      - Tokenise both, drop common stopwords. Short queries (1-2
-        tokens) require ALL tokens to be present in the title. Longer
-        queries require ≥ 60% of tokens.
-    """
-    if not query:
-        return True
-    title_l = (title or "").lower()
-    query_l = query.lower().strip()
-    if not title_l:
-        return False
-    if query_l in title_l:
-        return True
-    q_tokens = [t for t in _WORD_RE.findall(query_l) if len(t) >= 2]
-    if not q_tokens:
-        return True
-    t_tokens = set(_WORD_RE.findall(title_l))
-    matched = sum(1 for t in q_tokens if t in t_tokens or t in title_l)
-    if len(q_tokens) <= 2:
-        return matched == len(q_tokens)
-    return matched / len(q_tokens) >= 0.6
-
-
-# ─────────────────────────────────────────────────────────────────────
-# Popularity ranking — sources we hit first (and present first in the
-# results list). Earlier in the list = more popular / more trusted.
-# Anything not listed gets rank=999 (shown after the named ones,
-# stable alphabetical order between them).
-#
-# Single source of truth lives in memanga.scrapers.POPULAR_SOURCES so
-# the same order drives both the search-time submission queue and
-# the first-launch "which sources are pre-checked" seeding.
-# ─────────────────────────────────────────────────────────────────────
-
-
-from ..scrapers import POPULAR_SOURCES as SOURCE_POPULARITY  # noqa: E402
-_POPULARITY_RANK = {d: i for i, d in enumerate(SOURCE_POPULARITY)}
+# Relevance filter and popularity ranking are shared with the CLI's
+# `memanga search` — single source of truth lives in memanga.search.
+# Re-imported under the historical names so existing callers (and
+# tests) keep working.
+from ..search import (  # noqa: E402
+    result_matches_query as _result_matches_query,
+    source_rank,
+    sort_sources_by_popularity,
+)
+from ..scrapers import POPULAR_SOURCES as SOURCE_POPULARITY  # noqa: E402,F401
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -130,16 +82,6 @@ def looks_like_image(content: bytes, content_type: str = "") -> bool:
         return True
     ctype = (content_type or "").split(";")[0].strip().lower()
     return ctype.startswith("image/")
-
-
-def source_rank(domain: str) -> int:
-    """Lower = more popular. Unranked sources sort after named ones."""
-    return _POPULARITY_RANK.get(domain, 999)
-
-
-def sort_sources_by_popularity(sources: List[str]) -> List[str]:
-    """Return `sources` ordered most-popular-first, then alphabetical."""
-    return sorted(sources, key=lambda d: (source_rank(d), d))
 
 
 class BackgroundWorker:

--- a/memanga/search.py
+++ b/memanga/search.py
@@ -1,0 +1,348 @@
+"""
+Shared multi-source search engine.
+
+Both the CLI (`memanga search`) and the GUI Search page run the same
+sweep: fan a query out to many scrapers in parallel, filter the
+returned titles for relevance, and order results by source
+popularity. The GUI drives it through `BackgroundWorker.search_manga`
+(event-bus based, cancellable); the CLI uses the synchronous
+:func:`sweep` below. The building blocks live here so the two
+surfaces can't drift apart.
+"""
+
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from typing import Callable, List, Optional, Tuple
+from urllib.parse import urlparse
+
+from .scrapers import POPULAR_SOURCES, get_scraper
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Relevance filter — many "single-manga" scrapers in the registry
+# (BeastarsManga, TGManga, AjimeNoIppo, …) hard-code `search()` to
+# return their one manga regardless of the query string. Without this
+# filter, searching "Blue Lock" returns Beastars, Tokyo Ghoul, Hajime
+# no Ippo, etc. We compare the returned title against the query tokens
+# and drop everything that's obviously unrelated. Cheap and idempotent
+# — scrapers that already do server-side search (MangaDex API, etc.)
+# pass through unchanged.
+# ─────────────────────────────────────────────────────────────────────
+
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+def result_matches_query(title: str, query: str) -> bool:
+    """Decide whether `title` is a plausible match for `query`.
+
+    Rules:
+      - Empty query → everything passes.
+      - Whole query substring in title → pass.
+      - Tokenise both, drop common stopwords. Short queries (1-2
+        tokens) require ALL tokens to be present in the title. Longer
+        queries require ≥ 60% of tokens.
+    """
+    if not query:
+        return True
+    title_l = (title or "").lower()
+    query_l = query.lower().strip()
+    if not title_l:
+        return False
+    if query_l in title_l:
+        return True
+    q_tokens = [t for t in _WORD_RE.findall(query_l) if len(t) >= 2]
+    if not q_tokens:
+        return True
+    t_tokens = set(_WORD_RE.findall(title_l))
+    matched = sum(1 for t in q_tokens if t in t_tokens or t in title_l)
+    if len(q_tokens) <= 2:
+        return matched == len(q_tokens)
+    return matched / len(q_tokens) >= 0.6
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Popularity ranking — sources we hit first (and present first in the
+# results list). Earlier in POPULAR_SOURCES = more popular / more
+# trusted. Anything not listed gets rank=999 (shown after the named
+# ones, stable alphabetical order between them).
+# ─────────────────────────────────────────────────────────────────────
+
+
+_POPULARITY_RANK = {d: i for i, d in enumerate(POPULAR_SOURCES)}
+
+
+def source_rank(domain: str) -> int:
+    """Lower = more popular. Unranked sources sort after named ones."""
+    return _POPULARITY_RANK.get(domain, 999)
+
+
+def sort_sources_by_popularity(sources: List[str]) -> List[str]:
+    """Return `sources` ordered most-popular-first, then alphabetical."""
+    return sorted(sources, key=lambda d: (source_rank(d), d))
+
+
+# Sources known to be broken or dead — skipped in search so a worker
+# slot doesn't wait out the full timeout. Re-run tests/scrapers/live/
+# against a candidate domain before re-enabling it here.
+#
+# Reasons:
+#   - SHUTDOWN:     site shows a "shutdown" page (mangasee123)
+#   - DEAD_DNS:     domain resolves nowhere, every request times out
+#   - REPLACED:     domain forwards to an unrelated site (mangakakalot →
+#                   spinzywheel.com gambling page)
+#   - NEEDS_JS_API: site has an SPA + client-side search API that the
+#                   plain HTML doesn't expose (asurascans, mgeko.cc)
+BROKEN_SEARCH_SOURCES = {
+    # SHUTDOWN
+    "mangasee123.com",            # serves a "shutdown" image
+    # DEAD_DNS / unreachable
+    "mangareader.to",
+    "chapmanganato.to",
+    "readmanganato.com",
+    "manganato.com",
+    "mangakakalot.com",           # → spinzywheel.com
+    "mangakakalot.to",
+    "manga4life.com",             # ex-mangasee mirror, also dead
+    "mangalife.us",
+    # REPLACED / regional block / chronic timeout
+    "mangatown.com", "www.mangatown.com",
+    "manhwa18.cc",
+    "mangafreak.me", "mangafreak.ws", "ww2.mangafreak.me",
+    "bato.to", "batoto.to",
+    # NEEDS_JS_API — static HTML returns 0 hits, real search is client-side
+    "asuracomic.net", "asurascans.com", "asuratoon.com",
+    "mgeko.cc",
+    "mangabolt.com",
+    "truemanga.com", "mangamonk.com",
+    "mangahub.us",                # search endpoint requires headless JS
+    "hivetoons.org", "hivetoon.com",
+    "isekaiscan.com",
+    "zinmanga.com",
+    "kunmanga.com",
+    "flamecomics.xyz",            # SPA, search via API only
+    # Strong Cloudflare interactive challenge — even cloudscraper gets a
+    # 403. Would need a real headless browser. Drops them from search;
+    # user can still add manga from these by URL.
+    "manhuafast.com",
+    "manhuaus.org",
+    # Manganato.gg also serves the Cloudflare "Just a moment..." page
+    # to plain requests + Playwright without a deep wait. Its existing
+    # Playwright scraper times out at the 60s mark in practice.
+    "manganato.gg",
+}
+
+
+def compute_search_sources(config) -> List[str]:
+    """Build the source list for a multi-source sweep.
+
+    Searching every supported source (~290) would mostly hit
+    template-based single-manga sites (dddmanga.com, chainsawdevil.com,
+    …) whose `search()` is hard-wired to their one manga's keywords —
+    pure wasted network for any other query. We restrict to:
+
+      1. Real aggregators (anything in SCRAPERS that's not a
+         template-based single-manga site).
+      2. Every source the user has in their library — they've proven
+         useful for this user already.
+      3. Minus anything disabled on the Sources page
+         (`sources.disabled` in config).
+      4. Minus sites that are known dead / not searchable from plain
+         HTML (BROKEN_SEARCH_SOURCES — verified against the live
+         probe; updating that set is the supported way to re-enable a
+         source once its scraper is fixed).
+    """
+    from .scrapers import SCRAPERS
+    try:
+        from .scrapers.registry import TEMPLATE_SCRAPERS
+    except Exception:
+        TEMPLATE_SCRAPERS = {}
+
+    disabled = set(config.get("sources.disabled", []) or [])
+    library: set = set()
+    for m in config.get("manga", []):
+        for s in m.get("sources", []) or []:
+            if isinstance(s, dict):
+                d = s.get("source", "")
+                if not d and s.get("url"):
+                    d = urlparse(s["url"]).netloc.replace("www.", "")
+                if d:
+                    library.add(d)
+            elif isinstance(s, str):
+                d = urlparse(s).netloc.replace("www.", "")
+                if d:
+                    library.add(d)
+        d = m.get("source", "")
+        if d:
+            library.add(d)
+
+    # Real aggregators: anything in SCRAPERS that's NOT a template-based
+    # single-manga site. Template scrapers' search() only matches their
+    # configured keywords, so we'd just be probing the network for no
+    # reason.
+    template_domains = set(TEMPLATE_SCRAPERS.keys())
+    aggregators = {d for d in SCRAPERS.keys() if d not in template_domains}
+
+    # De-dupe canonical hostnames — many aliases map to the same scraper
+    # class (e.g. tcbscans.com / tcbscans.me / tcbonepiecechapters.com
+    # all hit the same TCBScansScraper). We can just collapse via
+    # set-of-classes lookup keyed on identity.
+    canonical: dict = {}
+    for d in (library | aggregators):
+        if d in disabled:
+            continue
+        if d in BROKEN_SEARCH_SOURCES:
+            continue
+        cls = SCRAPERS.get(d)
+        if cls is None:
+            continue
+        key = id(cls)
+        # Prefer library domains, then popular canonical domains, over
+        # less user-facing aliases such as api.mangadex.org.
+        current = canonical.get(key)
+        if (
+            current is None
+            or (d in library and current not in library)
+            or (
+                (d in library) == (current in library)
+                and source_rank(d) < source_rank(current)
+            )
+        ):
+            canonical[key] = d
+    return sorted(canonical.values())
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Synchronous sweep — used by the CLI. The GUI keeps its own
+# event-bus/cancellation wrapper in gui/workers.py but shares the
+# filter, ranking and source selection above.
+# ─────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SearchResult:
+    """One manga hit from one source."""
+    title: str
+    url: str
+    source: str
+    cover_url: Optional[str] = None
+    description: Optional[str] = None
+    chapter_count: Optional[int] = None
+
+
+@dataclass
+class SourceFailure:
+    """A source whose search() raised — kept so callers can report
+    partial coverage instead of silently hiding broken sources."""
+    source: str
+    error: str
+
+
+def _search_one_source(query: str, domain: str,
+                       limit: Optional[int]) -> List[SearchResult]:
+    scraper = get_scraper(domain)
+    found = scraper.search(query) or []
+    out: List[SearchResult] = []
+    for m in found:
+        # Tolerate both Manga dataclass (the contract) and plain dict
+        # (older scrapers / future variants).
+        if hasattr(m, "title") and hasattr(m, "url"):
+            title = getattr(m, "title", "") or ""
+            url = getattr(m, "url", "") or ""
+            cover = getattr(m, "cover_url", None)
+            desc = getattr(m, "description", None)
+        elif isinstance(m, dict):
+            title = m.get("title", "") or ""
+            url = m.get("url", "") or ""
+            cover = m.get("cover_url")
+            desc = m.get("description")
+        else:
+            continue
+        if not title or not url:
+            continue
+        if not result_matches_query(title, query):
+            # Single-manga site returned its manga for an unrelated
+            # query — drop it silently.
+            continue
+        out.append(SearchResult(title=title, url=url, source=domain,
+                                cover_url=cover, description=desc))
+        if limit is not None and len(out) >= limit:
+            break
+    return out
+
+
+def sweep(
+    query: str,
+    sources: List[str],
+    *,
+    limit: Optional[int] = None,
+    max_workers: int = 8,
+    on_source_done: Optional[Callable[[str, int], None]] = None,
+    on_source_failed: Optional[Callable[[str, str], None]] = None,
+) -> Tuple[List[SearchResult], List[SourceFailure]]:
+    """Search `query` across `sources` in parallel.
+
+    Blocks until every source has answered or failed. Results come
+    back ordered by source popularity (then source name), with each
+    source's own ordering preserved within that. `limit` caps results
+    per source, not overall.
+
+    Concurrency is capped at `max_workers` — hundreds of sources × 1
+    thread each would saturate the network stack and spin up a flood
+    of Playwright browsers.
+    """
+    ordered = sort_sources_by_popularity(sources)
+    results: List[SearchResult] = []
+    failures: List[SourceFailure] = []
+    if not ordered:
+        return results, failures
+
+    with ThreadPoolExecutor(max_workers=max_workers,
+                            thread_name_prefix="memanga-search") as pool:
+        futures = {pool.submit(_search_one_source, query, d, limit): d
+                   for d in ordered}
+        for f in as_completed(futures):
+            domain = futures[f]
+            try:
+                found = f.result()
+            except Exception as e:
+                msg = f"{type(e).__name__}: {e}"[:160]
+                failures.append(SourceFailure(source=domain, error=msg))
+                if on_source_failed:
+                    on_source_failed(domain, msg)
+                continue
+            results.extend(found)
+            if on_source_done:
+                on_source_done(domain, len(found))
+
+    # Stable sort: per-source order is preserved, sources are ranked
+    # by popularity so MangaDex / MangaPill hits lead the list.
+    results.sort(key=lambda r: (source_rank(r.source), r.source))
+    return results, failures
+
+
+def fetch_chapter_count(source: str, url: str) -> Optional[int]:
+    """Chapter count for one result, or None when the probe fails.
+    One attempt only — callers wanting retries (the GUI chip probe)
+    layer them on top."""
+    try:
+        scraper = get_scraper(source)
+        chapters = scraper.get_chapters(url) or []
+        return len(chapters)
+    except Exception:
+        return None
+
+
+def probe_chapter_counts(results: List[SearchResult],
+                         max_workers: int = 6) -> None:
+    """Fill in `chapter_count` on each result in place, in parallel.
+    Failed probes leave the field None."""
+    if not results:
+        return
+    with ThreadPoolExecutor(max_workers=max_workers,
+                            thread_name_prefix="chapter-count") as pool:
+        futures = {pool.submit(fetch_chapter_count, r.source, r.url): r
+                   for r in results}
+        for f in as_completed(futures):
+            futures[f].chapter_count = f.result()

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -289,6 +289,178 @@ class TestExportImport:
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# `search` — live multi-source search (scrapers mocked, no network)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _FakeSearchScraper:
+    def __init__(self, results=None, chapters=3, search_error=None):
+        self._results = results
+        self._chapters = chapters
+        self._search_error = search_error
+        self.get_chapters_calls = []
+
+    def search(self, query):
+        if self._search_error:
+            raise self._search_error
+        if self._results is not None:
+            return self._results
+        from memanga.scrapers import Manga
+        return [Manga(title="Blue Lock", url="https://fake.test/blue-lock",
+                      cover_url="https://fake.test/cover.jpg")]
+
+    def get_chapters(self, url):
+        self.get_chapters_calls.append(url)
+        return [object()] * self._chapters
+
+
+@pytest.fixture
+def fake_search_scraper(monkeypatch):
+    """Route every scraper lookup (CLI validation + engine sweep) to one
+    fake. Tests pass `--source fake.test` so the sweep stays single-source
+    and never consults the real registry."""
+    scraper = _FakeSearchScraper()
+
+    def _install(s):
+        monkeypatch.setattr("memanga.cli.get_scraper", lambda d: s)
+        monkeypatch.setattr("memanga.search.get_scraper", lambda d: s)
+        return s
+
+    _install(scraper)
+    scraper.reinstall = _install
+    return scraper
+
+
+class TestSearchCommand:
+    def test_table_output(self, run_cli, fake_search_scraper, capsys):
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test")
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Blue Lock" in out
+        assert "fake.test" in out
+        assert "3" in out            # chapter-count chip
+        assert "1 / 1 sources done" in out
+
+    def test_json_output(self, run_cli, fake_search_scraper, capsys):
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test", "--json")
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["query"] == "Blue Lock"
+        assert payload["sources_searched"] == 1
+        assert payload["failed"] == []
+        (result,) = payload["results"]
+        assert result["title"] == "Blue Lock"
+        assert result["source"] == "fake.test"
+        assert result["url"] == "https://fake.test/blue-lock"
+        assert result["chapters"] == 3
+
+    def test_no_chips_skips_chapter_probe(self, run_cli, fake_search_scraper,
+                                          capsys):
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--no-chips", "--json")
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["results"][0]["chapters"] is None
+        assert fake_search_scraper.get_chapters_calls == []
+
+    def test_limit_caps_per_source_results(self, run_cli, fake_search_scraper,
+                                           capsys):
+        from memanga.scrapers import Manga
+        many = [Manga(title=f"Blue Lock {i}", url=f"https://fake.test/{i}")
+                for i in range(8)]
+        fake_search_scraper.reinstall(_FakeSearchScraper(results=many))
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--limit", "2", "--no-chips", "--json")
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert len(payload["results"]) == 2
+
+    def test_add_directly_with_status(self, run_cli, fake_search_scraper,
+                                      config):
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--add", "1", "--status", "on-hold", "--no-chips")
+        assert rc == 0
+        (manga,) = config.get("manga", [])
+        assert manga["title"] == "Blue Lock"
+        assert manga["source"] == "fake.test"
+        assert manga["url"] == "https://fake.test/blue-lock"
+        assert manga["cover_url"] == "https://fake.test/cover.jpg"
+        assert manga["status"] == "on-hold"
+
+    def test_add_duplicate_rejected(self, run_cli, fake_search_scraper,
+                                    config):
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--add", "1", "--no-chips")
+        assert rc == 0
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--add", "1", "--no-chips")
+        assert rc == 1
+        assert len(config.get("manga", [])) == 1
+
+    def test_add_out_of_range(self, run_cli, fake_search_scraper, config):
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--add", "99", "--no-chips")
+        assert rc == 1
+        assert config.get("manga", []) == []
+
+    def test_json_add_out_of_range_exits_nonzero(self, run_cli,
+                                                 fake_search_scraper,
+                                                 capsys):
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--add", "99", "--no-chips", "--json")
+        assert rc == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["added"]["ok"] is False
+
+    def test_no_results(self, run_cli, fake_search_scraper, capsys):
+        fake_search_scraper.reinstall(_FakeSearchScraper(results=[]))
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--no-chips")
+        assert rc == 1
+        assert "No results" in capsys.readouterr().out
+
+    def test_source_failure_reported(self, run_cli, fake_search_scraper,
+                                     capsys):
+        fake_search_scraper.reinstall(
+            _FakeSearchScraper(search_error=RuntimeError("HTTP 502")))
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--no-chips")
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "1 failed" in out
+        assert "HTTP 502" in out
+
+    def test_unknown_source_errors(self, run_cli, isolated_home, capsys):
+        rc = run_cli("search", "Blue Lock",
+                     "--source", "not-a-real-source.example")
+        assert rc == 1
+        assert "Unknown source" in capsys.readouterr().out
+
+    def test_irrelevant_results_filtered(self, run_cli, fake_search_scraper,
+                                         capsys):
+        from memanga.scrapers import Manga
+        fake_search_scraper.reinstall(_FakeSearchScraper(results=[
+            Manga(title="Blue Lock", url="https://fake.test/bl"),
+            Manga(title="Beastars", url="https://fake.test/beastars"),
+        ]))
+        rc = run_cli("search", "Blue Lock", "--source", "fake.test",
+                     "--no-chips", "--json")
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert [r["title"] for r in payload["results"]] == ["Blue Lock"]
+
+    def test_default_source_selection_used(self, run_cli, monkeypatch,
+                                           fake_search_scraper, capsys):
+        """Without --source the command sweeps compute_search_sources()."""
+        monkeypatch.setattr("memanga.cli.compute_search_sources",
+                            lambda cfg: ["fake.test", "other.test"])
+        rc = run_cli("search", "Blue Lock", "--no-chips", "--json")
+        assert rc == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["sources_searched"] == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # `cron` — install / status / remove scheduled task
 # ─────────────────────────────────────────────────────────────────────────
 

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -1,0 +1,231 @@
+"""Unit tests for the shared search engine (memanga.search).
+
+Everything network-shaped is faked — scrapers are stubs returning
+canned Manga objects, no requests leave the process.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import Manga
+from memanga.search import (
+    SearchResult,
+    compute_search_sources,
+    fetch_chapter_count,
+    probe_chapter_counts,
+    result_matches_query,
+    sweep,
+)
+
+
+class FakeScraper:
+    def __init__(self, results=None, chapters=0, search_error=None,
+                 chapters_error=None):
+        self._results = results or []
+        self._chapters = chapters
+        self._search_error = search_error
+        self._chapters_error = chapters_error
+        self.search_calls = []
+        self.get_chapters_calls = []
+
+    def search(self, query):
+        self.search_calls.append(query)
+        if self._search_error:
+            raise self._search_error
+        return self._results
+
+    def get_chapters(self, url):
+        self.get_chapters_calls.append(url)
+        if self._chapters_error:
+            raise self._chapters_error
+        return [object()] * self._chapters
+
+
+def _patch_scrapers(monkeypatch, by_domain):
+    """Point memanga.search.get_scraper at a dict of fakes."""
+    def _get(domain):
+        if domain not in by_domain:
+            raise ValueError(f"No scraper available for: {domain}")
+        return by_domain[domain]
+    monkeypatch.setattr("memanga.search.get_scraper", _get)
+
+
+class FakeConfig:
+    def __init__(self, data=None):
+        self._data = data or {}
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# sweep
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestSweep:
+    def test_results_sorted_by_source_popularity(self, monkeypatch):
+        _patch_scrapers(monkeypatch, {
+            "zzz-unranked.com": FakeScraper(
+                [Manga(title="Blue Lock", url="https://zzz-unranked.com/bl")]),
+            "mangadex.org": FakeScraper(
+                [Manga(title="Blue Lock", url="https://mangadex.org/bl")]),
+        })
+        results, failures = sweep("Blue Lock",
+                                  ["zzz-unranked.com", "mangadex.org"])
+        assert not failures
+        assert [r.source for r in results] == ["mangadex.org",
+                                               "zzz-unranked.com"]
+
+    def test_irrelevant_titles_filtered(self, monkeypatch):
+        # Single-manga sites return their one manga for any query.
+        _patch_scrapers(monkeypatch, {
+            "beastars.example": FakeScraper(
+                [Manga(title="Beastars", url="https://beastars.example/b")]),
+            "mangadex.org": FakeScraper(
+                [Manga(title="Blue Lock", url="https://mangadex.org/bl")]),
+        })
+        results, failures = sweep("Blue Lock",
+                                  ["beastars.example", "mangadex.org"])
+        assert not failures
+        assert [r.title for r in results] == ["Blue Lock"]
+
+    def test_per_source_limit(self, monkeypatch):
+        many = [Manga(title=f"Blue Lock {i}", url=f"https://x.test/{i}")
+                for i in range(10)]
+        _patch_scrapers(monkeypatch, {"x.test": FakeScraper(many)})
+        results, _ = sweep("Blue Lock", ["x.test"], limit=3)
+        assert len(results) == 3
+
+    def test_source_failure_collected_and_reported(self, monkeypatch):
+        _patch_scrapers(monkeypatch, {
+            "broken.test": FakeScraper(search_error=RuntimeError("HTTP 502")),
+            "mangadex.org": FakeScraper(
+                [Manga(title="Blue Lock", url="https://mangadex.org/bl")]),
+        })
+        failed_calls = []
+        results, failures = sweep(
+            "Blue Lock", ["broken.test", "mangadex.org"],
+            on_source_failed=lambda src, err: failed_calls.append((src, err)),
+        )
+        assert len(results) == 1
+        assert len(failures) == 1
+        assert failures[0].source == "broken.test"
+        assert "HTTP 502" in failures[0].error
+        assert failed_calls == [("broken.test", failures[0].error)]
+
+    def test_unknown_source_is_a_failure_not_a_crash(self, monkeypatch):
+        _patch_scrapers(monkeypatch, {})
+        results, failures = sweep("Blue Lock", ["nope.test"])
+        assert results == []
+        assert len(failures) == 1
+
+    def test_dict_results_tolerated(self, monkeypatch):
+        _patch_scrapers(monkeypatch, {
+            "dicty.test": FakeScraper(
+                [{"title": "Blue Lock", "url": "https://dicty.test/bl",
+                  "cover_url": "https://dicty.test/c.jpg"}]),
+        })
+        results, _ = sweep("Blue Lock", ["dicty.test"])
+        assert len(results) == 1
+        assert results[0].cover_url == "https://dicty.test/c.jpg"
+
+    def test_on_source_done_callback(self, monkeypatch):
+        _patch_scrapers(monkeypatch, {
+            "mangadex.org": FakeScraper(
+                [Manga(title="Blue Lock", url="https://mangadex.org/bl")]),
+        })
+        done = []
+        sweep("Blue Lock", ["mangadex.org"],
+              on_source_done=lambda src, count: done.append((src, count)))
+        assert done == [("mangadex.org", 1)]
+
+    def test_empty_source_list(self):
+        results, failures = sweep("Blue Lock", [])
+        assert results == []
+        assert failures == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# chapter counts
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestChapterCounts:
+    def test_fetch_count(self, monkeypatch):
+        _patch_scrapers(monkeypatch, {"x.test": FakeScraper(chapters=42)})
+        assert fetch_chapter_count("x.test", "https://x.test/m") == 42
+
+    def test_fetch_count_failure_is_none(self, monkeypatch):
+        _patch_scrapers(monkeypatch, {
+            "x.test": FakeScraper(chapters_error=RuntimeError("boom")),
+        })
+        assert fetch_chapter_count("x.test", "https://x.test/m") is None
+
+    def test_probe_fills_in_place(self, monkeypatch):
+        _patch_scrapers(monkeypatch, {
+            "ok.test": FakeScraper(chapters=7),
+            "bad.test": FakeScraper(chapters_error=RuntimeError("boom")),
+        })
+        results = [
+            SearchResult(title="A", url="https://ok.test/a", source="ok.test"),
+            SearchResult(title="B", url="https://bad.test/b", source="bad.test"),
+        ]
+        probe_chapter_counts(results)
+        assert results[0].chapter_count == 7
+        assert results[1].chapter_count is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# source selection
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestComputeSearchSources:
+    def test_includes_aggregators_excludes_broken(self):
+        sources = compute_search_sources(FakeConfig())
+        assert "mangadex.org" in sources
+        assert "mangapill.com" in sources
+        # Known-dead sites never make the sweep list.
+        assert "mangasee123.com" not in sources
+        assert "manganato.com" not in sources
+
+    def test_disabled_sources_removed(self):
+        sources = compute_search_sources(FakeConfig({
+            "sources.disabled": ["mangadex.org"],
+        }))
+        assert "mangadex.org" not in sources
+        assert "mangapill.com" in sources
+
+    def test_template_single_manga_sites_excluded_by_default(self):
+        from memanga.scrapers.registry import TEMPLATE_SCRAPERS
+        sources = set(compute_search_sources(FakeConfig()))
+        overlap = sources & set(TEMPLATE_SCRAPERS.keys())
+        assert not overlap
+
+    def test_library_string_sources_do_not_crash(self):
+        # Legacy configs can store plain URL strings under "sources".
+        sources = compute_search_sources(FakeConfig({
+            "manga": [{"title": "X",
+                       "sources": ["https://mangadex.org/title/abc"]}],
+        }))
+        assert "mangadex.org" in sources
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# relevance filter (canonical home; GUI re-exports it)
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestRelevanceFilter:
+    def test_exact_and_superset_match(self):
+        assert result_matches_query("Blue Lock", "blue lock")
+        assert result_matches_query("Blue Lock - Episode Nagi", "blue lock")
+
+    def test_unrelated_title_dropped(self):
+        assert not result_matches_query("Beastars", "blue lock")
+        assert not result_matches_query("Tokyo Ghoul", "blue lock")
+
+    def test_empty_query_passes_everything(self):
+        assert result_matches_query("Anything", "")


### PR DESCRIPTION
## Summary

Adds a shared search engine used by the CLI and GUI search flows, then exposes it through a new `memanga search` command for title-based discovery across sources. The command supports JSON output, single-source search, per-source limits, optional chapter-count probes, direct add by result number, and status assignment.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #31