### PR TITLE
test(live): add staged scraper diagnostics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,13 @@ pytest tests/unit/gui
 
 # Live scraper health checks (hits real sites — slow, opt-in)
 pytest -m live tests/scrapers/live/
+
+# Curated end-to-end probes only — each walks search → chapters →
+# pages → image and a failure names the first broken stage
+pytest -m live tests/scrapers/live/test_live_parsing.py -v
+
+# Machine-readable report (per-stage details + failures_by_stage)
+pytest -m live tests/scrapers/live/ --health-report=health.json
 ```
 
 All checked-in tests should pass before you push. CI runs `pytest` on

--- a/tests/scrapers/live/_helpers.py
+++ b/tests/scrapers/live/_helpers.py
@@ -8,8 +8,10 @@ Python rather than only as pytest fixtures.
 from __future__ import annotations
 
 import socket
+import tempfile
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import pytest
 import requests
@@ -23,15 +25,51 @@ STATUS_HTTP_ERROR = "HTTP_ERROR"
 STATUS_STALE = "STALE"
 STATUS_SKIP = "SKIP"
 
+# Pipeline stage constants — each curated probe walks these in order,
+# so a failure names the first stage that broke.
+STAGE_REACHABILITY = "reachability"
+STAGE_SEARCH = "search"
+STAGE_CHAPTERS = "chapters"
+STAGE_PAGES = "pages"
+STAGE_IMAGE = "image"
+
+PIPELINE_STAGES = (
+    STAGE_REACHABILITY, STAGE_SEARCH, STAGE_CHAPTERS, STAGE_PAGES, STAGE_IMAGE,
+)
+
 
 @dataclass
 class HealthResult:
     """One row in the per-run health report."""
     domain: str
     status: str
+    stage: str = ""  # first pipeline stage that failed ("" = none / n.a.)
     detail: str = ""
     elapsed_ms: float = 0.0
     extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class StageResult:
+    """Outcome of one pipeline stage for one domain."""
+    stage: str
+    status: str
+    detail: str = ""
+    elapsed_ms: float = 0.0
+
+
+class StageFailure(Exception):
+    """Raised by ScraperPipeline when a stage fails.
+
+    Carries the failed stage plus everything that already passed, so
+    the test can report "search OK, chapters OK, pages BROKEN" instead
+    of one opaque STALE.
+    """
+
+    def __init__(self, failed: StageResult, stages: list):
+        self.failed = failed
+        self.stages = stages  # all stages run so far, failed one last
+        super().__init__(f"[{failed.status}:{failed.stage}] {failed.detail}")
 
 
 LIVE_TIMEOUT = 15  # seconds
@@ -44,6 +82,9 @@ LIVE_HEADERS = {
     "Accept-Language": "en-US,en;q=0.5",
 }
 
+# Enough to hold any of the magic byte signatures below.
+_MIN_IMAGE_BYTES = 1024
+
 
 def probe_url(url: str, timeout: float = LIVE_TIMEOUT) -> HealthResult:
     """Reach a URL and classify what came back."""
@@ -53,15 +94,18 @@ def probe_url(url: str, timeout: float = LIVE_TIMEOUT) -> HealthResult:
         resp = requests.get(url, headers=LIVE_HEADERS, timeout=timeout,
                               allow_redirects=True)
     except requests.exceptions.SSLError as e:
-        return HealthResult(domain, STATUS_DEAD, f"ssl error: {e!s}",
+        return HealthResult(domain, STATUS_DEAD, STAGE_REACHABILITY,
+                              f"ssl error: {e!s}",
                               (time.monotonic() - t0) * 1000)
     except (requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
             socket.gaierror) as e:
-        return HealthResult(domain, STATUS_DEAD, f"connection error: {e!s}",
+        return HealthResult(domain, STATUS_DEAD, STAGE_REACHABILITY,
+                              f"connection error: {e!s}",
                               (time.monotonic() - t0) * 1000)
     except requests.exceptions.RequestException as e:
-        return HealthResult(domain, STATUS_HTTP_ERROR, f"request error: {e!s}",
+        return HealthResult(domain, STATUS_HTTP_ERROR, STAGE_REACHABILITY,
+                              f"request error: {e!s}",
                               (time.monotonic() - t0) * 1000)
 
     elapsed = (time.monotonic() - t0) * 1000
@@ -71,23 +115,23 @@ def probe_url(url: str, timeout: float = LIVE_TIMEOUT) -> HealthResult:
         body_lower = resp.text[:2000].lower()
         if any(s in body_lower for s in
                 ("cloudflare", "cf-ray", "just a moment", "ddos protection")):
-            return HealthResult(domain, STATUS_PROTECTED,
+            return HealthResult(domain, STATUS_PROTECTED, STAGE_REACHABILITY,
                                   f"HTTP {resp.status_code} (Cloudflare-style)",
                                   elapsed)
-        return HealthResult(domain, STATUS_HTTP_ERROR,
+        return HealthResult(domain, STATUS_HTTP_ERROR, STAGE_REACHABILITY,
                               f"HTTP {resp.status_code}", elapsed)
 
     if resp.status_code >= 400:
-        return HealthResult(domain, STATUS_HTTP_ERROR,
+        return HealthResult(domain, STATUS_HTTP_ERROR, STAGE_REACHABILITY,
                               f"HTTP {resp.status_code}", elapsed)
 
     # Suspicious tiny body
     if len(resp.text) < 200:
-        return HealthResult(domain, STATUS_STALE,
+        return HealthResult(domain, STATUS_STALE, STAGE_REACHABILITY,
                               f"HTTP 200 but body only {len(resp.text)} bytes",
                               elapsed)
 
-    return HealthResult(domain, STATUS_OK,
+    return HealthResult(domain, STATUS_OK, "",
                           f"HTTP {resp.status_code} ({len(resp.text)} bytes)",
                           elapsed)
 
@@ -105,17 +149,156 @@ def assert_alive(result: HealthResult):
         pytest.fail(f"[STALE] {result.domain}: {result.detail}")
 
 
-def assert_parsed_something(scraper_call, *args, min_items: int = 1):
-    """Call scraper_call(*args); fail if it returns 0 results.
+def looks_like_image(data: bytes) -> bool:
+    """True if the byte prefix matches a known image format signature."""
+    return (
+        data.startswith(b"\xff\xd8\xff")            # JPEG
+        or data.startswith(b"\x89PNG\r\n\x1a\n")    # PNG
+        or data.startswith((b"GIF87a", b"GIF89a"))  # GIF
+        or (data[:4] == b"RIFF" and data[8:12] == b"WEBP")
+        or data[4:12] in (b"ftypavif", b"ftypheic")
+        or data.startswith(b"BM")                   # BMP
+    )
 
-    Wraps exceptions into STALE-style failures so they show up in the
-    report cleanly rather than as stack traces.
+
+def scraper_base_url(scraper) -> str:
+    """Configured base URL, whichever attribute the scraper family uses."""
+    return (getattr(scraper, "BASE_URL", None)
+            or getattr(scraper, "base_url", None) or "")
+
+
+class ScraperPipeline:
+    """Runs one scraper's user-visible stages in order against the live
+    site: search → chapters → pages → image download.
+
+    Each stage records a StageResult; the first failure raises
+    StageFailure carrying everything that already passed, so pytest
+    output and the JSON report can pinpoint the broken stage.
     """
-    try:
-        result = scraper_call(*args)
-    except Exception as e:
-        pytest.fail(f"[STALE] scraper raised: {type(e).__name__}: {e!s}")
-    if not result or len(result) < min_items:
-        pytest.fail(f"[STALE] scraper returned {len(result) if result else 0} items, "
-                     f"expected ≥ {min_items} (HTML structure may have changed)")
-    return result
+
+    def __init__(self, scraper, domain: str):
+        self.scraper = scraper
+        self.domain = domain
+        self.stages: list[StageResult] = []
+
+    # ── internals ────────────────────────────────────────────────
+
+    def _fail(self, stage: str, detail: str, elapsed_ms: float = 0.0,
+              status: str = STATUS_STALE):
+        failed = StageResult(stage, status, detail, elapsed_ms)
+        self.stages.append(failed)
+        raise StageFailure(failed, self.stages) from None
+
+    def _pass(self, stage: str, detail: str, elapsed_ms: float):
+        self.stages.append(StageResult(stage, STATUS_OK, detail, elapsed_ms))
+
+    def _call(self, stage: str, label: str, fn, *args):
+        """Call fn(*args); classify exceptions by stage + cause."""
+        t0 = time.monotonic()
+        try:
+            out = fn(*args)
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout, socket.gaierror) as e:
+            self._fail(stage, f"{label} → connection error: {e!s}",
+                       (time.monotonic() - t0) * 1000, STATUS_DEAD)
+        except requests.exceptions.HTTPError as e:
+            self._fail(stage, f"{label} → HTTP error: {e!s}",
+                       (time.monotonic() - t0) * 1000, STATUS_HTTP_ERROR)
+        except Exception as e:
+            self._fail(stage,
+                       f"{label} raised {type(e).__name__}: {e!s} "
+                       f"(HTML structure may have changed)",
+                       (time.monotonic() - t0) * 1000)
+        return out, (time.monotonic() - t0) * 1000
+
+    # ── stages ───────────────────────────────────────────────────
+
+    def search(self, query: str, min_results: int = 1) -> list:
+        label = f"search({query!r})"
+        results, ms = self._call(STAGE_SEARCH, label, self.scraper.search, query)
+        if not results or len(results) < min_results:
+            self._fail(STAGE_SEARCH,
+                       f"{label} returned {len(results) if results else 0} "
+                       f"results, expected ≥ {min_results}", ms)
+        first = results[0]
+        if not getattr(first, "url", ""):
+            self._fail(STAGE_SEARCH,
+                       f"{label} → first result {first.title!r} has empty url", ms)
+        self._pass(STAGE_SEARCH,
+                   f"{label} → {len(results)} results "
+                   f"(first: {first.title!r} {first.url})", ms)
+        return results
+
+    def chapters(self, manga_url: str, min_chapters: int = 1) -> list:
+        label = f"get_chapters({manga_url})"
+        chapters, ms = self._call(STAGE_CHAPTERS, label,
+                                    self.scraper.get_chapters, manga_url)
+        if not chapters or len(chapters) < min_chapters:
+            self._fail(STAGE_CHAPTERS,
+                       f"{label} returned "
+                       f"{len(chapters) if chapters else 0} chapters, "
+                       f"expected ≥ {min_chapters}", ms)
+        first = chapters[0]
+        if not getattr(first, "url", ""):
+            self._fail(STAGE_CHAPTERS,
+                       f"{label} → chapter {first.number!r} has empty url", ms)
+        self._pass(STAGE_CHAPTERS,
+                   f"{label} → {len(chapters)} chapters "
+                   f"(#{chapters[0].number} … #{chapters[-1].number})", ms)
+        return chapters
+
+    def pages(self, chapter) -> list:
+        label = f"get_pages(ch {chapter.number!r} {chapter.url})"
+        pages, ms = self._call(STAGE_PAGES, label,
+                                 self.scraper.get_pages, chapter.url)
+        if not pages:
+            self._fail(STAGE_PAGES, f"{label} returned 0 page URLs", ms)
+        first = pages[0]
+        if not isinstance(first, str) or not (
+                first.startswith(("http://", "https://", "//"))):
+            self._fail(STAGE_PAGES,
+                       f"{label} → first page URL looks wrong: {first!r}", ms)
+        self._pass(STAGE_PAGES,
+                   f"{label} → {len(pages)} page URLs (first: {first})", ms)
+        return pages
+
+    def image(self, page_url: str):
+        """Download the first page image via the scraper's own
+        download_image() (the production path, incl. Referer headers)
+        and verify the bytes are a real image."""
+        if page_url.startswith("//"):
+            page_url = "https:" + page_url
+        t0 = time.monotonic()
+        with tempfile.TemporaryDirectory(prefix="memanga-live-") as tmp:
+            path = Path(tmp) / "probe.img"
+            ok = self.scraper.download_image(page_url, path)
+            ms = (time.monotonic() - t0) * 1000
+            if not ok:
+                self._fail(STAGE_IMAGE,
+                           f"download_image({page_url}) returned False "
+                           f"({self._image_hint(page_url)})", ms)
+            data = path.read_bytes() if path.exists() else b""
+            if len(data) < _MIN_IMAGE_BYTES:
+                self._fail(STAGE_IMAGE,
+                           f"download_image({page_url}) wrote only "
+                           f"{len(data)} bytes", ms)
+            if not looks_like_image(data):
+                self._fail(STAGE_IMAGE,
+                           f"download_image({page_url}) wrote {len(data)} "
+                           f"bytes but not image data "
+                           f"(starts with {data[:12]!r})", ms)
+            self._pass(STAGE_IMAGE,
+                       f"downloaded first page ({len(data)} bytes, "
+                       f"valid image) from {page_url}", ms)
+
+    def _image_hint(self, url: str) -> str:
+        """download_image() swallows errors — re-probe for a diagnosis."""
+        try:
+            resp = self.scraper.session.get(
+                url, timeout=LIVE_TIMEOUT, stream=True)
+            hint = (f"direct GET → HTTP {resp.status_code}, "
+                    f"Content-Type: {resp.headers.get('Content-Type')}")
+            resp.close()
+            return hint
+        except Exception as e:
+            return f"direct GET failed: {type(e).__name__}: {e!s}"

--- a/tests/scrapers/live/conftest.py
+++ b/tests/scrapers/live/conftest.py
@@ -14,13 +14,18 @@ Capture a JSON report:
 
     pytest -m live tests/scrapers/live/ --health-report=health.json
 
-Failures are classified in the test name so you can scan the output:
+Failures are classified so you can scan the output:
   - DEAD        : DNS lookup failed, connection refused, timeout
   - PROTECTED   : Cloudflare/anti-bot 403/503 (site exists, blocked us)
   - HTTP_ERROR  : 4xx/5xx response
   - STALE       : site responded but the scraper extracted nothing
                   (likely the HTML structure changed)
   - OK          : reachable + scraper extracted real data
+
+Curated pipeline probes (test_live_parsing.py) additionally name the
+first broken stage — reachability, search, chapters, pages or image —
+both in the pytest failure message ("[STALE:pages] domain: ...") and
+in the JSON report's `stage` field / per-stage `extra.stages` rows.
 """
 
 from __future__ import annotations
@@ -74,6 +79,17 @@ def health_recorder():
     return _record
 
 
+def _count_failures_by_stage() -> dict:
+    from _helpers import STATUS_OK, STATUS_SKIP, STATUS_PROTECTED
+    counts: dict = {}
+    for r in _RESULTS:
+        # PROTECTED is informational, not a failure (see assert_alive).
+        if r.status not in (STATUS_OK, STATUS_SKIP, STATUS_PROTECTED) \
+                and r.stage:
+            counts[r.stage] = counts.get(r.stage, 0) + 1
+    return counts
+
+
 def pytest_sessionfinish(session, exitstatus):
     path = session.config.getoption("--health-report")
     if not path or not _RESULTS:
@@ -92,6 +108,9 @@ def pytest_sessionfinish(session, exitstatus):
             "stale": sum(1 for r in _RESULTS if r.status == STATUS_STALE),
             "skip": sum(1 for r in _RESULTS if r.status == STATUS_SKIP),
         },
+        # Which pipeline stage failures happened at (curated probes
+        # only — broad reachability rows always say "reachability").
+        "failures_by_stage": _count_failures_by_stage(),
         "results": [asdict(r) for r in _RESULTS],
     }
     Path(path).write_text(json.dumps(out, indent=2), encoding="utf-8")

--- a/tests/scrapers/live/test_live_parsing.py
+++ b/tests/scrapers/live/test_live_parsing.py
@@ -1,15 +1,21 @@
-"""End-to-end parsing health checks against live sites.
+"""End-to-end pipeline health checks against live sites.
 
 Reachability alone isn't enough — a site can be up while its HTML
-changed in a way that breaks the parser. This file actually invokes
-each scraper's search() / get_chapters() / get_pages() against the
-real site and fails when the parser returns zero results (likely
-indicates the site's structure drifted).
+changed in a way that breaks the parser. Each probe here walks the
+same stages a real download does, in order, against the live site:
+
+    reachability → search → chapters → pages → image
+
+and fails on the FIRST broken stage, so the pytest output (and the
+--health-report JSON) tells you *which part* of the scraper is broken,
+e.g. `[STALE:pages] mangapill.com: get_pages(...) returned 0 page
+URLs` — not just a generic STALE.
 
 We can't maintain a known-good URL per domain forever, so this file
 is deliberately curated — it tests a focused set of high-traffic
 sources + every scraper template family (one representative per
-template).
+template). Broad one-request-per-domain coverage lives in
+test_live_reachability.py.
 
 Skipped by default. Opt in with:
     pytest -m live tests/scrapers/live/test_live_parsing.py -v
@@ -21,143 +27,136 @@ Single source:
 
 from __future__ import annotations
 
+from dataclasses import dataclass, asdict
+
 import pytest
 
 from memanga.scrapers import get_scraper
 
 from _helpers import (  # injected onto sys.path by conftest.py
-    HealthResult, STATUS_OK, STATUS_STALE, STATUS_PROTECTED, STATUS_DEAD,
-    probe_url, assert_alive, assert_parsed_something, LIVE_TIMEOUT,
+    HealthResult, StageResult, StageFailure, ScraperPipeline,
+    STATUS_OK, STATUS_STALE, STATUS_PROTECTED, STATUS_DEAD, STATUS_HTTP_ERROR,
+    STAGE_REACHABILITY,
+    probe_url, scraper_base_url,
 )
 
 
 # ─────────────────────────────────────────────────────────────────────
-# Per-source health probes.
+# Per-source probe specs.
 #
-# Each probe is a callable that takes the scraper instance and either:
-#   - returns silently on success
-#   - calls pytest.fail / pytest.skip with a classified message
+# query=None means a single-manga template site: skip search and get
+# chapters straight from the configured base URL.
 #
-# Keep these LIGHT — one search + one get_chapters per probe is plenty.
-# Avoid get_pages on Playwright sites (too slow + brittle for CI).
+# Keep these LIGHT — the full pipeline is ~4 requests per source
+# (search, chapters, pages, one image). Disable later stages where a
+# site makes them too slow/brittle (e.g. check_pages=False for
+# Playwright-rendered readers).
 # ─────────────────────────────────────────────────────────────────────
 
 
-def _probe_search_then_chapters(scraper, query: str, *,
-                                  expect_results: int = 1,
-                                  expect_chapters: int = 1,
-                                  do_chapters: bool = True):
-    """search(query) → ≥1 result; first result's chapters → ≥1 chapter."""
-    results = assert_parsed_something(scraper.search, query,
-                                        min_items=expect_results)
-    if not do_chapters:
-        return
-    first = results[0]
-    assert_parsed_something(scraper.get_chapters, first.url,
-                              min_items=expect_chapters)
+@dataclass(frozen=True)
+class ProbeSpec:
+    description: str
+    query: str | None = None      # None → single-manga template site
+    check_chapters: bool = True
+    check_pages: bool = True
+    check_image: bool = True
 
 
-def _probe_single_manga_chapters(scraper):
-    """For single-manga template sites: chapters from the configured base."""
-    base = getattr(scraper, "BASE_URL", None) or getattr(scraper, "base_url", "")
-    assert_parsed_something(scraper.get_chapters, base, min_items=1)
-
-
-# Domain → (description, probe-fn). Curated list of sites we test
-# end-to-end. Easy to expand: just add another entry.
 PARSING_PROBES = {
-    # ── Aggregators (search + chapters) ──
-    "mangadex.org": (
-        "API client", lambda s: _probe_search_then_chapters(s, "one piece"),
-    ),
-    "mangapill.com": (
-        "Simple HTTP aggregator",
-        lambda s: _probe_search_then_chapters(s, "one piece"),
-    ),
-    "tcbonepiecechapters.com": (
-        "TCB Scans (project list)",
-        lambda s: _probe_search_then_chapters(s, "one piece"),
-    ),
-    "mangakakalot.com": (
-        "Mangakakalot",
-        lambda s: _probe_search_then_chapters(s, "naruto"),
-    ),
-    "manganato.com": (
-        "Manganato",
-        lambda s: _probe_search_then_chapters(s, "naruto"),
-    ),
-    "mangahub.io": (
-        "MangaHub", lambda s: _probe_search_then_chapters(s, "one piece"),
-    ),
+    # ── Aggregators (full pipeline) ──
+    "mangadex.org": ProbeSpec("API client", query="one piece"),
+    "mangapill.com": ProbeSpec("Simple HTTP aggregator", query="one piece"),
+    "tcbonepiecechapters.com": ProbeSpec("TCB Scans (project list)",
+                                           query="one piece"),
+    "mangakakalot.com": ProbeSpec("Mangakakalot", query="naruto"),
+    "manganato.com": ProbeSpec("Manganato", query="naruto"),
+    "mangahub.io": ProbeSpec("MangaHub", query="one piece"),
 
     # ── One representative per template family ──
-    "dddmanga.com": (
-        "NuxtSSR template (single-manga)",
-        _probe_single_manga_chapters,
-    ),
-    "akiramanga.com": (
-        "OGImageMeta template (single-manga)",
-        _probe_single_manga_chapters,
-    ),
-    "overlord-manga.online": (
-        "LaiondCDN template (single-manga)",
-        _probe_single_manga_chapters,
-    ),
-    "hxhmanga.com": (
-        "Mangosm template (single-manga)",
-        _probe_single_manga_chapters,
-    ),
-    "hiperdex.com": (
-        "WordPress Madara template (aggregator)",
-        lambda s: _probe_search_then_chapters(s, "solo leveling"),
-    ),
+    "dddmanga.com": ProbeSpec("NuxtSSR template (single-manga)"),
+    "akiramanga.com": ProbeSpec("OGImageMeta template (single-manga)"),
+    "overlord-manga.online": ProbeSpec("LaiondCDN template (single-manga)"),
+    "hxhmanga.com": ProbeSpec("Mangosm template (single-manga)"),
+    "hiperdex.com": ProbeSpec("WordPress Madara template (aggregator)",
+                                query="solo leveling"),
 
     # ── ReadManga base family ──
-    "readsnk.com": (
-        "ReadManga base (Attack on Titan)",
-        lambda s: _probe_search_then_chapters(s, "attack on titan",
-                                                do_chapters=False),
-    ),
+    # Search-only: chapter listing needs a manga URL slug this site's
+    # search results don't provide reliably.
+    "readsnk.com": ProbeSpec("ReadManga base (Attack on Titan)",
+                               query="attack on titan",
+                               check_chapters=False),
 }
+
+
+def _fail_message(domain: str, failure: StageFailure) -> str:
+    """Multi-line failure: broken stage first, then what already passed."""
+    lines = [f"[{failure.failed.status}:{failure.failed.stage}] "
+             f"{domain}: {failure.failed.detail}"]
+    for s in failure.stages:
+        if s is failure.failed:
+            mark = "FAIL"
+        elif s.status == STATUS_OK:
+            mark = "OK"
+        else:
+            mark = "WARN"
+        lines.append(f"  {mark} {s.stage:12s} {s.detail}  ({s.elapsed_ms:.0f}ms)")
+    return "\n".join(lines)
 
 
 @pytest.mark.live
 @pytest.mark.health
-@pytest.mark.parametrize("domain,description,probe",
-                          [(d, desc, fn) for d, (desc, fn) in PARSING_PROBES.items()],
+@pytest.mark.parametrize("domain,spec",
+                          list(PARSING_PROBES.items()),
                           ids=list(PARSING_PROBES.keys()))
-def test_scraper_parses_live_site(domain, description, probe, health_recorder):
-    """Full end-to-end check: reachability + parser still extracts data."""
+def test_scraper_pipeline_live(domain, spec, health_recorder):
+    """Stage-by-stage check: reachability, search, chapters, pages, image."""
     # 1. Reachability first — fail fast if the site is dead.
-    base = f"https://{domain}"
-    reach = probe_url(base)
+    reach = probe_url(f"https://{domain}")
+    stages = [StageResult(STAGE_REACHABILITY, reach.status, reach.detail,
+                            reach.elapsed_ms)]
     if reach.status == STATUS_DEAD:
-        health_recorder(reach)
-        pytest.fail(f"[DEAD] {domain}: {reach.detail}")
-    if reach.status == STATUS_PROTECTED:
-        # Real scraper bypasses Cloudflare — still try the probe.
-        pass
+        health_recorder(HealthResult(
+            domain, STATUS_DEAD, STAGE_REACHABILITY, reach.detail,
+            reach.elapsed_ms, extra={"stages": [asdict(s) for s in stages]}))
+        pytest.fail(f"[DEAD:reachability] {domain}: {reach.detail}")
+    # PROTECTED is not fatal — the real scraper bypasses Cloudflare,
+    # so still run the pipeline and let its stages decide.
 
-    # 2. Run the probe. Wraps any exception into STALE-style failure.
+    # 2. Walk the pipeline; first broken stage raises StageFailure.
     scraper = get_scraper(domain)
+    pipe = ScraperPipeline(scraper, domain)
+    pipe.stages = stages
+    failure = None
     try:
-        probe(scraper)
-        result = HealthResult(domain, STATUS_OK, description,
-                                reach.elapsed_ms)
-    except pytest.skip.Exception:
-        raise
-    except (pytest.fail.Exception, AssertionError) as e:
-        result = HealthResult(domain, STATUS_STALE, str(e), reach.elapsed_ms)
-        health_recorder(result)
-        raise
-    except Exception as e:
-        result = HealthResult(domain, STATUS_STALE,
-                                f"{type(e).__name__}: {e}", reach.elapsed_ms)
-        health_recorder(result)
-        raise
+        if spec.query is None:
+            manga_url = scraper_base_url(scraper)
+        else:
+            results = pipe.search(spec.query)
+            manga_url = results[0].url
+        if spec.check_chapters:
+            chapters = pipe.chapters(manga_url)
+            if spec.check_pages:
+                pages = pipe.pages(chapters[0])
+                if spec.check_image:
+                    pipe.image(pages[0])
+    except StageFailure as e:
+        health_recorder(HealthResult(
+            domain, e.failed.status, e.failed.stage, e.failed.detail,
+            reach.elapsed_ms,
+            extra={"stages": [asdict(s) for s in e.stages]}))
+        failure = e
 
+    if failure:
+        pytest.fail(_fail_message(domain, failure), pytrace=False)
+
+    result = HealthResult(
+        domain, STATUS_OK, "", spec.description, reach.elapsed_ms,
+        extra={"stages": [asdict(s) for s in pipe.stages]})
     health_recorder(result)
-    print(f"[{result.status:9s}] {domain:38s} {description}")
+    ran = ", ".join(s.stage for s in pipe.stages)
+    print(f"[{result.status:9s}] {domain:38s} {spec.description} ({ran})")
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -188,10 +187,12 @@ def test_zzz_health_summary_report():  # name puts it last alphabetically
 
     by_status: dict[str, list[str]] = {}
     for r in _RESULTS:
-        by_status.setdefault(r.status, []).append(r.domain)
+        label = f"{r.domain} (broke at: {r.stage})" if r.stage else r.domain
+        by_status.setdefault(r.status, []).append(label)
 
     lines = ["", "=" * 60, "SCRAPER HEALTH SUMMARY", "=" * 60]
-    for status in (STATUS_OK, STATUS_PROTECTED, STATUS_STALE, STATUS_DEAD):
+    for status in (STATUS_OK, STATUS_PROTECTED, STATUS_STALE,
+                     STATUS_HTTP_ERROR, STATUS_DEAD):
         domains = by_status.get(status, [])
         lines.append(f"{status:10s}: {len(domains):4d}")
         for d in sorted(domains):


### PR DESCRIPTION
## Summary

Adds staged live scraper diagnostics so curated probes report the first broken stage instead of one generic stale parser result.

- Records reachability, search, chapters, pages, and image download stages per source
- Adds `failures_by_stage` and per-stage rows to the JSON health report
- Documents the focused live probe commands in the contributor guide

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behaviour change)
- [x] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

None.