### PR TITLE
fix(gui): disable empty cancel-all action

### DIFF
--- a/memanga/gui/pages/downloads.py
+++ b/memanga/gui/pages/downloads.py
@@ -66,12 +66,14 @@ class DownloadsPage(BasePage):
         self._pause_all_btn.clicked.connect(self._toggle_pause_all)
         top_row.addWidget(self._pause_all_btn)
 
-        cancel_all_btn = QPushButton("  Cancel all")
-        cancel_all_btn.setProperty("variant", "danger")
-        cancel_all_btn.setIcon(_ic("x_close", T.tokens()["status.danger"], 14))
-        cancel_all_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        cancel_all_btn.clicked.connect(self._cancel_all)
-        top_row.addWidget(cancel_all_btn)
+        self._cancel_all_btn = QPushButton("  Cancel all")
+        self._cancel_all_btn.setProperty("variant", "danger")
+        self._cancel_all_btn.setIcon(_ic("x_close", T.tokens()["status.danger"], 14))
+        self._cancel_all_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._cancel_all_btn.clicked.connect(self._cancel_all)
+        # Issue #47: nothing to cancel until a download starts or queues.
+        self._cancel_all_btn.setEnabled(False)
+        top_row.addWidget(self._cancel_all_btn)
         h_layout.addLayout(top_row)
 
         # Meta line — live counts are populated by the download / queue
@@ -261,6 +263,7 @@ class DownloadsPage(BasePage):
             self._render_history()
         self._refresh_stats()
         self._refresh_tab_counts()
+        self._update_empty_state()
 
     def _refresh_tab_counts(self):
         """Re-render each tab button label with a trailing count like 'Active 3'."""
@@ -344,8 +347,12 @@ class DownloadsPage(BasePage):
     # ── Download event handlers ──
 
     def _update_empty_state(self):
+        # _active_items mirrors both running and queued downloads, so it is
+        # the single source of truth for "is there anything to cancel".
+        has_items = len(self._active_items) > 0
         try:
-            self._empty_label.setVisible(len(self._active_items) == 0)
+            self._empty_label.setVisible(not has_items)
+            self._cancel_all_btn.setEnabled(has_items)
         except Exception:
             pass
 
@@ -446,6 +453,14 @@ class DownloadsPage(BasePage):
             tid for tid in self._active_items.keys()
             if tid not in queued_task_ids
         ]
+
+        # Issue #47: with nothing running and nothing queued there is
+        # nothing to cancel — no events, no "Cancelled" confirmation.
+        # The button is disabled in that state, but guard the handler too
+        # so a stale click can never report a cancel that didn't happen.
+        if not running_task_ids and not queued_task_ids:
+            return
+
         for task_id in running_task_ids:
             self.app.worker.cancel_download(task_id)
 

--- a/tests/unit/gui/pages/test_downloads_page.py
+++ b/tests/unit/gui/pages/test_downloads_page.py
@@ -1,0 +1,85 @@
+"""Downloads page behavior tests."""
+
+from __future__ import annotations
+
+import threading
+
+
+def _queue_fake_download(app_window, tid="sim-47"):
+    app_window.worker._cancel_flags[tid] = threading.Event()
+    fake = {
+        "task_id": tid,
+        "manga": {"title": "T"},
+        "chapter": type("C", (), {"number": "1"})(),
+        "output_dir": "/tmp",
+        "output_format": "pdf",
+        "state": None,
+        "kindle_cfg": None,
+        "naming_template": None,
+        "cancel": app_window.worker._cancel_flags[tid],
+    }
+    app_window.worker._download_queue.append(fake)
+    app_window.events.publish(
+        "download_queued",
+        {"task_id": tid, "title": "T", "chapter": "1"},
+    )
+
+
+def test_cancel_all_disabled_when_empty(app_window, qapp):
+    app_window.show_page("downloads")
+    qapp.processEvents()
+    page = app_window._pages["downloads"]
+    assert len(page._active_items) == 0
+    assert page._cancel_all_btn.isEnabled() is False
+
+    _queue_fake_download(app_window)
+    app_window.events.poll()
+    qapp.processEvents()
+    assert page._cancel_all_btn.isEnabled() is True
+
+    page._cancel_all()
+    app_window.events.poll()
+    qapp.processEvents()
+    assert len(page._active_items) == 0
+    assert page._cancel_all_btn.isEnabled() is False
+
+
+def test_cancel_all_noop_when_empty(app_window, qapp, monkeypatch):
+    import memanga.gui.pages.downloads as downloads_mod
+
+    toasts = []
+    monkeypatch.setattr(
+        downloads_mod, "Toast", lambda *a, **k: toasts.append((a, k))
+    )
+    cancelled = []
+    app_window.events.subscribe("download_cancelled", cancelled.append)
+
+    page = app_window._pages["downloads"]
+    assert len(page._active_items) == 0
+    page._cancel_all()
+    app_window.events.poll()
+    qapp.processEvents()
+
+    assert toasts == []
+    assert cancelled == []
+
+
+def test_cancel_all_confirms_when_cancelling(app_window, qapp, monkeypatch):
+    import memanga.gui.pages.downloads as downloads_mod
+
+    toasts = []
+    monkeypatch.setattr(
+        downloads_mod, "Toast", lambda parent, msg, **k: toasts.append(msg)
+    )
+
+    _queue_fake_download(app_window)
+    app_window.events.poll()
+    qapp.processEvents()
+
+    page = app_window._pages["downloads"]
+    page._cancel_all()
+    app_window.events.poll()
+    qapp.processEvents()
+
+    assert len(app_window.worker._download_queue) == 0
+    assert toasts == ["Cancelled all downloads"]


### PR DESCRIPTION
## Summary

Disable the Downloads page Cancel all action when there is nothing active or queued, and guard the handler so an empty queue cannot show a false cancellation confirmation.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #47
