### PR TITLE
fix(backup): validate import schema version

### DIFF
--- a/memanga/backup.py
+++ b/memanga/backup.py
@@ -1,0 +1,62 @@
+"""Backup (export/import) schema versioning.
+
+The CLI (``memanga export`` / ``memanga import``) and the GUI settings
+page write the same JSON payload, stamped with a schema ``version`` so
+a future format change can be migrated or rejected instead of imported
+blindly::
+
+    {"version": 1, "exported_at": ..., "manga": [...], "state": {...}}
+
+Importers call :func:`validate_backup` before touching the payload and
+show :class:`BackupVersionError` messages to the user as-is, so keep
+them short and self-explanatory.
+"""
+
+from typing import Any, Callable, Dict
+
+EXPORT_VERSION = 1
+
+# Migrations from an older schema version to the next one. When
+# EXPORT_VERSION is bumped, register ``old_version: migrate_fn`` here so
+# backups from previous releases keep importing.
+_MIGRATIONS: Dict[int, Callable[[dict], dict]] = {}
+
+
+class BackupVersionError(ValueError):
+    """An import payload's schema version can't be handled."""
+
+
+def validate_backup(data: Any) -> dict:
+    """Check an import payload's schema ``version``, migrating if needed.
+
+    Returns the payload, migrated up to :data:`EXPORT_VERSION` when it
+    was produced by an older supported schema. Raises
+    :class:`BackupVersionError` with a user-facing message when the
+    version is missing, malformed, unsupported, or newer than this app
+    understands. Exports have stamped ``version`` since the feature
+    shipped, so a missing field means the file isn't a MeManga export.
+    """
+    if not isinstance(data, dict):
+        raise BackupVersionError("Not a MeManga backup file")
+
+    version = data.get("version")
+    if version is None:
+        raise BackupVersionError("Not a MeManga backup: no version field")
+    if isinstance(version, bool) or not isinstance(version, int):
+        raise BackupVersionError(f"Invalid backup version: {version!r}")
+    if version > EXPORT_VERSION:
+        raise BackupVersionError(
+            f"Backup version {version} is newer than this app supports "
+            f"(max {EXPORT_VERSION}); update MeManga"
+        )
+
+    while version < EXPORT_VERSION:
+        migrate = _MIGRATIONS.get(version)
+        if migrate is None:
+            raise BackupVersionError(
+                f"Backup version {version} is not supported"
+            )
+        data = migrate(data)
+        version += 1
+
+    return data

--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -19,6 +19,7 @@ from rich.prompt import Prompt, Confirm
 from rich.table import Table
 from rich import box
 
+from .backup import EXPORT_VERSION, BackupVersionError, validate_backup
 from .config import Config, get_app_password, set_app_password
 from .state import State
 from .downloader import check_for_updates, download_chapter, get_supported_sources, DownloaderError, ChapterWithSource, restart_browsers, _find_chapter_on_backup, _get_sources_from_manga
@@ -1119,7 +1120,7 @@ def cmd_export(args):
     manga_state = state.get("manga", {})
 
     export_data = {
-        "version": 1,
+        "version": EXPORT_VERSION,
         "exported_at": datetime.now().isoformat(),
         "manga": manga_list,
         "state": manga_state,
@@ -1144,6 +1145,12 @@ def cmd_import(args):
 
     with open(import_path, "r") as f:
         import_data = json.load(f)
+
+    try:
+        import_data = validate_backup(import_data)
+    except BackupVersionError as exc:
+        console.print(f"[red]Cannot import:[/red] {exc}")
+        return 1
 
     if "manga" not in import_data:
         console.print("[red]Invalid export file (missing 'manga' key)[/red]")

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -18,6 +18,7 @@ from PySide6.QtCore import Qt
 from .base import BasePage
 from .. import theme as T
 from ..components.toast import Toast
+from ...backup import EXPORT_VERSION, BackupVersionError, validate_backup
 
 
 class SettingsPage(BasePage):
@@ -948,7 +949,7 @@ class SettingsPage(BasePage):
             return
         try:
             data = {
-                "version": 1,
+                "version": EXPORT_VERSION,
                 "exported_at": datetime.now().isoformat(),
                 "manga": self.app.config.get("manga", []),
                 "state": self.app.app_state._data.get("manga", {}),
@@ -966,6 +967,11 @@ class SettingsPage(BasePage):
         try:
             with open(path, "r") as f:
                 data = json.load(f)
+            try:
+                data = validate_backup(data)
+            except BackupVersionError as exc:
+                Toast(self, str(exc), kind="error")
+                return
             manga_list = data.get("manga", [])
             if not isinstance(manga_list, list):
                 Toast(self, "Invalid file", kind="error")

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -275,17 +275,72 @@ class TestExportImport:
             # Export schema should include manga list somewhere.
             assert "manga" in str(data) or "Exp" in str(data)
 
+    def test_export_stamps_schema_version(self, run_cli, config, tmp_path):
+        from memanga.backup import EXPORT_VERSION
+        out = tmp_path / "backup.json"
+        rc = run_cli("export", str(out))
+        assert rc == 0
+        assert json.loads(out.read_text())["version"] == EXPORT_VERSION
+
     def test_import_merge(self, run_cli, config, tmp_path):
         # First export
         backup = tmp_path / "x.json"
         backup.write_text(json.dumps({
+            "version": 1,
             "manga": [{"title": "FromImport", "url": "u",
                        "source": "mangadex.org", "status": "reading"}]
         }))
-        rc = run_cli("import", str(backup), "--merge")
+        rc = run_cli("import", str(backup))
         if rc == 0:
             titles = [m["title"] for m in config.get("manga", []) or []]
             assert "FromImport" in titles
+
+    def test_import_roundtrip(self, run_cli, config, tmp_path):
+        """An export produced by the CLI must import cleanly (issue #42)."""
+        config.set("manga", [{"title": "RoundTrip", "url": "u",
+                              "source": "mangadex.org", "status": "reading"}])
+        config.save()
+        backup = tmp_path / "rt.json"
+        assert run_cli("export", str(backup)) == 0
+        config.set("manga", [])
+        config.save()
+        assert run_cli("import", str(backup)) == 0
+        titles = [m["title"] for m in config.get("manga", []) or []]
+        assert "RoundTrip" in titles
+
+    def test_import_missing_version_rejected(self, run_cli, config, tmp_path,
+                                             capsys):
+        """Issue #42: a file without the export's `version` stamp is not
+        a MeManga backup and must not be imported blindly."""
+        backup = tmp_path / "noversion.json"
+        backup.write_text(json.dumps({
+            "manga": [{"title": "Sneaky", "url": "u",
+                       "source": "mangadex.org", "status": "reading"}]
+        }))
+        capsys.readouterr()
+        rc = run_cli("import", str(backup))
+        assert rc == 1
+        assert "version" in capsys.readouterr().out.lower()
+        titles = [m["title"] for m in config.get("manga", []) or []]
+        assert "Sneaky" not in titles
+
+    def test_import_newer_version_rejected(self, run_cli, config, tmp_path,
+                                           capsys):
+        backup = tmp_path / "future.json"
+        backup.write_text(json.dumps({"version": 99, "manga": []}))
+        capsys.readouterr()
+        rc = run_cli("import", str(backup))
+        assert rc == 1
+        assert "newer" in capsys.readouterr().out.lower()
+
+    def test_import_malformed_version_rejected(self, run_cli, config,
+                                               tmp_path, capsys):
+        backup = tmp_path / "bad.json"
+        backup.write_text(json.dumps({"version": "one", "manga": []}))
+        capsys.readouterr()
+        rc = run_cli("import", str(backup))
+        assert rc == 1
+        assert "version" in capsys.readouterr().out.lower()
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -242,6 +242,58 @@ class TestSettingsPage:
         assert isinstance(page._concurrent_slider, JumpSlider)
         assert page._concurrent_slider.pageStep() == 1
 
+    def test_import_accepts_versioned_backup(self, app_window, qapp,
+                                             monkeypatch, tmp_path):
+        import json
+        from PySide6.QtWidgets import QFileDialog
+        good = tmp_path / "good.json"
+        good.write_text(json.dumps({
+            "version": 1,
+            "manga": [{"title": "FromBackup", "url": "u",
+                       "source": "mangadex.org", "status": "reading"}],
+            "state": {},
+        }))
+        monkeypatch.setattr(QFileDialog, "getOpenFileName",
+                            staticmethod(lambda *a, **k: (str(good), "")))
+        app_window.config.set("manga", [])
+        app_window._pages["settings"]._import()
+        titles = [m.get("title")
+                  for m in app_window.config.get("manga", []) or []]
+        assert "FromBackup" in titles
+
+    def test_import_rejects_versionless_backup(self, app_window, qapp,
+                                               monkeypatch, tmp_path):
+        # Regression for #42: import never read the export's `version`
+        # stamp, so any file with a `manga` array was imported blindly.
+        import json
+        from PySide6.QtWidgets import QFileDialog
+        bad = tmp_path / "noversion.json"
+        bad.write_text(json.dumps({
+            "manga": [{"title": "Sneaky", "url": "u",
+                       "source": "mangadex.org", "status": "reading"}],
+        }))
+        monkeypatch.setattr(QFileDialog, "getOpenFileName",
+                            staticmethod(lambda *a, **k: (str(bad), "")))
+        app_window.config.set("manga", [])
+        app_window._pages["settings"]._import()
+        titles = [m.get("title")
+                  for m in app_window.config.get("manga", []) or []]
+        assert "Sneaky" not in titles
+
+    def test_import_rejects_newer_backup_version(self, app_window, qapp,
+                                                 monkeypatch, tmp_path):
+        import json
+        from PySide6.QtWidgets import QFileDialog
+        future = tmp_path / "future.json"
+        future.write_text(json.dumps({"version": 99, "manga": [
+            {"title": "FromTheFuture", "url": "u",
+             "source": "mangadex.org", "status": "reading"}]}))
+        monkeypatch.setattr(QFileDialog, "getOpenFileName",
+                            staticmethod(lambda *a, **k: (str(future), "")))
+        app_window.config.set("manga", [])
+        app_window._pages["settings"]._import(replace=True)
+        assert app_window.config.get("manga", []) == []
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Detail (requires a manga in config)

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -1,0 +1,62 @@
+"""Backup schema-version validation (issue #42).
+
+Exports have stamped ``"version": 1`` since the feature shipped, but
+the importers never read it — any file with a ``manga`` array was
+imported blindly. ``validate_backup`` now gates every import: version 1
+passes through, anything missing/malformed/newer is rejected with a
+user-facing message, and older versions go through ``_MIGRATIONS``
+(empty while EXPORT_VERSION == 1).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.backup import (
+    EXPORT_VERSION,
+    BackupVersionError,
+    validate_backup,
+    _MIGRATIONS,
+)
+
+
+class TestValidateBackup:
+    def test_current_version_passes_through(self):
+        data = {"version": 1, "manga": [], "state": {}}
+        assert validate_backup(data) is data
+
+    def test_export_version_is_supported(self):
+        # Whatever we export must round-trip through our own validator.
+        assert validate_backup({"version": EXPORT_VERSION})["version"] == EXPORT_VERSION
+
+    def test_missing_version_rejected(self):
+        with pytest.raises(BackupVersionError, match="no version field"):
+            validate_backup({"manga": []})
+
+    def test_non_dict_rejected(self):
+        for payload in ([], "x", 1, None):
+            with pytest.raises(BackupVersionError, match="Not a MeManga backup"):
+                validate_backup(payload)
+
+    @pytest.mark.parametrize("bad", ["1", 1.0, True, [1], {}])
+    def test_malformed_version_rejected(self, bad):
+        with pytest.raises(BackupVersionError, match="Invalid backup version"):
+            validate_backup({"version": bad, "manga": []})
+
+    def test_newer_version_rejected_with_update_hint(self):
+        with pytest.raises(BackupVersionError, match="newer.*update MeManga"):
+            validate_backup({"version": EXPORT_VERSION + 1, "manga": []})
+
+    def test_older_version_without_migration_rejected(self):
+        # No version 0 ever existed, so nothing migrates from it.
+        with pytest.raises(BackupVersionError, match="not supported"):
+            validate_backup({"version": 0, "manga": []})
+
+    def test_migration_chain_runs(self, monkeypatch):
+        # Document how a future schema bump is expected to work: register
+        # a step per old version and validate_backup walks the chain.
+        monkeypatch.setitem(
+            _MIGRATIONS, 0, lambda d: {**d, "version": 1, "migrated": True}
+        )
+        out = validate_backup({"version": 0, "manga": []})
+        assert out["migrated"] is True


### PR DESCRIPTION
## Summary

Validate MeManga backup schema versions before importing from CLI or GUI, so current backups continue to import while missing, malformed, unsupported, or newer versions are rejected before data is changed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [ ] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #42
