### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -108,7 +108,7 @@ jobs:
         run: mv "release/${{ matrix.artifact_name }}" "${{ matrix.asset_name }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset_name }}
           path: ${{ matrix.asset_name }}
@@ -119,7 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts/
 
@@ -130,7 +130,7 @@ jobs:
           ls -la release/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: release/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,29 +9,54 @@ All notable changes are recorded here. Format loosely follows
 ## [0.3.0] - 2026-06-13
 
 ### Added
-- #31 `memanga search` command for live multi-source CLI search.
-- #32 Reader page-by-page mode with left/right navigation and layout
-  controls.
-- #35 Suspicious chapter-jump detection that checks backup sources
-  before accepting unusually large update batches.
+- #31 CLI-only users had no way to discover manga by title without
+  leaving the terminal, finding a source URL manually, then pasting it
+  back into `memanga add`. The new `memanga search` command reuses the
+  same multi-source search engine as the GUI, with relevance filtering,
+  source ordering, chapter-count probes, JSON output, and direct add
+  support.
+- #32 The Reader only supported continuous vertical scrolling, which is
+  awkward for print-style manga where pages are meant to advance one at
+  a time. Reader layout mode now supports continuous, single-page, and
+  two-page reading with keyboard navigation and per-manga persistence.
+- #35 A source could report a huge bogus chapter jump and MeManga would
+  trust it, potentially downloading or emailing dozens of incorrect
+  chapters. Suspicious update batches are now scored before delivery,
+  checked against backup sources when available, and held back unless
+  they are confirmed or explicitly forced.
 
 ### Changed
-- Reader progress now marks chapters as read only near the end of the
-  chapter instead of too early.
-- Concurrent-download slider clicks now jump to the clicked value
-  rather than snapping to the minimum or maximum.
+- #45 Reader progress previously marked a chapter as read before the
+  user actually reached the end. The read threshold now waits until the
+  final portion of the chapter, so library progress reflects real
+  reading progress instead of early scroll position.
+- #46 Clicking the concurrent-downloads slider could snap straight to
+  the minimum or maximum instead of the clicked value. Slider clicks now
+  map to the actual clicked position, making the setting predictable.
+- Release workflow actions now use Node 24-compatible major versions,
+  avoiding the GitHub Actions Node 20 deprecation warning before the
+  v0.3.0 tag build runs.
 
 ### Fixed
-- #42 Backup import now validates the exported schema version instead
-  of silently accepting unsupported backup data.
-- #43 Reader arrow keys navigate chapters/pages as expected.
-- #44 Long settings filename-template previews no longer break the
-  theme options layout.
-- #47 "Cancel All" is disabled when there is no active or queued
-  download work.
-- #48 MangaPill covers load in the GUI by sending the required source
-  referer.
-- #49 The Reader "Next chapter" button label remains visible.
+- #42 Backup import ignored the export schema version, so unsupported
+  backup data could be accepted silently. Import now validates the
+  version field before restoring data, giving future migrations a safe
+  rejection path instead of corrupt or surprising state.
+- #43 Reader arrow keys did not navigate, even though page-based
+  reading expects keyboard controls. Arrow/Page/Home/End handling now
+  works with the active reader layout mode.
+- #44 Very long filename-template previews in Settings could overflow
+  and break the theme options layout. The preview now stays constrained
+  inside the settings panel.
+- #47 The Downloads page left "Cancel All" enabled when there was no
+  active or queued work, then reported a misleading cancellation. The
+  action is now disabled for an empty queue.
+- #48 MangaPill cover images could fail to load in the GUI because the
+  source rejected image requests without its expected referer. Cover
+  fetching now sends the required source referer.
+- #49 The Reader's "Next chapter" button could hide its label, making
+  the navigation control unclear. The button layout now keeps the label
+  visible.
 
 ## [0.2.2] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-13
+
+### Added
+- #31 `memanga search` command for live multi-source CLI search.
+- #32 Reader page-by-page mode with left/right navigation and layout
+  controls.
+- #35 Suspicious chapter-jump detection that checks backup sources
+  before accepting unusually large update batches.
+
+### Changed
+- Reader progress now marks chapters as read only near the end of the
+  chapter instead of too early.
+- Concurrent-download slider clicks now jump to the clicked value
+  rather than snapping to the minimum or maximum.
+
+### Fixed
+- #42 Backup import now validates the exported schema version instead
+  of silently accepting unsupported backup data.
+- #43 Reader arrow keys navigate chapters/pages as expected.
+- #44 Long settings filename-template previews no longer break the
+  theme options layout.
+- #47 "Cancel All" is disabled when there is no active or queued
+  download work.
+- #48 MangaPill covers load in the GUI by sending the required source
+  referer.
+- #49 The Reader "Next chapter" button label remains visible.
+
 ## [0.2.2] - 2026-06-10
 
 ### Added

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.2.2"
+version = "0.3.0"
 description = "Automatic manga downloader with Kindle support"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Prepare the v0.3.0 release metadata before tagging.

- Bumps package metadata from 0.2.2 to 0.3.0
- Adds the v0.3.0 changelog section for the completed milestone work

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #31
Closes #32
Closes #35
Closes #42
Closes #43
Closes #44
Closes #47
Closes #48
Closes #49

## Notes

All tests were reported green on macOS before this release-prep PR. This PR only changes release metadata and changelog content.