### PR TITLE
feat(reader): add page-by-page layouts

### DIFF
--- a/memanga/gui/assets/icons/__init__.py
+++ b/memanga/gui/assets/icons/__init__.py
@@ -101,6 +101,15 @@ ICONS: dict[str, str] = {
         '<path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9"/>'
         '<path d="M10 21a2 2 0 0 0 4 0"/></g></svg>'
     ),
+    # Continuous-scroll glyph: pages stacked vertically, the lower one
+    # cropped by the viewport (issue #32 reader layout toggle).
+    "view_continuous": (
+        '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'
+        '<g fill="none" stroke="{color}" stroke-width="1.7" stroke-linejoin="round">'
+        '<rect x="6" y="2" width="12" height="9" rx="1"/>'
+        '<path d="M6 15h12M6 15v7M18 15v7"/>'
+        '</g></svg>'
+    ),
     # Single-page glyph: one upright rectangle (issue #24 dual-page toggle).
     "view_single": (
         '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'

--- a/memanga/gui/components/layout_dropdown.py
+++ b/memanga/gui/components/layout_dropdown.py
@@ -1,0 +1,23 @@
+"""
+Layout dropdown — per-manga reader page layout (issue #32).
+
+Same QToolButton + two-line menu shape as ModeDropdown; only the
+option set differs. The selected key is stored on the manga's config
+entry as ``reader_mode`` and read by the reader when a chapter opens.
+"""
+
+from .mode_dropdown import ModeDropdown
+
+
+LAYOUT_OPTIONS = [
+    ("continuous", "Continuous", "All pages stacked in one vertical scroll."),
+    ("single",     "Single page", "One page at a time; arrows turn pages."),
+    ("double",     "Two-up",      "Two-page spreads; arrows turn spreads."),
+]
+
+
+class LayoutDropdown(ModeDropdown):
+    """Continuous / Single page / Two-up picker for the detail page."""
+
+    def __init__(self, parent=None, initial: str = "continuous"):
+        super().__init__(parent, initial=initial, options=LAYOUT_OPTIONS)

--- a/memanga/gui/components/mode_dropdown.py
+++ b/memanga/gui/components/mode_dropdown.py
@@ -67,8 +67,11 @@ class ModeDropdown(QToolButton):
 
     value_changed = Signal(str)
 
-    def __init__(self, parent=None, initial: str = "auto"):
+    def __init__(self, parent=None, initial: str = "auto", options=None):
         super().__init__(parent)
+        # `options` lets subclasses (e.g. LayoutDropdown) reuse the same
+        # trigger + two-line menu with a different option set.
+        self._options = list(options) if options is not None else MODE_OPTIONS
         self._value = initial
         self.setArrowType(Qt.ArrowType.NoArrow)
         self.setPopupMode(QToolButton.ToolButtonPopupMode.InstantPopup)
@@ -107,7 +110,7 @@ class ModeDropdown(QToolButton):
         )
         self.setMenu(self._menu)
 
-        for key, label, desc in MODE_OPTIONS:
+        for key, label, desc in self._options:
             wa = QWidgetAction(self)
             item = _ModeItemWidget(label, desc, lambda k=key: self._on_pick(k))
             item.setMinimumWidth(260)
@@ -121,7 +124,7 @@ class ModeDropdown(QToolButton):
         return self._value
 
     def set_value(self, key: str):
-        if key not in {k for k, _, _ in MODE_OPTIONS}:
+        if key not in {k for k, _, _ in self._options}:
             return
         self._value = key
         self._refresh_text()
@@ -136,7 +139,7 @@ class ModeDropdown(QToolButton):
         self.value_changed.emit(key)
 
     def _refresh_text(self):
-        label = next((lbl for k, lbl, _ in MODE_OPTIONS if k == self._value),
+        label = next((lbl for k, lbl, _ in self._options if k == self._value),
                      self._value.title())
         self.setText(label)
         self.update()

--- a/memanga/gui/pages/detail.py
+++ b/memanga/gui/pages/detail.py
@@ -218,6 +218,7 @@ class DetailPage(BasePage):
 
         from ..components.status_dropdown import StatusDropdown
         from ..components.mode_dropdown import ModeDropdown
+        from ..components.layout_dropdown import LayoutDropdown
 
         def _control_column(label_text: str, widget: QWidget) -> QVBoxLayout:
             col = QVBoxLayout()
@@ -240,6 +241,19 @@ class DetailPage(BasePage):
         self._mode_combo = ModeDropdown(initial=current_mode)
         self._mode_combo.value_changed.connect(self._on_mode_change)
         cc_l.addLayout(_control_column("MODE", self._mode_combo))
+
+        # Reader layout (issue #32) — same fallback chain the reader
+        # uses: per-manga value, then the global default, then the
+        # legacy dual-page boolean (issue #24).
+        current_layout = (
+            manga.get("reader_mode")
+            or self.app.config.get("gui.reader_view_mode")
+            or ("double" if self.app.config.get("gui.reader_dual_page", False)
+                else "continuous")
+        )
+        self._layout_combo = LayoutDropdown(initial=current_layout)
+        self._layout_combo.value_changed.connect(self._on_layout_change)
+        cc_l.addLayout(_control_column("READER LAYOUT", self._layout_combo))
 
         cc_l.addStretch(1)  # push columns left, no centering void
 
@@ -778,6 +792,26 @@ class DetailPage(BasePage):
             else "Mode: Auto — new chapters will download on next check",
             kind="info",
         )
+
+    # ── Reader layout (Continuous / Single page / Two-up) ──
+
+    def _on_layout_change(self, new_layout: str):
+        """Persist this manga's reader layout (issue #32)."""
+        if not self._manga:
+            return
+        from ..components.layout_dropdown import LAYOUT_OPTIONS
+        if new_layout not in {k for k, _, _ in LAYOUT_OPTIONS}:
+            return
+        manga_list = self.app.config.get("manga", [])
+        for m in manga_list:
+            if m.get("title") == self._manga.get("title"):
+                m["reader_mode"] = new_layout
+                self._manga = m
+                break
+        self.app.config.save()
+        label = next((lbl for k, lbl, _ in LAYOUT_OPTIONS if k == new_layout),
+                     new_layout)
+        Toast(self, f"Reader layout: {label}", kind="info")
 
     # ── Edit ──
 

--- a/memanga/gui/pages/reader.py
+++ b/memanga/gui/pages/reader.py
@@ -1,5 +1,6 @@
 """
-Reader page - Built-in vertical scroll manga reader with keyboard shortcuts and zoom.
+Reader page - Built-in manga reader with keyboard shortcuts and zoom.
+Three layouts: continuous vertical scroll, single page, two-up spreads.
 """
 
 import io
@@ -97,7 +98,8 @@ def _extract_images_from_folder(folder: Path) -> List[QImage]:
 
 
 class ReaderPage(BasePage):
-    """Vertical scroll manga reader with keyboard shortcuts and zoom."""
+    """Manga reader with continuous / single-page / two-up layouts,
+    keyboard shortcuts and zoom."""
 
     ZOOM_MIN = 0.5
     ZOOM_MAX = 2.5
@@ -108,6 +110,10 @@ class ReaderPage(BasePage):
     # appended after the last page, so finishing the final page is
     # enough without having to pixel-perfectly hit the bottom.
     READ_THRESHOLD = 0.98
+    # Issue #32: the three reader layouts the toolbar toggle cycles
+    # between. "double" is the issue-#24 two-up view, now paged.
+    VIEW_MODES = ("continuous", "single", "double")
+    PAGED_MODES = ("single", "double")
 
     def __init__(self, parent, app):
         super().__init__(parent, app)
@@ -117,13 +123,19 @@ class ReaderPage(BasePage):
         self._page_labels: list = []
         self._zoom_level = 1.0
         self._fit_width = True
-        # Issue #24: dual-page (two-up) view mode, persisted across launches.
-        self._dual_page = bool(self.app.config.get("gui.reader_dual_page", False))
+        # Issue #32: reader layout — "continuous" (vertical scroll, all
+        # pages stacked), "single" (one page at a time) or "double"
+        # (two-up spreads, one spread at a time). Resolved per manga in
+        # _load_chapter; this is just the cold default.
+        self._view_mode = "continuous"
+        # First visible page index in the paged modes (always even in
+        # "double" so spreads stay aligned to the same page pairs).
+        self._current_page = 0
         self._content: Optional[QWidget] = None
         self._scroll = None
         self._image_layout = None
         self._page_indicator = None
-        self._dual_btn = None
+        self._mode_btns = {}
         # Issue #45: set once the current chapter has been marked read,
         # so the scroll handler only fires the state write + event once.
         self._read_marked = False
@@ -186,6 +198,16 @@ class ReaderPage(BasePage):
             self._go_next_chapter()
         elif key == Qt.Key.Key_P:
             self._go_prev_chapter()
+        elif self._view_mode in self.PAGED_MODES and key in (
+                Qt.Key.Key_Right, Qt.Key.Key_PageDown, Qt.Key.Key_Space):
+            self._page_step(+1)
+        elif self._view_mode in self.PAGED_MODES and key in (
+                Qt.Key.Key_Left, Qt.Key.Key_PageUp):
+            self._page_step(-1)
+        elif self._view_mode in self.PAGED_MODES and key == Qt.Key.Key_Home:
+            self._go_to_page(0)
+        elif self._view_mode in self.PAGED_MODES and key == Qt.Key.Key_End:
+            self._go_to_page(len(self._images) - 1)
         elif key == Qt.Key.Key_Down:
             self._scroll_vertical(+1)
         elif key == Qt.Key.Key_Up:
@@ -210,8 +232,10 @@ class ReaderPage(BasePage):
         bar.setValue(bar.value() + direction * max(40, bar.pageStep() // 2))
 
     def _arrow_horizontal(self, direction: int):
-        """Left/Right: pan when zoomed content overflows horizontally,
-        otherwise jump to the prev/next chapter (mirrors P/N)."""
+        """Left/Right in continuous mode: pan when zoomed content
+        overflows horizontally, otherwise jump to the prev/next chapter
+        (mirrors P/N). Paged modes never reach here — their Left/Right
+        turn pages in keyPressEvent (issue #32)."""
         if self._scroll is not None:
             bar = self._scroll.horizontalScrollBar()
             if bar.maximum() > 0:
@@ -221,6 +245,34 @@ class ReaderPage(BasePage):
             self._go_next_chapter()
         else:
             self._go_prev_chapter()
+
+    # ── Page-by-page navigation (issue #32) ───────────────────────────
+    # Only active in the "single" and "double" layouts. Up/Down keep
+    # their scroll meaning so a zoomed-in page can still be read top to
+    # bottom; Left/Right/PageUp/PageDown/Space/Home/End move between
+    # pages (or spreads in two-up).
+
+    def _page_step(self, direction: int):
+        """Advance one page (single) or one spread (double)."""
+        step = 2 if self._view_mode == "double" else 1
+        self._go_to_page(self._current_page + direction * step)
+
+    def _go_to_page(self, index: int):
+        if not self._images:
+            return
+        index = max(0, min(len(self._images) - 1, index))
+        if self._view_mode == "double":
+            index -= index % 2  # spreads stay aligned to fixed pairs
+        if index == self._current_page:
+            return
+        self._current_page = index
+        self._rebuild_images()
+        # Each new page starts at its top-left corner, like turning a
+        # physical page — leftover scroll from a zoomed previous page
+        # would otherwise open the new one mid-panel.
+        if self._scroll is not None:
+            self._scroll.verticalScrollBar().setValue(0)
+            self._scroll.horizontalScrollBar().setValue(0)
 
     def _zoom_in(self):
         if self._zoom_level < self.ZOOM_MAX:
@@ -232,29 +284,67 @@ class ReaderPage(BasePage):
             self._zoom_level -= self.ZOOM_STEP
             self._rebuild_images()
 
-    # ── Dual-page view (issue #24) ────────────────────────────────────
-    def _toggle_dual_page(self):
-        """Flip between single + dual page view. Re-renders + persists."""
-        self._dual_page = not self._dual_page
-        self.app.config.set("gui.reader_dual_page", self._dual_page)
-        self.app.config.save()
-        self._refresh_dual_btn()
-        self._rebuild_images()
+    # ── Reader layout (issues #24, #32) ───────────────────────────────
+    # Three layouts: continuous scroll, single page, two-up spreads.
+    # The choice persists per manga so a webtoon can stay continuous
+    # while a print manga stays single-page.
 
-    def _refresh_dual_btn(self):
-        """Sync the toggle button's icon + tooltip to the current mode."""
-        if not self._dual_btn:
+    def _resolve_view_mode(self) -> str:
+        """Layout for the current manga: its config entry's
+        ``reader_mode``, else the global ``gui.reader_view_mode``, else
+        the legacy ``gui.reader_dual_page`` boolean (issue #24)."""
+        title = (self._manga or {}).get("title", "")
+        for entry in self.app.config.get("manga", []) or []:
+            if entry.get("title") == title:
+                mode = entry.get("reader_mode")
+                if mode in self.VIEW_MODES:
+                    return mode
+                break
+        mode = self.app.config.get("gui.reader_view_mode")
+        if mode in self.VIEW_MODES:
+            return mode
+        if self.app.config.get("gui.reader_dual_page", False):
+            return "double"
+        return "continuous"
+
+    def _set_view_mode(self, mode: str):
+        """Switch layout, persist it for this manga, and re-render."""
+        if mode not in self.VIEW_MODES or mode == self._view_mode:
             return
+        if self._view_mode == "continuous" and self._scroll is not None \
+                and self._images:
+            # Carry the reading position over: estimate the current page
+            # from the scroll ratio, same as the progress bar does.
+            sb = self._scroll.verticalScrollBar()
+            ratio = sb.value() / max(1, sb.maximum())
+            self._current_page = min(len(self._images) - 1,
+                                     int(ratio * len(self._images)))
+        self._view_mode = mode
+
+        def _store(entry):
+            entry["reader_mode"] = mode
+        title = (self._manga or {}).get("title", "")
+        if not (title and self.app.config.update_manga(title, _store)):
+            # Manga not in config (e.g. removed mid-read): fall back to
+            # the global default so the choice still sticks.
+            self.app.config.set("gui.reader_view_mode", mode)
+            self.app.config.save()
+
+        self._refresh_mode_btns()
+        self._rebuild_images()
+        if self._scroll is not None:
+            self._scroll.verticalScrollBar().setValue(0)
+            self._scroll.horizontalScrollBar().setValue(0)
+
+    def _refresh_mode_btns(self):
+        """Accent-tint the active layout's toolbar button."""
         from ..assets.icons import icon as _ic
         from PySide6.QtCore import QSize
-        # Icon shows the CURRENT mode; tooltip explains the click action.
-        if self._dual_page:
-            self._dual_btn.setIcon(_ic("view_dual", T.tokens()["accent.primary"], 16))
-            self._dual_btn.setToolTip("Switch to single-page view")
-        else:
-            self._dual_btn.setIcon(_ic("view_single", T.tokens()["text.t_2"], 16))
-            self._dual_btn.setToolTip("Switch to dual-page view")
-        self._dual_btn.setIconSize(QSize(16, 16))
+        for mode, (btn, icon_name) in self._mode_btns.items():
+            color = (T.tokens()["accent.primary"] if mode == self._view_mode
+                     else T.tokens()["text.t_2"])
+            btn.setIcon(_ic(icon_name, color, 16))
+            btn.setIconSize(QSize(16, 16))
 
     # ── Ctrl+wheel zoom (issue #16) ──────────────────────────────────────
     # The scroll area's viewport eats wheel events for native scrolling.
@@ -433,8 +523,7 @@ class ReaderPage(BasePage):
 
         if hasattr(self, "_zoom_label") and self._zoom_label:
             self._zoom_label.setText(f"{int(self._zoom_level * 100)}%")
-        if self._page_indicator:
-            self._page_indicator.setText(f"1 / {len(self._images)}")
+        self._update_progress_display()
 
     def _clear_sub_layout(self, layout):
         """Recursively drain a layout's children + delete widgets."""
@@ -448,6 +537,11 @@ class ReaderPage(BasePage):
 
     def _on_scroll(self, _value):
         """Update the sticky bottom progress bar from scroll position."""
+        # Issue #32: in the paged layouts scrolling only moves within
+        # the current page — progress is tracked per page in
+        # _update_progress_display instead.
+        if self._view_mode in self.PAGED_MODES:
+            return
         try:
             sb = self._scroll.verticalScrollBar()
             mx = max(1, sb.maximum())
@@ -464,6 +558,31 @@ class ReaderPage(BasePage):
                 self._mark_current_read()
         except Exception:
             pass
+
+    def _update_progress_display(self):
+        """Sync the page indicator + bottom progress bar to the reading
+        position. Continuous mode derives it from the scroll offset; the
+        paged modes (issue #32) from the visible page index — which also
+        marks the chapter read once the final page is on screen."""
+        if self._view_mode not in self.PAGED_MODES:
+            self._on_scroll(0)  # ratio is re-read from the scrollbar
+            return
+        total = len(self._images)
+        if not total:
+            return
+        first = self._current_page
+        last = min(total - 1, first + 1) if self._view_mode == "double" else first
+        try:
+            if self._page_indicator:
+                self._page_indicator.setText(f"{first + 1} / {total}")
+            ratio = (last + 1) / total
+            self._progress_left.setText(f"Page {first + 1} of {total}")
+            self._progress_track.setValue(int(ratio * 1000))
+            self._progress_pct.setText(f"{int(ratio * 100)}%")
+        except (AttributeError, RuntimeError):
+            pass
+        if last >= total - 1:
+            self._mark_current_read()
 
     def _mark_current_read(self):
         """Mark the current chapter read (issue #45: only called when the
@@ -487,6 +606,11 @@ class ReaderPage(BasePage):
         """A chapter that fits entirely in the viewport never scrolls, so
         the end-of-scroll threshold can't fire — but the user is already
         seeing all of it, which is as "finished" as it gets."""
+        # Paged layouts (issue #32) mark read from the page index in
+        # _update_progress_display — a single fitting page there just
+        # means the user is on ONE page, not done with the chapter.
+        if self._view_mode in self.PAGED_MODES:
+            return
         if self._read_marked or self._scroll is None or not self._images:
             return
         viewport_h = self._scroll.viewport().height()
@@ -525,8 +649,17 @@ class ReaderPage(BasePage):
                 Qt.TransformationMode.SmoothTransformation,
             )
 
-        if not self._dual_page:
-            # ── Single-page (default) ──
+        # Paged layouts center the (short) content in the viewport;
+        # continuous keeps everything pinned to the top of the scroll.
+        if self._image_layout is not None:
+            if self._view_mode in self.PAGED_MODES:
+                self._image_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            else:
+                self._image_layout.setAlignment(
+                    Qt.AlignmentFlag.AlignHCenter | Qt.AlignmentFlag.AlignTop)
+
+        if self._view_mode == "continuous":
+            # ── Continuous (default): all pages stacked vertically ──
             for qimg in self._images:
                 lbl = QLabel()
                 lbl.setPixmap(_scaled_pixmap(qimg, max_w))
@@ -535,31 +668,43 @@ class ReaderPage(BasePage):
                 self._page_labels.append(lbl)
             return
 
-        # ── Dual-page (issue #24): pairs of pages side-by-side ──
-        # Each spread = a horizontal row holding two QLabels (or one if
-        # the chapter has an odd page count). Allocate half max_w per
-        # side so the spread as a whole stays inside the viewport.
+        # ── Paged layouts (issue #32): only the current page/spread ──
+        self._current_page = max(0, min(len(self._images) - 1,
+                                        self._current_page))
+        if self._view_mode == "double":
+            self._current_page -= self._current_page % 2
+
+        if self._view_mode == "single":
+            lbl = QLabel()
+            lbl.setPixmap(_scaled_pixmap(self._images[self._current_page], max_w))
+            lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            self._image_layout.addWidget(lbl)
+            self._page_labels.append(lbl)
+            return
+
+        # ── Two-up (issues #24, #32): one spread, two pages side-by-side
+        # (or one if the chapter ends on an odd page). Allocate half
+        # max_w per side so the spread as a whole stays inside the
+        # viewport.
         per_side = max(120, (max_w - 8) // 2)
-        i = 0
-        while i < len(self._images):
-            spread = QHBoxLayout()
-            spread.setSpacing(4)
-            spread.setContentsMargins(0, 0, 0, 0)
-            spread.setAlignment(Qt.AlignmentFlag.AlignHCenter)
+        i = self._current_page
+        spread = QHBoxLayout()
+        spread.setSpacing(4)
+        spread.setContentsMargins(0, 0, 0, 0)
+        spread.setAlignment(Qt.AlignmentFlag.AlignHCenter)
 
-            for j in (0, 1):
-                if i + j >= len(self._images):
-                    break
-                lbl = QLabel()
-                lbl.setPixmap(_scaled_pixmap(self._images[i + j], per_side))
-                lbl.setAlignment(Qt.AlignmentFlag.AlignTop | (
-                    Qt.AlignmentFlag.AlignRight if j == 0 else Qt.AlignmentFlag.AlignLeft
-                ))
-                spread.addWidget(lbl)
-                self._page_labels.append(lbl)
+        for j in (0, 1):
+            if i + j >= len(self._images):
+                break
+            lbl = QLabel()
+            lbl.setPixmap(_scaled_pixmap(self._images[i + j], per_side))
+            lbl.setAlignment(Qt.AlignmentFlag.AlignTop | (
+                Qt.AlignmentFlag.AlignRight if j == 0 else Qt.AlignmentFlag.AlignLeft
+            ))
+            spread.addWidget(lbl)
+            self._page_labels.append(lbl)
 
-            self._image_layout.addLayout(spread)
-            i += 2
+        self._image_layout.addLayout(spread)
 
     def _load_chapter(self):
         # Tear down previous content
@@ -570,6 +715,10 @@ class ReaderPage(BasePage):
         # Issue #45: each chapter load starts with an unread gate, even
         # when navigating Prev/Next within the reader.
         self._read_marked = False
+        # Issue #32: every chapter opens on its first page, in whatever
+        # layout this manga last used (or the global/legacy fallback).
+        self._current_page = 0
+        self._view_mode = self._resolve_view_mode()
 
         self._content = QWidget()
         content_layout = QVBoxLayout(self._content)
@@ -633,17 +782,24 @@ class ReaderPage(BasePage):
             next_btn.clicked.connect(lambda checked=False, c=next_ch: self._navigate_chapter(c))
             top_layout.addWidget(next_btn)
 
-        # ── Dual-page toggle (issue #24) ────────────────────────────────
-        # Same iconified style as the zoom +/- buttons. Tooltip names
-        # the mode the click WILL switch to (matches OS conventions).
-        from ..assets.icons import icon as _ic
-        from PySide6.QtCore import QSize
-        self._dual_btn = QPushButton()
-        self._dual_btn.setFixedSize(36, 28)
-        self._dual_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        self._dual_btn.clicked.connect(self._toggle_dual_page)
-        self._refresh_dual_btn()
-        top_layout.addWidget(self._dual_btn)
+        # ── Layout toggle (issues #24, #32) ─────────────────────────────
+        # Three iconified buttons (same style as the zoom +/- chip):
+        # continuous scroll, single page, two-up. The active layout's
+        # icon is accent-tinted in _refresh_mode_btns.
+        self._mode_btns = {}
+        for mode, icon_name, tip in (
+            ("continuous", "view_continuous", "Continuous vertical scroll"),
+            ("single", "view_single", "Single page at a time"),
+            ("double", "view_dual", "Two-page spreads"),
+        ):
+            btn = QPushButton()
+            btn.setFixedSize(36, 28)
+            btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            btn.setToolTip(tip)
+            btn.clicked.connect(lambda checked=False, m=mode: self._set_view_mode(m))
+            self._mode_btns[mode] = (btn, icon_name)
+            top_layout.addWidget(btn)
+        self._refresh_mode_btns()
 
         # Zoom chip
         zoom_minus = QPushButton("−")
@@ -733,8 +889,10 @@ class ReaderPage(BasePage):
 
         self._render_images()
 
-        # "Next Chapter" button at bottom
-        if idx >= 0 and idx < len(downloaded) - 1:
+        # "Next Chapter" button at bottom — continuous mode only: the
+        # paged layouts re-render per page, so an in-flow footer would
+        # show under every single page rather than after the last one.
+        if self._view_mode == "continuous" and 0 <= idx < len(downloaded) - 1:
             next_ch = downloaded[idx + 1]
             next_frame = QWidget()
             next_frame_layout = QHBoxLayout(next_frame)
@@ -790,7 +948,7 @@ class ReaderPage(BasePage):
         sb = self._scroll.verticalScrollBar()
         sb.valueChanged.connect(self._on_scroll)
         # Initial paint.
-        self._on_scroll(0)
+        self._update_progress_display()
         # Issue #45: after the layout settles, a chapter short enough to
         # fit the viewport whole is immediately fully visible — the
         # scroll threshold can never fire for it.

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -12,6 +12,7 @@ If any of these go red, a previously-fixed bug has come back.
 | #20 | "Download from chapter X" downloaded all chapters |
 | #21 | No pan/drag when zoomed in reader |
 | #23 | Non-image format downloads written to root, not <dir>/<title>/ |
+| #32 | Reader page-by-page mode with left/right arrow navigation |
 | #40 | Pause All / Resume All dropped queued downloads |
 | #43 | Arrow keys dead in the reader |
 | #45 | Chapter marked read before reaching the end |
@@ -425,6 +426,150 @@ def test_issue_45_reader_marks_read_at_end(app_window, qapp, sample_manga,
     qapp.processEvents()
 
     assert app_window.app_state.is_chapter_read(title, "1")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #32 — Page-by-page reading modes (single / two-up) with arrow keys
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_issue_32_single_mode_arrows_turn_pages(app_window, qapp,
+                                                  sample_manga, make_cbz):
+    from PySide6.QtCore import Qt
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz,
+                          chapters=("1", "2"), pages=4)
+    reader._set_view_mode("single")
+    qapp.processEvents()
+    assert reader._current_page == 0
+    assert len(reader._page_labels) == 1  # only the current page rendered
+
+    _press(reader, Qt.Key.Key_Right)
+    assert reader._current_page == 1
+    _press(reader, Qt.Key.Key_Left)
+    assert reader._current_page == 0
+    # Clamped at the first page — and crucially Left/Right never fall
+    # through to the continuous-mode chapter jump.
+    _press(reader, Qt.Key.Key_Left)
+    assert reader._current_page == 0
+    assert str(reader._chapter) == "1"
+
+
+def test_issue_32_single_mode_space_pgdn_home_end(app_window, qapp,
+                                                    sample_manga, make_cbz):
+    from PySide6.QtCore import Qt
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=5)
+    reader._set_view_mode("single")
+
+    _press(reader, Qt.Key.Key_Space)
+    assert reader._current_page == 1
+    _press(reader, Qt.Key.Key_PageDown)
+    assert reader._current_page == 2
+    _press(reader, Qt.Key.Key_PageUp)
+    assert reader._current_page == 1
+    _press(reader, Qt.Key.Key_End)
+    assert reader._current_page == 4
+    _press(reader, Qt.Key.Key_Home)
+    assert reader._current_page == 0
+
+
+def test_issue_32_double_mode_steps_by_spread(app_window, qapp,
+                                                sample_manga, make_cbz):
+    from PySide6.QtCore import Qt
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=5)
+    reader._set_view_mode("double")
+    qapp.processEvents()
+    assert reader._current_page == 0
+    assert len(reader._page_labels) == 2  # one spread = two pages
+
+    _press(reader, Qt.Key.Key_Right)
+    assert reader._current_page == 2
+    _press(reader, Qt.Key.Key_End)
+    # Last spread of a 5-page chapter holds only the odd final page.
+    assert reader._current_page == 4
+    assert len(reader._page_labels) == 1
+    _press(reader, Qt.Key.Key_Left)
+    assert reader._current_page == 2
+
+
+def test_issue_32_right_at_last_page_stays_in_chapter(app_window, qapp,
+                                                        sample_manga,
+                                                        make_cbz):
+    from PySide6.QtCore import Qt
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz,
+                          chapters=("1", "2"), pages=2)
+    reader._set_view_mode("single")
+    _press(reader, Qt.Key.Key_End)
+    assert reader._current_page == 1
+    _press(reader, Qt.Key.Key_Right)
+    assert reader._current_page == 1
+    assert str(reader._chapter) == "1"
+
+
+def test_issue_32_up_down_scroll_within_page_when_zoomed(app_window, qapp,
+                                                           sample_manga,
+                                                           make_cbz):
+    from PySide6.QtCore import Qt
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=3)
+    reader._set_view_mode("single")
+    reader._zoom_in(); reader._zoom_in()
+    qapp.processEvents()
+    bar = reader._scroll.verticalScrollBar()
+    assert bar.maximum() > 0, "test needs the page to overflow the viewport"
+
+    _press(reader, Qt.Key.Key_Down)
+    assert bar.value() > 0           # scrolled within the page…
+    assert reader._current_page == 0  # …without turning it
+    _press(reader, Qt.Key.Key_Up)
+    assert bar.value() == 0
+
+
+def test_issue_32_last_page_marks_chapter_read(app_window, qapp,
+                                                 sample_manga, make_cbz):
+    from PySide6.QtCore import Qt
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=4)
+    reader._set_view_mode("single")
+    title = sample_manga["title"]
+    assert not app_window.app_state.is_chapter_read(title, "1")
+
+    _press(reader, Qt.Key.Key_End)
+    qapp.processEvents()
+    assert app_window.app_state.is_chapter_read(title, "1")
+
+
+def test_issue_32_mode_persists_per_manga(app_window, qapp, sample_manga,
+                                            make_cbz):
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz)
+    reader._set_view_mode("single")
+
+    entry = next(m for m in app_window.config.get("manga", [])
+                 if m.get("title") == sample_manga["title"])
+    assert entry.get("reader_mode") == "single"
+
+    # Leave the reader and come back — the manga reopens single-page.
+    app_window.show_page("library"); qapp.processEvents()
+    app_window.show_page("reader", manga=sample_manga, chapter="1")
+    qapp.processEvents()
+    assert reader._view_mode == "single"
+
+
+def test_issue_32_legacy_dual_page_config_maps_to_double(app_window, qapp,
+                                                           sample_manga,
+                                                           make_cbz):
+    app_window.config.set("gui.reader_dual_page", True)
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=4)
+    assert reader._view_mode == "double"
+
+
+def test_issue_32_detail_layout_dropdown_persists(app_window, qapp,
+                                                    sample_manga):
+    app_window.config.set("manga", [sample_manga])
+    app_window.show_page("detail", manga=sample_manga); qapp.processEvents()
+    page = app_window._pages["detail"]
+    page._on_layout_change("single")
+
+    entry = next(m for m in app_window.config.get("manga", [])
+                 if m.get("title") == sample_manga["title"])
+    assert entry.get("reader_mode") == "single"
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds per-manga reader layout selection for continuous scroll, single-page, and two-up reading. Paged layouts render only the active page or spread and support arrow/Page/Space/Home/End navigation while keeping zoom and pan behavior available.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [ ] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #32