### PR TITLE
feat(check): guard suspicious chapter batches

### DIFF
--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -429,10 +429,34 @@ def cmd_check(args):
         console.print(f"[dim]Checking:[/dim] [cyan]{title}[/cyan]...")
         
         try:
-            new_chapters = check_for_updates(manga, state, from_chapter=from_chapter)
-            
+            force_suspicious = getattr(args, 'force_suspicious', False)
+            new_chapters = check_for_updates(
+                manga, state,
+                from_chapter=from_chapter,
+                force_suspicious=force_suspicious,
+            )
+
+            # A batch that doesn't fit this manga's history was withheld
+            # because it couldn't be confirmed by a backup source.
+            suspicious = state.get_suspicious_batch(title) if from_chapter is None else None
+            if suspicious:
+                console.print(
+                    f"  [yellow]└─ Warning: Suspicious chapter batch detected: "
+                    f"{suspicious.get('count')} chapter(s) up to "
+                    f"{suspicious.get('highest')} "
+                    f"(last tracked: {suspicious.get('last_chapter')})[/yellow]"
+                )
+                for reason in suspicious.get("reasons", []):
+                    console.print(f"     [dim]- {reason}[/dim]")
+                console.print(f"     [dim]- {suspicious.get('backup_status')}[/dim]")
+                console.print(
+                    "     [yellow]Skipped auto-delivery. Run "
+                    "'memanga check --force-suspicious' to accept anyway.[/yellow]"
+                )
+
             if not new_chapters:
-                console.print("  [dim]└─ No new chapters[/dim]")
+                if not suspicious:
+                    console.print("  [dim]└─ No new chapters[/dim]")
                 continue
             
             console.print(f"  [green]└─ {len(new_chapters)} new chapter(s)![/green]")
@@ -1340,6 +1364,7 @@ Examples:
     p_check.add_argument("-q", "--quiet", action="store_true", help="Minimal output (for cron)")
     p_check.add_argument("-s", "--safe", action="store_true", help="Safe mode: restart browser every 3 chapters (for bulk downloads)")
     p_check.add_argument("-n", "--dry-run", action="store_true", help="List new chapters without downloading")
+    p_check.add_argument("--force-suspicious", action="store_true", help="Accept a chapter batch even if it was flagged as suspicious")
     p_check.add_argument("--format", choices=["pdf", "epub", "cbz", "zip", "jpg", "png", "webp"], help="Output format (overrides config)")
     p_check.add_argument("--retries", type=int, default=3, metavar="N", help="Retry failed page downloads N times (default: 3, 0 to disable)")
     p_check.set_defaults(func=cmd_check)

--- a/memanga/downloader.py
+++ b/memanga/downloader.py
@@ -125,6 +125,7 @@ def check_for_updates(
     state: State,
     from_chapter: Optional[float] = None,
     return_all: bool = False,
+    force_suspicious: bool = False,
 ):
     """
     Check if a manga has new chapters, with backup source support.
@@ -140,6 +141,14 @@ def check_for_updates(
        - Not in pending_backup? Add it, skip (start waiting)
     5. If primary gets the chapter later, we prefer primary
 
+    Suspicious batches: when the primary source suddenly exposes a batch
+    of "new" chapters that doesn't fit the manga's history (huge count,
+    big numeric jump, gappy numbering), the batch is verified against
+    backup sources. If no backup confirms it, the chapters are withheld,
+    recorded via ``state.set_suspicious_batch``, and a warning notification
+    is added. Nothing is downloaded or delivered until the user re-runs
+    with ``force_suspicious=True``.
+
     Args:
         manga: Manga entry from config with title, sources (or url/source)
         state: State manager to check last downloaded chapter
@@ -148,8 +157,10 @@ def check_for_updates(
             where ``all_chapters`` is the full chapter list from the primary
             source wrapped as :class:`ChapterWithSource` (used by the GUI
             Detail page to show every chapter as Read/Download). When False
-            (default), returns just the filtered new-chapter list — preserves
+            (default), returns just the filtered new-chapter list, preserving
             the original CLI signature.
+        force_suspicious: Accept a batch even if it looks suspicious
+            (``memanga check --force-suspicious``).
 
     Returns:
         ``List[ChapterWithSource]`` (default) or
@@ -177,6 +188,12 @@ def check_for_updates(
     # Track what we found on each source
     primary_chapters: Dict[str, Chapter] = {}  # chapter_num -> Chapter
     backup_chapters: Dict[str, Tuple[Chapter, str, str]] = {}  # chapter_num -> (Chapter, source, url)
+
+    # Every chapter number seen on any backup source (full list, not just
+    # new ones). Used to verify suspicious primary batches.
+    backup_all_numbers: set = set()
+    backup_sources_checked = 0
+    primary_checked = False
 
     # Full chapter list from the primary source (every chapter, downloaded or not).
     # Used by the GUI Detail page when return_all=True so it can render every
@@ -210,10 +227,14 @@ def check_for_updates(
         # Detail-page cache. Backup sources are intentionally skipped here —
         # we don't want backup-only chapters polluting the canonical list.
         if is_primary:
+            primary_checked = True
             primary_all = [
                 ChapterWithSource(ch, source, url, is_backup=False)
                 for ch in all_chapters
             ]
+        else:
+            backup_sources_checked += 1
+            backup_all_numbers.update(round(ch.numeric, 3) for ch in all_chapters)
 
         # Filter to new chapters
         new_chapters = [
@@ -236,6 +257,56 @@ def check_for_updates(
         raise DownloaderError(
             f"All sources failed for '{title}': " + "; ".join(source_errors)
         )
+
+    # Suspicious-batch guard. Only meaningful when we have a baseline (a
+    # previously tracked chapter) and the user isn't explicitly
+    # bulk-downloading with from_chapter.
+    if from_chapter is None and last_num > 0 and primary_checked:
+        from .suspicion import evaluate_new_chapters
+
+        suspicion = evaluate_new_chapters(
+            state, title,
+            [ch.numeric for ch in primary_chapters.values()],
+            last_num,
+        )
+        if suspicion.suspicious and not force_suspicious:
+            suspect = sorted(primary_chapters.values())
+            suspect_numbers = [round(ch.numeric, 3) for ch in suspect]
+
+            # Verify against backup sources before withholding anything.
+            confirmed = sum(1 for n in suspect_numbers if n in backup_all_numbers)
+            if backup_sources_checked and confirmed / len(suspect_numbers) >= 0.5:
+                # Backup largely agrees with the primary, so accept the batch.
+                state.clear_suspicious_batch(title)
+            else:
+                if backup_sources_checked:
+                    backup_status = (
+                        f"backup confirmed only {confirmed}/{len(suspect_numbers)} chapters"
+                    )
+                else:
+                    backup_status = "no backup source available to verify"
+                state.set_suspicious_batch(title, {
+                    "detected_at": datetime.now().isoformat(),
+                    "chapters": [ch.number for ch in suspect],
+                    "count": len(suspect),
+                    "last_chapter": last_num,
+                    "highest": max(suspect_numbers),
+                    "score": suspicion.score,
+                    "reasons": suspicion.reasons,
+                    "backup_status": backup_status,
+                })
+                state.add_notification(
+                    "warn",
+                    f"Suspicious chapter batch for '{title}': "
+                    f"{len(suspect)} chapter(s) up to {max(suspect_numbers):g} "
+                    f"({backup_status}). Skipped auto-delivery.",
+                )
+                # Withhold the whole primary batch from download/delivery.
+                primary_chapters = {}
+        else:
+            # Batch is normal, forced, or backup-confirmed. Drop any
+            # stale suspicious record so warnings don't linger.
+            state.clear_suspicious_batch(title)
 
     # Process primary chapters first (always download these)
     for ch_num, ch in primary_chapters.items():

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -197,6 +197,29 @@ class State:
         return manga_state.get("pending_backup", {})
     
     # ========================================================================
+    # Suspicious Batch Tracking
+    # ========================================================================
+
+    def set_suspicious_batch(self, manga_title: str, info: Dict[str, Any]):
+        """Record a suspicious chapter batch that was held back from
+        download/delivery. ``info`` should describe the batch (chapters,
+        score, reasons, backup verification status, detected_at)."""
+        self._ensure_manga_entry(manga_title)
+        self._data["manga"][manga_title]["suspicious_batch"] = info
+        self.save()
+
+    def get_suspicious_batch(self, manga_title: str) -> Optional[Dict[str, Any]]:
+        """Get the held-back suspicious batch for a manga, if any."""
+        return self.get_manga_state(manga_title).get("suspicious_batch")
+
+    def clear_suspicious_batch(self, manga_title: str):
+        """Clear the suspicious batch record (accepted, confirmed, or stale)."""
+        manga_state = self._data.get("manga", {}).get(manga_title, {})
+        if "suspicious_batch" in manga_state:
+            del manga_state["suspicious_batch"]
+            self.save()
+
+    # ========================================================================
     # Failed Chapter Tracking
     # ========================================================================
 

--- a/memanga/suspicion.py
+++ b/memanga/suspicion.py
@@ -1,0 +1,188 @@
+"""Suspicious chapter-batch detection.
+
+A source can suddenly expose bogus or re-numbered chapters (real case:
+MangaFire's AJAX chapter list made a manga tracked at ~52.3 look like it
+had 64 new chapters up to 148, then 154/156). If we trust that blindly,
+``check`` downloads and emails a large backlog of wrong chapters.
+
+This module scores a candidate batch of new chapters against what is
+"normal" for that manga: its historical batch size, how long since it
+last updated, and how far the chapter numbers jump, so the downloader
+can hold back suspicious batches until a backup source confirms them or
+the user forces acceptance.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from statistics import median
+from typing import List, Optional
+
+# A manga with no download history is assumed to release a couple of
+# chapters at a time, roughly weekly. These only seed the allowance;
+# real history (when available) overrides them.
+DEFAULT_TYPICAL_BATCH_SIZE = 2.0
+DEFAULT_CADENCE_DAYS = 7.0
+
+# Download-history entries closer together than this belong to the same
+# batch (one check run downloads its chapters within minutes/hours).
+BATCH_GAP_HOURS = 12.0
+
+# Score at or above which a batch is considered suspicious.
+SUSPICION_THRESHOLD = 3
+
+
+@dataclass
+class SuspicionResult:
+    """Outcome of evaluating a candidate new-chapter batch."""
+
+    suspicious: bool
+    score: int
+    reasons: List[str] = field(default_factory=list)
+
+
+def evaluate_chapter_batch(
+    new_numbers: List[float],
+    last_number: float,
+    typical_batch_size: Optional[float] = None,
+    days_since_last_update: Optional[float] = None,
+) -> SuspicionResult:
+    """Score a batch of candidate new chapter numbers.
+
+    Args:
+        new_numbers: Numeric chapter numbers found on the primary source
+            that are newer than the last tracked chapter.
+        last_number: The manga's last tracked chapter (numeric). 0 or
+            negative means no baseline; a fresh manga legitimately
+            returns its whole catalogue, so nothing is flagged.
+        typical_batch_size: Median chapters-per-update for this manga
+            (from download history), if known.
+        days_since_last_update: Days since this manga last got a chapter,
+            if known. A long-dormant series can plausibly catch up with a
+            bigger batch, so this scales the allowance.
+
+    Returns:
+        SuspicionResult with the verdict, score, and human-readable reasons.
+    """
+    nums = sorted(n for n in new_numbers if n is not None and n > 0)
+    if not nums or last_number is None or last_number <= 0:
+        return SuspicionResult(False, 0)
+
+    score = 0
+    reasons: List[str] = []
+
+    baseline = max(typical_batch_size or DEFAULT_TYPICAL_BATCH_SIZE, 1.0)
+    elapsed = (
+        days_since_last_update
+        if days_since_last_update and days_since_last_update > 0
+        else DEFAULT_CADENCE_DAYS
+    )
+    # The longer a series sat idle, the bigger a legitimate catch-up
+    # batch can be.
+    allowance = baseline * max(1.0, elapsed / DEFAULT_CADENCE_DAYS)
+
+    batch = len(nums)
+    if batch >= max(8.0, 4 * allowance):
+        score += 2
+        reasons.append(
+            f"{batch} new chapters at once (typical batch around {baseline:g})"
+        )
+    elif batch >= max(5.0, 2 * allowance):
+        score += 1
+        reasons.append(
+            f"{batch} new chapters is above this manga's usual batch of around {baseline:g}"
+        )
+
+    # Numeric jump from the last tracked chapter. Decimal/split releases
+    # (52.3 -> 52.5, "2 Part 1") stay well under the threshold; a
+    # re-numbering like 52.3 -> 156 blows past it.
+    jump = nums[-1] - last_number
+    allowed_jump = max(10.0, last_number * 0.5)
+    if jump > 2 * allowed_jump:
+        score += 3
+        reasons.append(
+            f"chapter number jumped from {last_number:g} to {nums[-1]:g}"
+        )
+    elif jump > allowed_jump:
+        score += 2
+        reasons.append(
+            f"chapter number jumped from {last_number:g} to {nums[-1]:g}"
+        )
+    elif jump > max(5.0, allowed_jump / 2):
+        score += 1
+        reasons.append(
+            f"chapter number advanced unusually far ({last_number:g} -> {nums[-1]:g})"
+        )
+
+    # Real releases are contiguous; bogus lists tend to have holes
+    # (53, 55-93, 103-104, ...).
+    gaps = sum(1 for a, b in zip(nums, nums[1:]) if b - a > 2)
+    if gaps >= 2:
+        score += 1
+        reasons.append(f"{gaps} numbering gaps inside the batch")
+
+    return SuspicionResult(score >= SUSPICION_THRESHOLD, score, reasons)
+
+
+def estimate_typical_batch_size(state, manga_title: str) -> Optional[float]:
+    """Median batch size for a manga, derived from its download history.
+
+    Downloads recorded within :data:`BATCH_GAP_HOURS` of each other count
+    as one batch (a single check run). Returns ``None`` when there is no
+    usable history.
+    """
+    try:
+        history = state.get("download_history", []) or []
+    except Exception:
+        return None
+
+    times = []
+    for entry in history:
+        if entry.get("title") != manga_title:
+            continue
+        try:
+            times.append(datetime.fromisoformat(entry["timestamp"]))
+        except (KeyError, TypeError, ValueError):
+            continue
+
+    if not times:
+        return None
+
+    times.sort()
+    batch_sizes = [1]
+    for prev, cur in zip(times, times[1:]):
+        if (cur - prev).total_seconds() / 3600.0 <= BATCH_GAP_HOURS:
+            batch_sizes[-1] += 1
+        else:
+            batch_sizes.append(1)
+
+    return float(median(batch_sizes))
+
+
+def get_days_since_last_update(state, manga_title: str) -> Optional[float]:
+    """Days since the manga last received a chapter, from state."""
+    try:
+        last_updated = state.get_manga_state(manga_title).get("last_updated")
+    except Exception:
+        return None
+    if not last_updated:
+        return None
+    try:
+        then = datetime.fromisoformat(last_updated)
+    except (TypeError, ValueError):
+        return None
+    return max((datetime.now() - then).total_seconds() / 86400.0, 0.0)
+
+
+def evaluate_new_chapters(
+    state,
+    manga_title: str,
+    new_numbers: List[float],
+    last_number: float,
+) -> SuspicionResult:
+    """Convenience wrapper: pull per-manga history from state and score."""
+    return evaluate_chapter_batch(
+        new_numbers,
+        last_number,
+        typical_batch_size=estimate_typical_batch_size(state, manga_title),
+        days_since_last_update=get_days_since_last_update(state, manga_title),
+    )

--- a/tests/unit/test_suspicion.py
+++ b/tests/unit/test_suspicion.py
@@ -1,0 +1,401 @@
+"""Tests for suspicious chapter-batch detection (issue #35).
+
+Covers:
+  - evaluate_chapter_batch heuristics, including the real MangaFire
+    incident (manga tracked at ~52.3 suddenly "gaining" 64 chapters up
+    to 148, then 154/156)
+  - history estimation helpers (typical batch size, days since update)
+  - the check_for_updates guard: blocking, backup verification,
+    force_suspicious, from_chapter bypass, stale-record clearing
+  - State suspicious_batch persistence
+  - CLI: --force-suspicious flag and warning output
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timedelta
+
+import pytest
+
+from memanga.suspicion import (
+    SUSPICION_THRESHOLD,
+    evaluate_chapter_batch,
+    estimate_typical_batch_size,
+    get_days_since_last_update,
+)
+
+
+# The bogus chapter list MangaFire exposed on 2026-05-10:
+# 53, 55-93, 103-104, 124-141, 143-144, 147-148 (64 chapters).
+MANGAFIRE_BOGUS_BATCH = (
+    [53.0]
+    + [float(n) for n in range(55, 94)]
+    + [103.0, 104.0]
+    + [float(n) for n in range(124, 142)]
+    + [143.0, 144.0, 147.0, 148.0]
+)
+
+
+# -------------------------------------------------------------------------
+# evaluate_chapter_batch: pure heuristics
+# -------------------------------------------------------------------------
+
+
+class TestEvaluateChapterBatch:
+    def test_mangafire_incident_is_flagged(self):
+        result = evaluate_chapter_batch(MANGAFIRE_BOGUS_BATCH, 52.3)
+        assert result.suspicious
+        assert result.score >= SUSPICION_THRESHOLD
+        assert result.reasons
+
+    def test_followup_huge_jump_is_flagged(self):
+        # Second event from the issue: only chapters 154 and 156 appear,
+        # but the manga is tracked at 52.3, so the jump alone is enough.
+        result = evaluate_chapter_batch([154.0, 156.0], 52.3)
+        assert result.suspicious
+
+    def test_normal_weekly_update_passes(self):
+        result = evaluate_chapter_batch([53.0], 52.3)
+        assert not result.suspicious
+        assert result.score == 0
+
+    def test_decimal_split_chapters_pass(self):
+        # 52 -> 52.1 / 52.2 / 52.5 is a known decimal/split pattern.
+        result = evaluate_chapter_batch([52.1, 52.2, 52.5], 52.0)
+        assert not result.suspicious
+
+    def test_batch_release_matching_history_passes(self):
+        # A series that normally drops 4 chapters at once.
+        result = evaluate_chapter_batch(
+            [101.0, 102.0, 103.0, 104.0], 100.0, typical_batch_size=4.0
+        )
+        assert not result.suspicious
+
+    def test_no_baseline_never_flags(self):
+        # Fresh manga: the whole catalogue is "new", which is normal.
+        result = evaluate_chapter_batch([float(n) for n in range(1, 201)], 0.0)
+        assert not result.suspicious
+
+    def test_empty_batch_never_flags(self):
+        assert not evaluate_chapter_batch([], 52.3).suspicious
+
+    def test_dormant_series_catchup_passes(self):
+        # 8 chapters after 60 idle days is a plausible catch-up.
+        result = evaluate_chapter_batch(
+            [float(n) for n in range(11, 19)], 10.0,
+            days_since_last_update=60.0,
+        )
+        assert not result.suspicious
+
+    def test_large_contiguous_dump_on_active_series_is_flagged(self):
+        # 30 chapters overnight on a series tracked at 10 is not normal.
+        result = evaluate_chapter_batch(
+            [float(n) for n in range(11, 41)], 10.0,
+            days_since_last_update=1.0,
+        )
+        assert result.suspicious
+
+
+# -------------------------------------------------------------------------
+# History estimation helpers
+# -------------------------------------------------------------------------
+
+
+class _HistoryStub:
+    """Minimal state stand-in exposing only download_history."""
+
+    def __init__(self, history):
+        self._history = history
+
+    def get(self, key, default=None):
+        if key == "download_history":
+            return self._history
+        return default
+
+
+class TestEstimateTypicalBatchSize:
+    def test_median_of_grouped_batches(self):
+        base = datetime(2026, 5, 1, 8, 0)
+        history = []
+        # Three weekly batches of sizes 1, 3, 1 -> median 1.
+        for week, size in enumerate((1, 3, 1)):
+            for i in range(size):
+                history.append({
+                    "title": "X",
+                    "chapter": str(week * 10 + i),
+                    "timestamp": (base + timedelta(days=7 * week, minutes=i)).isoformat(),
+                })
+        assert estimate_typical_batch_size(_HistoryStub(history), "X") == 1.0
+
+    def test_other_titles_ignored(self):
+        history = [{
+            "title": "Other",
+            "chapter": "1",
+            "timestamp": datetime.now().isoformat(),
+        }]
+        assert estimate_typical_batch_size(_HistoryStub(history), "X") is None
+
+    def test_no_history_returns_none(self):
+        assert estimate_typical_batch_size(_HistoryStub([]), "X") is None
+
+    def test_state_without_get_is_tolerated(self):
+        class NoGet:
+            pass
+        assert estimate_typical_batch_size(NoGet(), "X") is None
+
+
+class TestDaysSinceLastUpdate:
+    def test_reads_last_updated_from_state(self, state):
+        state.set_last_chapter("X", "5")
+        days = get_days_since_last_update(state, "X")
+        assert days is not None
+        assert days < 0.1
+
+    def test_unknown_manga_returns_none(self, state):
+        assert get_days_since_last_update(state, "Nope") is None
+
+
+# -------------------------------------------------------------------------
+# check_for_updates guard integration
+# -------------------------------------------------------------------------
+
+
+def _scraper_returning(numbers):
+    from memanga.scrapers.base import Chapter
+
+    class _Scraper:
+        def get_chapters(self, url):
+            return [Chapter(f"{n:g}", "", f"u/{n:g}") for n in numbers]
+
+    return _Scraper()
+
+
+def _patch_scrapers(monkeypatch, by_domain):
+    import memanga.downloader as dl
+    monkeypatch.setattr(dl, "get_scraper", lambda d: by_domain[d])
+
+
+SINGLE_SOURCE_MANGA = {
+    "title": "Tomodachi",
+    "source": "primary.test",
+    "url": "https://primary.test/m",
+}
+
+MULTI_SOURCE_MANGA = {
+    "title": "Tomodachi",
+    "fallback_delay_days": 2,
+    "sources": [
+        {"source": "primary.test", "url": "https://primary.test/m"},
+        {"source": "backup.test", "url": "https://backup.test/m"},
+    ],
+}
+
+
+class TestCheckForUpdatesGuard:
+    def test_suspicious_batch_blocked_without_backup(self, state, monkeypatch):
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3] + MANGAFIRE_BOGUS_BATCH),
+        })
+
+        new = check_for_updates(SINGLE_SOURCE_MANGA, state)
+
+        assert new == []
+        record = state.get_suspicious_batch("Tomodachi")
+        assert record is not None
+        assert record["count"] == len(MANGAFIRE_BOGUS_BATCH)
+        assert record["backup_status"] == "no backup source available to verify"
+        # Nothing was committed as downloaded.
+        assert state.get_downloaded_chapters("Tomodachi") == []
+        # A warning notification was logged for the GUI.
+        notifs = state.get_notifications()
+        assert any(n["type"] == "warn" and "Tomodachi" in n["message"] for n in notifs)
+
+    def test_backup_confirming_batch_allows_it(self, state, monkeypatch):
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        chapters = [52.3] + MANGAFIRE_BOGUS_BATCH
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning(chapters),
+            "backup.test": _scraper_returning(chapters),
+        })
+
+        new = check_for_updates(MULTI_SOURCE_MANGA, state)
+
+        assert len(new) == len(MANGAFIRE_BOGUS_BATCH)
+        assert state.get_suspicious_batch("Tomodachi") is None
+
+    def test_backup_disagreeing_blocks_batch(self, state, monkeypatch):
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3] + MANGAFIRE_BOGUS_BATCH),
+            # Backup agrees the series is only around chapter 52.x.
+            "backup.test": _scraper_returning([51.0, 52.0, 52.3]),
+        })
+
+        new = check_for_updates(MULTI_SOURCE_MANGA, state)
+
+        assert new == []
+        record = state.get_suspicious_batch("Tomodachi")
+        assert record is not None
+        assert "backup confirmed only 0" in record["backup_status"]
+
+    def test_force_suspicious_accepts_batch(self, state, monkeypatch):
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3] + MANGAFIRE_BOGUS_BATCH),
+        })
+
+        # First run blocks and records the batch.
+        assert check_for_updates(SINGLE_SOURCE_MANGA, state) == []
+        assert state.get_suspicious_batch("Tomodachi") is not None
+
+        # Forced run accepts it and clears the record.
+        new = check_for_updates(SINGLE_SOURCE_MANGA, state, force_suspicious=True)
+        assert len(new) == len(MANGAFIRE_BOGUS_BATCH)
+        assert state.get_suspicious_batch("Tomodachi") is None
+
+    def test_from_chapter_bypasses_guard(self, state, monkeypatch):
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3] + MANGAFIRE_BOGUS_BATCH),
+        })
+
+        # Explicit bulk re-download is a deliberate user action.
+        new = check_for_updates(SINGLE_SOURCE_MANGA, state, from_chapter=0)
+        assert len(new) == len(MANGAFIRE_BOGUS_BATCH) + 1
+
+    def test_record_cleared_when_source_recovers(self, state, monkeypatch):
+        from memanga.downloader import check_for_updates
+        import memanga.downloader as dl
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3] + MANGAFIRE_BOGUS_BATCH),
+        })
+        assert check_for_updates(SINGLE_SOURCE_MANGA, state) == []
+        assert state.get_suspicious_batch("Tomodachi") is not None
+
+        # Source fixes its list: only the genuine next chapter remains.
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3, 53.0]),
+        })
+        new = check_for_updates(SINGLE_SOURCE_MANGA, state)
+        assert [c.number for c in new] == ["53"]
+        assert state.get_suspicious_batch("Tomodachi") is None
+
+    def test_normal_update_unaffected(self, state, monkeypatch):
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.0, 52.3, 53.0, 54.0]),
+        })
+
+        new = check_for_updates(SINGLE_SOURCE_MANGA, state)
+        assert [c.number for c in new] == ["53", "54"]
+        assert state.get_suspicious_batch("Tomodachi") is None
+
+
+# -------------------------------------------------------------------------
+# State persistence of the suspicious record
+# -------------------------------------------------------------------------
+
+
+class TestStateSuspiciousBatch:
+    def test_roundtrip_and_clear(self, state):
+        info = {"count": 64, "reasons": ["jump"], "backup_status": "none"}
+        state.set_suspicious_batch("X", info)
+        assert state.get_suspicious_batch("X") == info
+
+        state.clear_suspicious_batch("X")
+        assert state.get_suspicious_batch("X") is None
+
+    def test_clear_unknown_manga_is_noop(self, state):
+        state.clear_suspicious_batch("Never Seen")  # must not raise
+
+    def test_persists_across_reload(self, state, isolated_home):
+        from memanga.state import State
+        state.set_suspicious_batch("X", {"count": 2})
+        reloaded = State(config_dir=isolated_home / ".config" / "memanga")
+        assert reloaded.get_suspicious_batch("X") == {"count": 2}
+
+
+# -------------------------------------------------------------------------
+# CLI: --force-suspicious flag and warning output
+# -------------------------------------------------------------------------
+
+
+class TestCliForceSuspicious:
+    @pytest.fixture
+    def cli(self, isolated_home, monkeypatch):
+        """memanga.cli with its module-level config/state rebound to the
+        isolated home (they are built at import time)."""
+        from memanga import cli as cli_mod
+        from memanga.config import Config
+        from memanga.state import State
+        monkeypatch.setattr(cli_mod, "config", Config())
+        monkeypatch.setattr(
+            cli_mod, "state",
+            State(config_dir=isolated_home / ".config" / "memanga"),
+        )
+        return cli_mod
+
+    @staticmethod
+    def _check_args(**overrides):
+        defaults = dict(
+            title=None, auto=True, yes=False, quiet=True,
+            from_chapter=None, all=False, safe=False, dry_run=True,
+            format=None, retries=3, force_suspicious=False,
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    def test_check_help_mentions_flag(self, cli, capsys, monkeypatch):
+        import sys
+        monkeypatch.setattr(sys, "argv", ["memanga", "check", "--help"])
+        with pytest.raises(SystemExit):
+            cli.main()
+        assert "--force-suspicious" in capsys.readouterr().out
+
+    def test_flag_is_passed_to_check_for_updates(self, cli, monkeypatch):
+        cli.config.set("manga", [dict(SINGLE_SOURCE_MANGA)])
+
+        seen = {}
+
+        def _fake_check(manga, state, from_chapter=None, force_suspicious=False):
+            seen["force_suspicious"] = force_suspicious
+            return []
+
+        monkeypatch.setattr(cli, "check_for_updates", _fake_check)
+        cli.cmd_check(self._check_args(force_suspicious=True))
+        assert seen["force_suspicious"] is True
+
+    def test_warning_printed_when_batch_withheld(self, cli, monkeypatch, capsys):
+        cli.config.set("manga", [dict(SINGLE_SOURCE_MANGA)])
+        cli.state.set_suspicious_batch("Tomodachi", {
+            "count": 64, "highest": 148.0, "last_chapter": 52.3,
+            "reasons": ["chapter number jumped from 52.3 to 148"],
+            "backup_status": "no backup source available to verify",
+        })
+
+        monkeypatch.setattr(
+            cli, "check_for_updates",
+            lambda manga, state, from_chapter=None, force_suspicious=False: [],
+        )
+        cli.cmd_check(self._check_args())
+
+        out = capsys.readouterr().out
+        assert "Suspicious chapter batch detected" in out
+        assert "--force-suspicious" in out
+        assert "Skipped auto-delivery" in out


### PR DESCRIPTION
## Summary

Adds suspicious chapter-batch detection before `check` commits or delivers new chapters. Suspicious primary-source jumps are scored using per-manga history, batch size, numeric jumps, and numbering gaps; backup sources can confirm the batch, otherwise it is held with warning details until `memanga check --force-suspicious` is used.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [ ] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #35
