### PR TITLE
fix(mangafire): use current chapter API

### DIFF
--- a/memanga/scrapers/mangafire.py
+++ b/memanga/scrapers/mangafire.py
@@ -1,15 +1,17 @@
 """
-MangaFire.to scraper with VRF bypass and image descrambling.
+MangaFire.to scraper using the site's JSON API.
 
-Based on:
-- https://github.com/f4rh4d-4hmed/MangaFire-API (image descrambler)
-- https://github.com/zzyil/AIO-Webtoon-Downloader (VRF capture approach)
+MangaFire moved from server-rendered /manga/slug.hid pages with /ajax
+endpoints to an SPA under /title/hid-slug backed by a JSON API:
 
-Features:
-- Direct AJAX API access (tries without VRF first)
-- Playwright-based VRF token capture (fallback for protected endpoints)
-- Image descrambling for protected/scrambled images
-- Chapter list and page extraction
+- GET /api/titles/{hid}/chapters?language=en&limit=100&page=N  (chapter list)
+- GET /api/chapters/{chapter_id}                               (page image URLs)
+
+Both work with plain HTTP (no VRF token needed). Search still goes through
+a persistent Playwright Firefox (see VRFGenerator.search).
+
+Image descrambling based on:
+- https://github.com/f4rh4d-4hmed/MangaFire-API
 """
 
 import re
@@ -19,7 +21,7 @@ import time
 from io import BytesIO
 from typing import List, Optional, Dict, Tuple
 from pathlib import Path
-from urllib.parse import urlparse, parse_qs
+from urllib.parse import urlparse
 from concurrent.futures import ThreadPoolExecutor
 
 from bs4 import BeautifulSoup
@@ -498,11 +500,48 @@ class MangaFireScraper(BaseScraper):
         self._current_offsets: Dict[str, int] = {}
 
     def _extract_id_from_url(self, url: str) -> str:
-        """Extract manga ID from URL (e.g., 'dkw' from '/manga/one-piece.dkw')."""
+        """Extract MangaFire title hid from old and current URL formats."""
         path = urlparse(url).path
-        if '.' in path:
-            return path.split('.')[-1]
+        if match := re.search(r'/title/([^/-]+)(?:-|$)', path):
+            return match.group(1)
+        if match := re.search(r'/manga/[^/]+\.([^/.]+)$', path):
+            return match.group(1)
+        if match := re.search(r'/read/[^/]+\.([^/.]+)/', path):
+            return match.group(1)
+        if match := re.search(r'/api/titles/([^/]+)', path):
+            return match.group(1)
         return ''
+
+    def _format_chapter_number(self, value) -> str:
+        """Format API chapter numbers without adding trailing .0."""
+        if value is None:
+            return ''
+        if isinstance(value, int):
+            return str(value)
+        if isinstance(value, float) and value.is_integer():
+            return str(int(value))
+        return str(value).strip()
+
+    def _api_get_json(self, url: str) -> dict:
+        """Fetch a MangaFire API endpoint and raise useful scraper errors."""
+        try:
+            response = self.session.get(url, timeout=30)
+        except requests.RequestException as e:
+            raise MangaFireError(f"MangaFire request failed for {url}: {e}") from e
+        except Exception as e:
+            raise MangaFireError(f"MangaFire request failed for {url}: {e}") from e
+
+        if response.status_code != 200:
+            raise MangaFireError(
+                f"MangaFire returned HTTP {response.status_code} for {url}"
+            )
+
+        try:
+            return response.json()
+        except ValueError as e:
+            raise MangaFireError(
+                f"MangaFire returned a non-JSON response for {url}: {e}"
+            ) from e
 
     def _parse_chapter_url(self, chapter_url: str) -> Tuple[str, str, str]:
         """
@@ -518,7 +557,18 @@ class MangaFireScraper(BaseScraper):
         lang = 'en'
         chap_num = '1'
 
-        # Find manga ID (the part after the dot)
+        if parts[:2] == ['api', 'chapters'] and len(parts) >= 3:
+            return parts[2], lang, chap_num
+
+        # New reader/title URLs carry the title hid before the first dash.
+        if len(parts) >= 2 and parts[0] == 'title':
+            manga_id = parts[1].split('-', 1)[0]
+            for i, part in enumerate(parts):
+                if part == 'read' and i + 1 < len(parts):
+                    lang = parts[i + 1]
+                    break
+
+        # Old reader URLs carry the manga hid after the dot.
         for i, part in enumerate(parts):
             if '.' in part:
                 manga_id = part.split('.')[-1]
@@ -576,66 +626,63 @@ class MangaFireScraper(BaseScraper):
         if not manga_id:
             raise ValueError(f"Could not extract manga ID from URL: {manga_url}")
 
-        # Use AJAX endpoint for chapter list (works without VRF!)
-        ajax_url = f"{self.base_url}/ajax/manga/{manga_id}/chapter/{language}"
+        chapters: List[Chapter] = []
+        seen_numbers = set()
+        page = 1
 
-        last_error = None
-        response = None
-        for attempt in range(1, 4):
-            try:
-                response = self.session.get(ajax_url, timeout=30)
-                break
-            except requests.RequestException as e:
-                last_error = e
-                if attempt < 3:
-                    time.sleep(attempt)
-                    continue
-                raise MangaFireError(f"MangaFire request failed for {ajax_url}: {e}") from e
-            except Exception as e:
-                raise MangaFireError(f"MangaFire request failed for {ajax_url}: {e}") from e
-
-        if response is None:
-            raise MangaFireError(f"MangaFire request failed for {ajax_url}: {last_error}")
-
-        # A non-200 transport status is an upstream failure (Cloudflare 5xx,
-        # gateway timeout, rate limit) — not an empty chapter list.
-        if response.status_code != 200:
-            raise MangaFireError(
-                f"MangaFire returned HTTP {response.status_code} for {ajax_url}"
+        while True:
+            api_url = (
+                f"{self.base_url}/api/titles/{manga_id}/chapters"
+                f"?language={language}&limit=100&page={page}"
             )
+            data = self._api_get_json(api_url)
+            items = data.get('items')
+            if not isinstance(items, list):
+                raise MangaFireError(
+                    f"MangaFire returned an invalid chapter list for {api_url}"
+                )
 
-        try:
-            data = response.json()
-        except ValueError as e:
-            raise MangaFireError(f"MangaFire returned a non-JSON response for {ajax_url}: {e}") from e
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                chapter_id = item.get('id')
+                number = self._format_chapter_number(item.get('number', ''))
+                if not chapter_id or not number or number in seen_numbers:
+                    continue
 
-        # The AJAX envelope carries its own status code; anything other than
-        # 200 (often a wrapped Cloudflare error) means the request did not
-        # actually return a chapter list.
-        if data.get('status') != 200 or 'result' not in data:
-            raise MangaFireError(self._chapter_error_message(ajax_url, data))
+                seen_numbers.add(number)
+                name = str(item.get('name') or '').strip()
+                chapters.append(Chapter(
+                    number=number,
+                    title=name or f"Chapter {number}",
+                    url=f"{self.base_url}/api/chapters/{chapter_id}",
+                ))
 
-        chapters = []
-        soup = BeautifulSoup(data['result'], 'html.parser')
-
-        for li in soup.select('li'):
-            a_tag = li.select_one('a')
-            if not a_tag:
-                continue
-
-            href = a_tag.get('href', '')
-            title = a_tag.get('title', '')
-            chap_num = li.get('data-number', '0')
-
-            full_url = href if href.startswith('http') else f"{self.base_url}{href}"
-
-            chapters.append(Chapter(
-                number=chap_num,
-                title=title,
-                url=full_url,
-            ))
+            meta = data.get('meta') if isinstance(data.get('meta'), dict) else {}
+            if not meta.get('hasNext'):
+                break
+            page += 1
 
         return sorted(chapters, key=lambda x: x.numeric)
+
+    def _resolve_chapter_api_url(self, chapter_url: str) -> str:
+        """Resolve a saved MangaFire chapter URL to the current chapter API URL."""
+        parsed = urlparse(chapter_url)
+        if re.search(r'/api/chapters/\d+', parsed.path):
+            if chapter_url.startswith('http'):
+                return chapter_url
+            return f"{self.base_url}{parsed.path}"
+
+        manga_id, lang, chap_num = self._parse_chapter_url(chapter_url)
+        if not manga_id:
+            raise MangaFireError(f"Could not parse MangaFire chapter URL: {chapter_url}")
+
+        wanted = self._format_chapter_number(chap_num)
+        for chapter in self.get_chapters(f"{self.base_url}/title/{manga_id}", language=lang):
+            if chapter.number == wanted:
+                return chapter.url
+
+        raise MangaFireError(f"MangaFire chapter {wanted} not found for {manga_id}")
 
     def _try_direct_ajax(self, manga_id: str, lang: str, chap_num: str) -> Tuple[List[str], List[int]]:
         """
@@ -690,46 +737,36 @@ class MangaFireScraper(BaseScraper):
         """
         Get all page image URLs for a chapter.
 
-        First tries direct AJAX (fast, no browser).
-        Falls back to Playwright browser for VRF bypass if needed.
-
-        The offsets are stored internally for use during download.
+        Uses MangaFire's current JSON API. The old AJAX endpoints now return
+        the SPA shell instead of chapter/page JSON.
         """
-        # Parse the chapter URL
-        manga_id, lang, chap_num = self._parse_chapter_url(chapter_url)
+        api_url = self._resolve_chapter_api_url(chapter_url)
+        data = self._api_get_json(api_url)
+        chapter_data = (
+            data.get('data') if isinstance(data.get('data'), dict) else data
+        )
+        pages = chapter_data.get('pages') if isinstance(chapter_data, dict) else None
+        if not isinstance(pages, list):
+            raise MangaFireError(
+                f"MangaFire returned an invalid page list for {api_url}"
+            )
 
-        if not manga_id:
-            print(f"[MangaFire] Could not parse chapter URL: {chapter_url}")
-            return []
-
-        print(f"[MangaFire] Chapter: manga_id={manga_id}, lang={lang}, chap={chap_num}")
-
-        # First, try direct AJAX (works for many chapters without VRF)
-        urls, offsets = self._try_direct_ajax(manga_id, lang, chap_num)
-
-        if urls:
-            # Store offsets for descrambling
-            self._current_offsets.clear()
-            for url, offset in zip(urls, offsets):
+        self._current_offsets.clear()
+        image_urls = []
+        for page in pages:
+            if isinstance(page, dict):
+                url = page.get('url')
+                offset = page.get('offset') or page.get('scrambleOffset') or 0
+            else:
+                url = page
+                offset = 0
+            if not url:
+                continue
+            image_urls.append(url)
+            if isinstance(offset, int) and offset > 0:
                 self._current_offsets[url] = offset
-            return urls
 
-        # Fallback: Use Playwright browser for VRF bypass
-        if PLAYWRIGHT_AVAILABLE:
-            print("[MangaFire] Direct AJAX failed, trying browser bypass...")
-            vrf_gen = get_vrf_generator()
-            urls, offsets = vrf_gen.get_chapter_pages(chapter_url)
-
-            if urls:
-                self._current_offsets.clear()
-                for url, offset in zip(urls, offsets):
-                    self._current_offsets[url] = offset
-                return urls
-        else:
-            print("[MangaFire] Playwright not available for VRF bypass")
-
-        print(f"[MangaFire] Could not get pages for: {chapter_url}")
-        return []
+        return image_urls
 
     def download_image(self, url: str, path) -> bool:
         """

--- a/tests/unit/scrapers/test_mangafire.py
+++ b/tests/unit/scrapers/test_mangafire.py
@@ -31,52 +31,74 @@ class _Session:
 
 
 class TestMangaFireGetChapters:
-    def test_parses_ajax_chapter_list(self):
+    def test_extracts_title_hid_from_old_and_new_urls(self):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+
+        assert scraper._extract_id_from_url("https://mangafire.to/manga/demo.abc") == "abc"
+        assert scraper._extract_id_from_url("https://mangafire.to/title/abc-demo") == "abc"
+        assert scraper._extract_id_from_url("https://mangafire.to/read/demo.abc/en/chapter-1") == "abc"
+
+    def test_parses_api_chapter_list_and_deduplicates_numbers(self):
         from memanga.scrapers.mangafire import MangaFireScraper
 
         scraper = MangaFireScraper()
         scraper.session = _Session([
             _Response(payload={
-                "status": 200,
-                "result": """
-                    <ul>
-                      <li data-number="2"><a href="/read/demo.abc/en/chapter-2" title="Chapter 2"></a></li>
-                      <li data-number="1"><a href="/read/demo.abc/en/chapter-1" title="Chapter 1"></a></li>
-                    </ul>
-                """,
+                "items": [
+                    {"id": 102, "number": 2, "name": "", "createdAt": 20},
+                    {"id": 202, "number": 2, "name": "", "createdAt": 10},
+                    {"id": 101, "number": 1, "name": "Start", "createdAt": 5},
+                    {"id": 115, "number": 1.5, "name": "", "createdAt": 7},
+                ],
+                "meta": {"hasNext": False},
             }),
         ])
 
         chapters = scraper.get_chapters("https://mangafire.to/manga/demo.abc")
 
+        assert [ch.number for ch in chapters] == ["1", "1.5", "2"]
+        assert chapters[0].title == "Start"
+        assert chapters[1].title == "Chapter 1.5"
+        assert chapters[2].url == "https://mangafire.to/api/chapters/102"
+
+    def test_follows_api_chapter_pagination(self):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={
+                "items": [{"id": 101, "number": 1, "name": ""}],
+                "meta": {"hasNext": True},
+            }),
+            _Response(payload={
+                "items": [{"id": 202, "number": 2, "name": ""}],
+                "meta": {"hasNext": False},
+            }),
+        ])
+
+        chapters = scraper.get_chapters("https://mangafire.to/title/abc-demo")
+
+        assert scraper.session.calls == 2
         assert [ch.number for ch in chapters] == ["1", "2"]
-        assert chapters[0].url == "https://mangafire.to/read/demo.abc/en/chapter-1"
 
     def test_cloudflare_ajax_error_raises_instead_of_empty_list(self):
         from memanga.scrapers.mangafire import MangaFireError, MangaFireScraper
 
         scraper = MangaFireScraper()
         scraper.session = _Session([
-            _Response(payload={
-                "status": 522,
-                "title": "Error 522: Connection timed out",
-                "error_name": "connection_timeout",
-                "retryable": True,
-                "retry_after": 120,
-                "cloudflare_error": True,
-            }),
+            _Response(status_code=503, payload={"message": "unavailable"}),
         ])
 
         with pytest.raises(MangaFireError) as exc:
             scraper.get_chapters("https://mangafire.to/manga/demo.abc")
 
         message = str(exc.value)
-        assert "status=522" in message
-        assert "Connection timed out" in message
-        assert "retryable=True" in message
-        assert "retry_after=120s" in message
+        assert "HTTP 503" in message
+        assert "/api/titles/abc/chapters" in message
 
-    def test_request_errors_retry_before_failing(self, monkeypatch):
+    def test_request_errors_raise_instead_of_empty_list(self, monkeypatch):
         import requests
         from memanga.scrapers import mangafire as mf
 
@@ -85,16 +107,55 @@ class TestMangaFireGetChapters:
         scraper = mf.MangaFireScraper()
         scraper.session = _Session([
             requests.Timeout("temporary timeout"),
+        ])
+
+        with pytest.raises(mf.MangaFireError, match="temporary timeout"):
+            scraper.get_chapters("https://mangafire.to/manga/demo.abc")
+
+        assert scraper.session.calls == 1
+
+
+class TestMangaFireGetPages:
+    def test_get_pages_uses_chapter_api_url(self):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
             _Response(payload={
-                "status": 200,
-                "result": '<li data-number="1"><a href="/read/demo.abc/en/chapter-1" title="Chapter 1"></a></li>',
+                "data": {
+                    "pages": [
+                        {"url": "https://cdn.example/001.jpg"},
+                        {"url": "https://cdn.example/002.jpg", "offset": 3},
+                    ],
+                },
             }),
         ])
 
-        chapters = scraper.get_chapters("https://mangafire.to/manga/demo.abc")
+        pages = scraper.get_pages("https://mangafire.to/api/chapters/123")
 
-        assert scraper.session.calls == 2
-        assert [ch.number for ch in chapters] == ["1"]
+        assert pages == ["https://cdn.example/001.jpg", "https://cdn.example/002.jpg"]
+        assert scraper._current_offsets == {"https://cdn.example/002.jpg": 3}
+
+    def test_get_pages_resolves_saved_old_reader_url(self):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={
+                "items": [
+                    {"id": 100, "number": 1, "name": ""},
+                    {"id": 200, "number": 2, "name": ""},
+                ],
+                "meta": {"hasNext": False},
+            }),
+            _Response(payload={
+                "data": {"pages": [{"url": "https://cdn.example/002.jpg"}]},
+            }),
+        ])
+
+        pages = scraper.get_pages("https://mangafire.to/read/demo.abc/en/chapter-2")
+
+        assert pages == ["https://cdn.example/002.jpg"]
 
 
 class TestVRFBrowserInitAtomicity:


### PR DESCRIPTION
## Summary

Updates MangaFire chapter and page extraction for the current `/api`-backed site so old saved MangaFire URLs continue to work after the legacy AJAX endpoints stopped returning JSON.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #71