### PR TITLE
chore(release): prepare v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-06
+
+### Fixed
+- #71 MangaFire changed its chapter and page endpoints, so saved
+  MangaFire library entries could no longer fetch real chapter lists.
+  MangaFire now reads the current `/api` chapter and page payloads,
+  keeps old saved MangaFire URLs compatible, follows paginated chapter
+  lists, and deduplicates repeated chapter numbers before update checks
+  or downloads run.
+
 ## [0.3.0] - 2026-06-13
 
 ### Added

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.3.0"
+version = "0.3.1"
 description = "Automatic manga downloader with Kindle support"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Prepares the v0.3.1 hotfix release metadata after the MangaFire API fix landed on main.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Prepares v0.3.1 for #71.