### PR TITLE
fix(mangafire): restore search results

### DIFF
--- a/memanga/scrapers/mangafire.py
+++ b/memanga/scrapers/mangafire.py
@@ -4,11 +4,11 @@ MangaFire.to scraper using the site's JSON API.
 MangaFire moved from server-rendered /manga/slug.hid pages with /ajax
 endpoints to an SPA under /title/hid-slug backed by a JSON API:
 
+- GET /api/titles?keyword={query}                              (search)
 - GET /api/titles/{hid}/chapters?language=en&limit=100&page=N  (chapter list)
 - GET /api/chapters/{chapter_id}                               (page image URLs)
 
-Both work with plain HTTP (no VRF token needed). Search still goes through
-a persistent Playwright Firefox (see VRFGenerator.search).
+All work with plain HTTP (no VRF token or browser needed).
 
 Image descrambling based on:
 - https://github.com/f4rh4d-4hmed/MangaFire-API
@@ -21,10 +21,9 @@ import time
 from io import BytesIO
 from typing import List, Optional, Dict, Tuple
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 from concurrent.futures import ThreadPoolExecutor
 
-from bs4 import BeautifulSoup
 from PIL import Image
 
 from .base import BaseScraper, Chapter, Manga
@@ -315,90 +314,6 @@ class VRFGenerator:
             self._get_chapter_pages_in_thread, chapter_url, timeout=120,
         )
 
-    # ------------------------------------------------------------------
-    # Search via persistent browser
-    # ------------------------------------------------------------------
-    # MangaFire returns 403 to plain HTTP (Cloudflare), so search must
-    # go through a real browser. Launching a fresh Firefox per call
-    # adds ~5-10 s of cold-start latency on top of the actual search
-    # work, which on slower networks pushes MangaFire past the point
-    # the GUI considers it usable. Reusing the persistent VRFGenerator
-    # browser drops per-search cost to ~0.5 s after warm-up.
-    def _search_in_thread(self, query: str) -> List[Manga]:
-        """Run a search using the persistent Firefox in this thread.
-
-        Must be called via `_run_serialized` (same lock as chapter-page
-        extraction) — otherwise concurrent calls would race on the same
-        thread-local `_vrf_thread_local.page`.
-        """
-        page = self._ensure_browser_in_thread()
-
-        results: List[Manga] = []
-        try:
-            # Hit the homepage so the search bar is available + Cloudflare
-            # cookies seed on first call. After the first warm-up this is
-            # cached and returns in <500 ms.
-            page.goto(
-                'https://mangafire.to/',
-                wait_until='domcontentloaded',
-                timeout=60000,
-            )
-            # The search bar redirects to /filter?keyword=…&vrf=<token>.
-            # The server-signed VRF token is not constructible locally, so
-            # the search bar is used instead of building the URL directly.
-            si = page.locator(
-                'input[placeholder*="Search"], input[name="keyword"]'
-            ).first
-            si.fill(query)
-            si.press('Enter')
-            page.wait_for_load_state('domcontentloaded', timeout=30000)
-            # Wait for the first result row OR give up after 10 s. Using
-            # wait_for_selector instead of a fixed sleep means fast
-            # responses come back fast and empty/blocked responses don't
-            # hold the lock longer than necessary.
-            try:
-                page.wait_for_selector(
-                    '.info a[href*="/manga/"]', timeout=10000,
-                )
-            except Exception:
-                pass
-
-            soup = BeautifulSoup(page.content(), 'html.parser')
-            seen_urls = set()
-            for link in soup.select('.info a[href*="/manga/"]'):
-                href = link.get('href', '')
-                title = link.get_text(strip=True)
-                if not title or len(title) < 2:
-                    continue
-                full_url = href if href.startswith('http') \
-                    else f"https://mangafire.to{href}"
-                if full_url in seen_urls:
-                    continue
-                seen_urls.add(full_url)
-                cover_url = None
-                parent = link.find_parent(class_='unit')
-                if parent:
-                    img = parent.select_one('.inner img')
-                    if img:
-                        cover_url = img.get('src')
-                results.append(Manga(
-                    title=title, url=full_url, cover_url=cover_url,
-                ))
-        except Exception as e:
-            print(f"[MangaFire] Search error (persistent browser): {e}")
-        return results[:10]
-
-    def search(self, query: str) -> List[Manga]:
-        """Search via the persistent VRFGenerator browser.
-
-        Public entry point — runs `_search_in_thread` under the same
-        executor lock as chapter-page extraction so they share the
-        thread-local browser without racing.
-        """
-        return self._run_serialized(
-            self._search_in_thread, query, timeout=60,
-        )
-
     def _close_in_thread(self):
         """Clean up browser resources - runs in executor thread."""
         try:
@@ -474,8 +389,7 @@ class MangaFireScraper(BaseScraper):
     # Supported languages
     LANGUAGES = ['en', 'es', 'es-la', 'fr', 'ja', 'pt', 'pt-br']
 
-    # Search now goes through VRFGenerator's persistent browser
-    # (see search() below), avoiding a per-scraper executor.
+    # Search uses the JSON API directly (see search() below).
     # Chapter-pages route through VRFGenerator's own _run_serialized.
 
     def __init__(self):
@@ -588,14 +502,37 @@ class MangaFireScraper(BaseScraper):
         return manga_id, lang, chap_num
 
     def search(self, query: str) -> List[Manga]:
-        """Search for manga via the persistent VRFGenerator browser.
+        """Search for manga via MangaFire's JSON API.
 
-        Routes through `get_vrf_generator()` (a process-wide singleton
-        that keeps Firefox open across calls) instead of launching a
-        fresh browser per query, so per-search latency stays under a
-        second once the browser is warm.
+        The browse page renders results client-side, but the SPA's own
+        /api/titles endpoint returns the search payload directly.
         """
-        return get_vrf_generator().search(query)
+        api_url = f"{self.base_url}/api/titles?keyword={quote(query, safe='')}"
+        data = self._api_get_json(api_url)
+        items = data.get('items')
+        if not isinstance(items, list):
+            raise MangaFireError(
+                f"MangaFire returned an invalid search response for {api_url}"
+            )
+
+        results: List[Manga] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            title = str(item.get('title') or '').strip()
+            path = item.get('url') or ''
+            if not title or not path:
+                continue
+            full_url = path if path.startswith('http') \
+                else f"{self.base_url}/{path.lstrip('/')}"
+            poster = item.get('poster') \
+                if isinstance(item.get('poster'), dict) else {}
+            cover_url = (poster.get('medium') or poster.get('large')
+                         or poster.get('small'))
+            results.append(Manga(
+                title=title, url=full_url, cover_url=cover_url,
+            ))
+        return results[:10]
 
     def _chapter_error_message(self, ajax_url: str, data: dict) -> str:
         """Build a concise error from MangaFire/Cloudflare AJAX envelopes."""

--- a/tests/unit/scrapers/test_base_interface.py
+++ b/tests/unit/scrapers/test_base_interface.py
@@ -187,48 +187,60 @@ class TestGetScraperRegistry:
             assert hasattr(s, m), f"{domain} scraper missing {m}"
 
 
-class TestMangaFireSearchUsesPersistentBrowser:
-    """Regression: launching a fresh Firefox per call adds ~5-10 s of
-    cold-start latency, which on slower networks pushes MangaFire past
-    the search worker's per-source budget and the source never makes
-    it into the result list. search() must route through VRFGenerator,
-    which keeps Firefox open across calls (chapter-page extraction
-    already does this; search joins the same persistent browser).
+class TestMangaFireSearchUsesJsonApi:
+    """Regression (issue #74): the old flow drove the homepage search bar
+    through the persistent Playwright browser and scraped
+    `.info a[href*="/manga/"]` result links. The browse page the search
+    bar redirects to renders results client-side under /title/hid-slug
+    links, so that selector matched nothing and every search returned 0
+    results. search() must hit GET /api/titles?keyword=... over plain HTTP
+    instead - no browser involved at all.
     """
 
-    def test_search_delegates_to_vrf_generator(self, monkeypatch):
+    class _FakeResponse:
+        status_code = 200
+
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _FakeSession:
+        def __init__(self, payload):
+            self._payload = payload
+            self.urls = []
+
+        def get(self, url, **kwargs):
+            self.urls.append(url)
+            return TestMangaFireSearchUsesJsonApi._FakeResponse(self._payload)
+
+    def test_search_hits_titles_api_with_encoded_keyword(self):
         from memanga.scrapers import mangafire as mf
-
-        captured = {"called_with": None, "n": 0}
-
-        class _FakeVRF:
-            def search(self, query):
-                captured["called_with"] = query
-                captured["n"] += 1
-                return [mf.Manga(title="Stub", url="https://x/m")]
-
-        monkeypatch.setattr(mf, "get_vrf_generator", lambda: _FakeVRF())
 
         scraper = mf.MangaFireScraper()
-        results = scraper.search("Blue Lock")
+        scraper.session = self._FakeSession({
+            "items": [{
+                "title": "Blue Lock",
+                "url": "/title/abc-blue-lock",
+                "poster": {"medium": "https://cdn.example/bl@280.jpg"},
+            }],
+            "meta": {"total": 1},
+        })
 
-        assert captured["n"] == 1
-        assert captured["called_with"] == "Blue Lock"
-        assert results and results[0].title == "Stub"
+        results = scraper.search("blue lock/2")
 
-    def test_search_does_not_launch_new_firefox(self, monkeypatch):
-        """Hard guard: calling MangaFireScraper.search() must NOT
-        invoke `playwright.firefox.launch` directly. Re-introducing the
-        per-call launch pattern fails this test.
+        assert scraper.session.urls == [
+            "https://mangafire.to/api/titles?keyword=blue%20lock%2F2",
+        ]
+        assert results and results[0].url == "https://mangafire.to/title/abc-blue-lock"
+
+    def test_search_does_not_launch_firefox(self, monkeypatch):
+        """Hard guard: calling MangaFireScraper.search() must NOT start
+        Playwright at all - search works over plain HTTP.
         """
         from memanga.scrapers import mangafire as mf
-        # Stub the VRF generator so the real persistent browser doesn't
-        # spin up either — we only care that no fresh launch happens.
-        monkeypatch.setattr(
-            mf, "get_vrf_generator",
-            lambda: type("V", (), {"search": lambda self, q: []})(),
-        )
-        # Trap any direct sync_playwright().start() call.
+
         called = {"n": 0}
 
         class _BoomPW:
@@ -237,7 +249,7 @@ class TestMangaFireSearchUsesPersistentBrowser:
             firefox = type("_F", (), {
                 "launch": staticmethod(
                     lambda *a, **k: (_ for _ in ()).throw(
-                        AssertionError("search must not launch a fresh Firefox"),
+                        AssertionError("search must not launch Firefox"),
                     )
                 ),
             })()
@@ -248,8 +260,9 @@ class TestMangaFireSearchUsesPersistentBrowser:
         monkeypatch.setattr(pwapi, "sync_playwright", lambda: _BoomPW())
 
         scraper = mf.MangaFireScraper()
+        scraper.session = self._FakeSession({"items": [], "meta": {}})
         scraper.search("x")
-        assert called["n"] == 0, "search should reuse VRF browser, not launch a new one"
+        assert called["n"] == 0, "search must stay browser-free"
 
 
 class TestWeebCentralSearchHitsDataEndpoint:

--- a/tests/unit/scrapers/test_mangafire.py
+++ b/tests/unit/scrapers/test_mangafire.py
@@ -158,6 +158,89 @@ class TestMangaFireGetPages:
         assert pages == ["https://cdn.example/002.jpg"]
 
 
+class TestMangaFireSearch:
+    """Issue #74: search must use GET /api/titles?keyword=... - the old
+    browser-driven homepage search scraped `/manga/` result links that
+    the browse page no longer renders, so it always found 0 results.
+    """
+
+    def test_parses_api_items_into_manga(self):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={
+                "items": [
+                    {
+                        "title": "One Piece",
+                        "url": "/title/dkw-one-piece",
+                        "poster": {
+                            "small": "https://cdn.example/op@100.jpg",
+                            "medium": "https://cdn.example/op@280.jpg",
+                        },
+                    },
+                    {
+                        # No medium poster - falls back to large.
+                        "title": "One Piece Academy",
+                        "url": "https://mangafire.to/title/1qz0v-one-piece-academy",
+                        "poster": {"large": "https://cdn.example/opa.jpg"},
+                    },
+                    {"title": "", "url": "/title/x-skipped-no-title"},
+                    {"title": "Skipped, no URL"},
+                    "not-a-dict",
+                ],
+                "meta": {"total": 4},
+            }),
+        ])
+
+        results = scraper.search("one piece")
+
+        assert [(m.title, m.url, m.cover_url) for m in results] == [
+            ("One Piece", "https://mangafire.to/title/dkw-one-piece",
+             "https://cdn.example/op@280.jpg"),
+            ("One Piece Academy",
+             "https://mangafire.to/title/1qz0v-one-piece-academy",
+             "https://cdn.example/opa.jpg"),
+        ]
+
+    def test_caps_results_at_ten(self):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={
+                "items": [
+                    {"title": f"Manga {i}", "url": f"/title/h{i}-manga-{i}"}
+                    for i in range(20)
+                ],
+            }),
+        ])
+
+        assert len(scraper.search("manga")) == 10
+
+    def test_invalid_search_payload_raises(self):
+        from memanga.scrapers.mangafire import MangaFireError, MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={"message": "shape changed"}),
+        ])
+
+        with pytest.raises(MangaFireError, match="invalid search response"):
+            scraper.search("one piece")
+
+    def test_http_error_raises_instead_of_empty_list(self):
+        from memanga.scrapers.mangafire import MangaFireError, MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(status_code=503, payload={}),
+        ])
+
+        with pytest.raises(MangaFireError, match="HTTP 503"):
+            scraper.search("one piece")
+
+
 class TestVRFBrowserInitAtomicity:
     """Issue #28: a failed firefox.launch() must surface the real error,
     not a masking AttributeError on a half-initialised thread-local.


### PR DESCRIPTION
## Summary

Restores MangaFire search by using the site's JSON title endpoint instead of scraping the client-rendered browse page.

- Calls `/api/titles?keyword=...` directly for MangaFire search
- Parses API title items into MeManga search results with cover URLs
- Updates MangaFire regression tests to cover API search and browser-free search

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #74.
