### PR TITLE
feat(scraper): add MangaPark source

### DIFF
--- a/memanga/scrapers/__init__.py
+++ b/memanga/scrapers/__init__.py
@@ -8,6 +8,7 @@ Working sources:
 - Mangakatana (mangakatana.com) - General library
 - MangaDex (mangadex.org) - Community uploads (skip Shueisha)
 - Mangapill (mangapill.com) - Large library, no Cloudflare
+- MangaPark (mangapark1.com) - Large library, simple requests
 - MangaReader (mangareader.to) - Large library, clean UI
 - MangaSee (mangasee123.com) - High quality scans
 - MangaBuddy (mangabuddy.com) - Popular aggregator
@@ -30,6 +31,7 @@ from .asurascans import AsuraScansScraper
 from .mangakatana import MangakatanataScraper
 from .mangadex import MangaDexScraper
 from .mangapill import MangapillScraper
+from .mangapark import MangaParkScraper
 from .mangareader import MangaReaderScraper
 from .mangafire import MangaFireScraper
 from .mangasee import MangaSeeScraper
@@ -184,6 +186,9 @@ SCRAPERS = {
 
     # Mangapill - Large library (no Cloudflare, simple requests)
     "mangapill.com": MangapillScraper,
+
+    # MangaPark - current working domain
+    "mangapark1.com": MangaParkScraper,
 
     # MangaReader.to
     "mangareader.to": MangaReaderScraper,
@@ -665,6 +670,7 @@ def list_supported_sources():
 POPULAR_SOURCES = [
     "mangadex.org",
     "mangapill.com",
+    "mangapark1.com",
     "mangafire.to",
     "mangabuddy.com",
     "weebcentral.com",

--- a/memanga/scrapers/mangapark.py
+++ b/memanga/scrapers/mangapark.py
@@ -1,0 +1,198 @@
+"""
+MangaPark scraper
+https://mangapark1.com
+
+MangaPark's older domains are unreliable from normal requests, while
+mangapark1.com currently serves the catalog without a browser challenge.
+Chapter lists come from the site's JSON endpoint, and page images need a
+Referer header when downloaded from the CDN.
+"""
+
+import re
+import logging
+from typing import List
+from urllib.parse import quote_plus
+from .base import BaseScraper, Chapter, Manga
+
+logger = logging.getLogger(__name__)
+
+
+class MangaParkScraper(BaseScraper):
+    """Scraper for MangaPark (mangapark1.com)."""
+
+    name = "mangapark"
+    base_url = "https://mangapark1.com"
+
+    def search(self, query: str) -> List[Manga]:
+        """Search for manga by title via /filter?keyword=..."""
+        from bs4 import BeautifulSoup
+
+        url = f"{self.base_url}/filter?keyword={quote_plus(query)}"
+        html = self._get_html(url)
+        soup = BeautifulSoup(html, "html.parser")
+
+        results = []
+        seen = set()
+        # Result cards are div.unit; each holds a poster link and a text
+        # title link, both pointing at /manga/<slug>.
+        for unit in soup.select("div.unit"):
+            link = unit.select_one('a[href*="/manga/"]')
+            if not link:
+                continue
+            href = link.get("href", "")
+            if not href or href in seen:
+                continue
+            seen.add(href)
+
+            manga_url = href if href.startswith("http") else f"{self.base_url}{href}"
+
+            img = unit.find("img")
+            # Poster link text is just a flag emoji; prefer the info-block
+            # text link, then the cover's alt attribute.
+            title = ""
+            for a in unit.select('a[href*="/manga/"]'):
+                text = a.get_text(strip=True)
+                if text and not a.find("img") and len(text) > 2:
+                    title = text
+                    break
+            if not title and img:
+                title = img.get("alt", "")
+            if not title:
+                title = href.rstrip("/").split("/")[-1].replace("-", " ").title()
+
+            cover_url = None
+            if img:
+                cover_url = img.get("data-src") or img.get("src")
+                if cover_url and cover_url.startswith("/"):
+                    cover_url = f"{self.base_url}{cover_url}"
+
+            if title and len(title) > 2:
+                results.append(Manga(
+                    title=title,
+                    url=manga_url,
+                    cover_url=cover_url,
+                ))
+
+        return results[:10]
+
+    def _slug_from_url(self, manga_url: str) -> str:
+        """Extract the comic slug from a /manga/<slug> URL."""
+        match = re.search(r"/manga/([^/?#]+)", manga_url)
+        if not match:
+            raise ValueError(f"Not a MangaPark manga URL: {manga_url}")
+        return match.group(1)
+
+    def get_chapters(self, manga_url: str) -> List[Chapter]:
+        """Get all chapters via the JSON chapter-list endpoint.
+
+        The manga page HTML only embeds the latest ~20 chapters; the
+        site's own "Load All Chapters" button calls this endpoint.
+        """
+        slug = self._slug_from_url(manga_url)
+        try:
+            data = self._get_json(
+                f"{self.base_url}/get-chapter-list",
+                params={"slug": slug},
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+            entries = data.get("data", []) if data.get("success") else []
+        except Exception as e:
+            logger.debug(f"Chapter-list endpoint failed for {slug}: {e}")
+            entries = []
+
+        chapters = []
+        seen = set()
+        for entry in entries:
+            chapter_slug = entry.get("chapter_slug")
+            if not chapter_slug or chapter_slug in seen:
+                continue
+            seen.add(chapter_slug)
+
+            num = entry.get("chapter_num")
+            if isinstance(num, float) and num.is_integer():
+                num = int(num)
+            number = str(num) if num is not None else ""
+            if not number:
+                match = re.search(r"(\d+\.?\d*)", chapter_slug)
+                number = match.group(1) if match else chapter_slug
+
+            chapters.append(Chapter(
+                number=number,
+                title=entry.get("chapter_name"),
+                url=f"{self.base_url}/read/{slug}/{chapter_slug}",
+                date=entry.get("updated_at"),
+            ))
+
+        if not chapters:
+            chapters = self._chapters_from_html(manga_url, slug)
+
+        return sorted(chapters)
+
+    def _chapters_from_html(self, manga_url: str, slug: str) -> List[Chapter]:
+        """Fallback: scrape /read/<slug>/... links off the manga page."""
+        from bs4 import BeautifulSoup
+
+        html = self._get_html(manga_url)
+        soup = BeautifulSoup(html, "html.parser")
+
+        chapters = []
+        seen = set()
+        for link in soup.select(f'a[href*="/read/{slug}/"]'):
+            href = link.get("href", "")
+            if not href or href in seen:
+                continue
+            seen.add(href)
+
+            chapter_url = href if href.startswith("http") else f"{self.base_url}{href}"
+            text = link.get("title") or link.get_text(strip=True)
+            match = re.search(r"chapter[_\s-]*(\d+\.?\d*)", text, re.I) \
+                or re.search(r"(\d+\.?\d*)", text) \
+                or re.search(r"chapter[_\s-]*(\d+)(?:-(\d+))?", href, re.I)
+            if match and len(match.groups()) > 1 and match.group(2):
+                number = f"{match.group(1)}.{match.group(2)}"
+            else:
+                number = match.group(1) if match else text
+
+            chapters.append(Chapter(
+                number=number,
+                title=text or None,
+                url=chapter_url,
+            ))
+
+        return chapters
+
+    def get_pages(self, chapter_url: str) -> List[str]:
+        """Get page image URLs from the reader page.
+
+        Pages are lazyload <img data-src> tags inside div.pages; the
+        CDN URLs are server-rendered, no JS needed.
+        """
+        from bs4 import BeautifulSoup
+
+        html = self._get_html(chapter_url)
+        soup = BeautifulSoup(html, "html.parser")
+
+        pages = []
+        seen = set()
+        for img in soup.select("div.pages img"):
+            src = img.get("data-src") or img.get("src")
+            if not src or "/assets/" in src or src in seen:
+                continue
+            seen.add(src)
+            pages.append(src)
+
+        return pages
+
+    def download_image(self, url: str, path) -> bool:
+        """Download image with Referer — the CDN 403s without it."""
+        from pathlib import Path
+
+        try:
+            response = self._request(url, headers={"Referer": f"{self.base_url}/"})
+            path = Path(path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(response.content)
+            return True
+        except Exception as e:
+            logger.debug(f"Failed to download {url}: {e}")
+            return False

--- a/tests/scrapers/fixtures/mangapark/chapter.html
+++ b/tests/scrapers/fixtures/mangapark/chapter.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="cdn-thumb-domain" content="https://cdn2.holdingyouclose.xyz">
+</head>
+<body>
+<img src="/assets/images/manga-park.webp" alt="MangaPark Logo">
+<div class="pages longstrip">
+  <div class="page fit-w">
+    <div class="img loaded"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp" data-src='https://cdn2.holdingyouclose.xyz/one-piece/1/0.webp' data-number="0"></div>
+  </div>
+  <div class="page fit-w">
+    <div class="img loaded"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp" data-src='https://cdn2.holdingyouclose.xyz/one-piece/1/1.webp' data-number="1"></div>
+  </div>
+  <!-- duplicate of page 1: must be deduped -->
+  <div class="page fit-w">
+    <div class="img loaded"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp" data-src='https://cdn2.holdingyouclose.xyz/one-piece/1/1.webp' data-number="1"></div>
+  </div>
+  <div class="page fit-w">
+    <div class="img loaded"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp" data-src='https://cdn2.holdingyouclose.xyz/one-piece/1/2.webp' data-number="2"></div>
+  </div>
+  <!-- placeholder-only img: must be skipped -->
+  <div class="page fit-w">
+    <div class="img"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/scrapers/fixtures/mangapark/chapter_list.json
+++ b/tests/scrapers/fixtures/mangapark/chapter_list.json
@@ -1,0 +1,11 @@
+{
+  "success": true,
+  "data": [
+    {"comic_id": 4280, "chapter_id": 1241, "chapter_name": "Chapter 1187", "chapter_slug": "chapter-1187", "updated_at": "2026-07-03 03:21:33", "chapter_num": 1187},
+    {"comic_id": 4280, "chapter_id": 1139, "chapter_name": "Chapter 1186", "chapter_slug": "chapter-1186", "updated_at": "2026-06-28 03:40:34", "chapter_num": 1186},
+    {"comic_id": 4280, "chapter_id": 901, "chapter_name": "Chapter 10.5", "chapter_slug": "chapter-10-5", "updated_at": "2026-06-01 00:00:00", "chapter_num": 10.5},
+    {"comic_id": 4280, "chapter_id": 12, "chapter_name": "Chapter 1", "chapter_slug": "chapter-1", "updated_at": "2026-05-01 00:00:00", "chapter_num": 1.0},
+    {"comic_id": 4280, "chapter_id": 12, "chapter_name": "Chapter 1", "chapter_slug": "chapter-1", "updated_at": "2026-05-01 00:00:00", "chapter_num": 1.0}
+  ],
+  "total": 5
+}

--- a/tests/scrapers/fixtures/mangapark/manga.html
+++ b/tests/scrapers/fixtures/mangapark/manga.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="tab-content" data-name="chapter">
+  <div class="list-body">
+    <ul id="chapter-list" class="scroll-sm">
+      <li class="item" data-number="1241">
+        <a href="https://mangapark1.com/read/one-piece/chapter-1187" title="Chapter 1187"><span>Chapter 1187: </span> <span>4 day ago</span></a>
+      </li>
+      <li class="item" data-number="1139">
+        <a href="https://mangapark1.com/read/one-piece/chapter-1186" title="Chapter 1186"><span>Chapter 1186: </span> <span>9 day ago</span></a>
+      </li>
+      <li class="item" data-number="901">
+        <a href="https://mangapark1.com/read/one-piece/chapter-10-5" title="Chapter 10.5"><span>Chapter 10.5: </span> <span>1 year ago</span></a>
+      </li>
+      <li class="item text-center load-all-btn">
+        <button id="load-all-chapters-btn" data-comic-slug="one-piece">Load All Chapters</button>
+      </li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/scrapers/fixtures/mangapark/search.html
+++ b/tests/scrapers/fixtures/mangapark/search.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="original card-lg">
+  <div class="unit item-4280">
+    <div class="inner">
+      <a href="https://mangapark1.com/manga/one-piece" class="poster" style="position:relative;">
+        <div><img src="/assets/images/image-default-bbato.webp" data-src="https://cdn2.holdingyouclose.xyz/thumb/one-piece.webp" alt="One Piece" class="lazyload image-thumb" referrerpolicy="origin"></div>
+        <span class="lang-flag-badge" title="EN">🇬🇧</span>
+      </a>
+      <div class="info">
+        <div><a class="type" href="https://mangapark1.com/type/manga" style="margin-right:4px;">Manga</a></div>
+        <a href="https://mangapark1.com/manga/one-piece">One Piece</a>
+        <ul class="content" data-name="chap">
+          <li><a href="https://mangapark1.com/read/one-piece/chapter-1187" title="Chapter 1187"><span>Chapter 1187</span> <span>4 day ago</span></a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="unit item-4281">
+    <div class="inner">
+      <a href="https://mangapark1.com/manga/one-piece-official-colored" class="poster">
+        <div><img src="/assets/images/image-default-bbato.webp" data-src="https://cdn2.holdingyouclose.xyz/thumb/one-piece-official-colored.webp" alt="One Piece (Official Colored)" class="lazyload image-thumb"></div>
+        <span class="lang-flag-badge" title="EN">🇬🇧</span>
+      </a>
+      <div class="info">
+        <div><a class="type" href="https://mangapark1.com/type/manga">Manga</a></div>
+        <a href="https://mangapark1.com/manga/one-piece-official-colored">One Piece (Official Colored)</a>
+      </div>
+    </div>
+  </div>
+  <!-- duplicate URL: must be deduped -->
+  <div class="unit item-4280">
+    <div class="inner">
+      <a href="https://mangapark1.com/manga/one-piece" class="poster">
+        <div><img src="/assets/images/image-default-bbato.webp" data-src="https://cdn2.holdingyouclose.xyz/thumb/one-piece.webp" alt="One Piece" class="lazyload image-thumb"></div>
+      </a>
+    </div>
+  </div>
+  <!-- no info text link: title must fall back to img alt -->
+  <div class="unit item-5000">
+    <div class="inner">
+      <a href="https://mangapark1.com/manga/chopperman-yuke-yuke-minna-no-chopper-sensei" class="poster">
+        <div><img src="/assets/images/image-default-bbato.webp" data-src="https://cdn2.holdingyouclose.xyz/thumb/chopperman.webp" alt="Chopperman - Yuke Yuke! Minna no Chopper-sensei" class="lazyload image-thumb"></div>
+        <span class="lang-flag-badge" title="EN">🇬🇧</span>
+      </a>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/scrapers/live/test_live_parsing.py
+++ b/tests/scrapers/live/test_live_parsing.py
@@ -67,6 +67,7 @@ PARSING_PROBES = {
     # ── Aggregators (full pipeline) ──
     "mangadex.org": ProbeSpec("API client", query="one piece"),
     "mangapill.com": ProbeSpec("Simple HTTP aggregator", query="one piece"),
+    "mangapark1.com": ProbeSpec("MangaPark", query="one piece"),
     "tcbonepiecechapters.com": ProbeSpec("TCB Scans (project list)",
                                            query="one piece"),
     "mangakakalot.com": ProbeSpec("Mangakakalot", query="naruto"),

--- a/tests/scrapers/test_mangapark.py
+++ b/tests/scrapers/test_mangapark.py
@@ -1,0 +1,124 @@
+"""HTML/JSON-fixture tests for MangaParkScraper (mangapark1.com)."""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers.mangapark import MangaParkScraper
+
+
+@pytest.fixture
+def scraper():
+    return MangaParkScraper()
+
+
+class TestSearch:
+    def test_parses_units_and_dedupes(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("mangapark", "search.html"))
+        results = scraper.search("one piece")
+        # 3 unique manga URLs after dedup of the repeated one-piece card
+        assert len(results) == 3
+        by_url = {r.url: r for r in results}
+        assert "https://mangapark1.com/manga/one-piece" in by_url
+        assert by_url["https://mangapark1.com/manga/one-piece"].title == "One Piece"
+        assert by_url["https://mangapark1.com/manga/one-piece"].cover_url == \
+            "https://cdn2.holdingyouclose.xyz/thumb/one-piece.webp"
+
+    def test_title_falls_back_to_img_alt(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("mangapark", "search.html"))
+        results = scraper.search("chopper")
+        titles = [r.title for r in results]
+        # Card with no info-block text link uses the cover alt text
+        assert "Chopperman - Yuke Yuke! Minna no Chopper-sensei" in titles
+
+    def test_no_results(self, scraper, patch_html):
+        patch_html(scraper, "<html><body></body></html>")
+        assert scraper.search("nothing") == []
+
+
+class TestGetChapters:
+    def test_uses_json_endpoint(self, scraper, patch_json, load_json_fixture):
+        patch_json(scraper, load_json_fixture("mangapark", "chapter_list.json"))
+        chapters = scraper.get_chapters("https://mangapark1.com/manga/one-piece")
+        # 4 unique chapters after dedup of the repeated chapter-1 entry
+        assert len(chapters) == 4
+        # Sorted ascending
+        nums = [c.numeric for c in chapters]
+        assert nums == sorted(nums)
+        # Integer-valued floats normalised: 1.0 -> "1"
+        assert chapters[0].number == "1"
+        # Decimal chapters preserved
+        assert any(c.number == "10.5" for c in chapters)
+        # URLs built from slug + chapter_slug
+        assert chapters[-1].url == \
+            "https://mangapark1.com/read/one-piece/chapter-1187"
+        assert chapters[-1].date == "2026-07-03 03:21:33"
+
+    def test_falls_back_to_html_when_endpoint_fails(
+            self, scraper, monkeypatch, patch_html, load_fixture):
+        def boom(*a, **k):
+            raise IOError("endpoint down")
+        monkeypatch.setattr(scraper, "_get_json", boom)
+        patch_html(scraper, load_fixture("mangapark", "manga.html"))
+        chapters = scraper.get_chapters("https://mangapark1.com/manga/one-piece")
+        assert len(chapters) == 3
+        assert any(c.number == "10.5" for c in chapters)
+        assert all("/read/one-piece/" in c.url for c in chapters)
+
+    def test_rejects_non_manga_url(self, scraper):
+        with pytest.raises(ValueError):
+            scraper.get_chapters("https://mangapark1.com/blog")
+
+
+class TestGetPages:
+    def test_extracts_cdn_urls_skips_placeholders(
+            self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("mangapark", "chapter.html"))
+        pages = scraper.get_pages(
+            "https://mangapark1.com/read/one-piece/chapter-1")
+        # 3 unique pages: duplicate and /assets/ placeholder excluded
+        assert pages == [
+            "https://cdn2.holdingyouclose.xyz/one-piece/1/0.webp",
+            "https://cdn2.holdingyouclose.xyz/one-piece/1/1.webp",
+            "https://cdn2.holdingyouclose.xyz/one-piece/1/2.webp",
+        ]
+
+    def test_no_pages(self, scraper, patch_html):
+        patch_html(scraper, "<html><body></body></html>")
+        assert scraper.get_pages("https://mangapark1.com/read/x/chapter-1") == []
+
+
+class TestDownloadImage:
+    def test_sends_referer_and_writes_file(
+            self, monkeypatch, scraper, tmp_path, fake_response):
+        captured = {}
+
+        def fake_request(url, **kwargs):
+            captured.update(kwargs)
+            return fake_response(content=b"imgdata" * 100)
+
+        monkeypatch.setattr(scraper, "_request", fake_request)
+        ok = scraper.download_image(
+            "https://cdn2.holdingyouclose.xyz/one-piece/1/0.webp",
+            tmp_path / "p.webp")
+        assert ok is True
+        assert (tmp_path / "p.webp").read_bytes() == b"imgdata" * 100
+        assert captured["headers"]["Referer"] == "https://mangapark1.com/"
+
+    def test_failure_returns_false(self, monkeypatch, scraper, tmp_path):
+        def boom(*a, **k):
+            raise IOError("nope")
+        monkeypatch.setattr(scraper, "_request", boom)
+        assert scraper.download_image("https://x", tmp_path / "p.webp") is False
+
+
+class TestRegistry:
+    def test_domain_resolves_to_scraper(self):
+        from memanga.scrapers import get_scraper
+        s = get_scraper("mangapark1.com")
+        assert isinstance(s, MangaParkScraper)
+
+    def test_www_prefix_resolves(self):
+        from memanga.scrapers import get_scraper
+        s = get_scraper("www.mangapark1.com")
+        assert isinstance(s, MangaParkScraper)


### PR DESCRIPTION
## Summary
- add a `mangapark1.com` scraper with search, JSON chapter-list parsing, page extraction, and CDN image downloads
- register MangaPark in supported/popular sources and the live scraper probe set
- add focused fixture coverage for parsing, fallback, registry, and download behavior

## Tests
- `python -m compileall -q memanga tests`
- `venv/bin/pytest tests/scrapers/test_mangapark.py tests/unit/scrapers/test_base_interface.py tests/unit/test_search.py tests/unit/gui/test_workers.py -q`
- `venv/bin/pytest -m live tests/scrapers/live/test_live_parsing.py -k mangapark1 --health-report=/tmp/memanga-mangapark-live-20260707.json -ra -q`
- `venv/bin/python -m memanga.cli search 'one piece' --source mangapark1.com`
- `git diff --check`

Closes #78
