### PR TITLE
fix(gui): constrain settings filename preview

### DIFF
--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from PySide6.QtWidgets import (
     QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QFrame,
     QScrollArea, QWidget, QComboBox, QCheckBox, QRadioButton,
-    QLineEdit, QFileDialog, QButtonGroup,
+    QLineEdit, QFileDialog, QButtonGroup, QSizePolicy,
 )
 from PySide6.QtCore import Qt
 from .base import BasePage
@@ -399,8 +399,12 @@ class SettingsPage(BasePage):
         pf_label.setProperty("role", "hint")
         pf_l.addWidget(pf_label)
         self._filename_preview = QLabel("")
-        pf_l.addWidget(self._filename_preview)
-        pf_l.addStretch(1)
+        self._filename_preview.setWordWrap(True)
+        self._filename_preview.setSizePolicy(
+            QSizePolicy.Policy.Ignored,
+            QSizePolicy.Policy.Preferred,
+        )
+        pf_l.addWidget(self._filename_preview, 1)
         f.addWidget(self._preview_frame)
         # Style + restyle on theme change so it isn't stuck on the
         # snapshot taken at construct time.

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -234,6 +234,25 @@ class TestSettingsPage:
         page._refresh_filename_preview()
         assert "1" in page._filename_preview.text()
 
+    def test_long_template_stays_in_column(self, app_window, qapp):
+        from PySide6.QtWidgets import QSizePolicy
+
+        app_window.show_page("settings"); qapp.processEvents()
+        page = app_window._pages["settings"]
+
+        long_tpl = "{title}-" + ("VeryLongUnbrokenTemplatePart" * 20)
+        page._naming_entry.setText(long_tpl)
+        page._refresh_filename_preview()
+        qapp.processEvents()
+
+        assert page._filename_preview.wordWrap()
+        assert (
+            page._filename_preview.sizePolicy().horizontalPolicy()
+            == QSizePolicy.Policy.Ignored
+        )
+        assert page._preview_frame.width() < 800
+        assert page._filename_preview.width() < 800
+
     def test_concurrent_slider_jumps_to_click(self, app_window, qapp):
         # Regression for #46: a stock QSlider's groove click page-steps
         # (default pageStep=10), saturating the 1..8 range to an extreme.


### PR DESCRIPTION
## Summary

Constrain the Settings filename preview so long templates stay inside the general settings column instead of widening the page and distorting nearby sections.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [ ] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #44