### PR TITLE
chore(release): prepare v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-08
+
+### Added
+- #77 Comix.to is now available as a supported source. Search runs
+  through the rendered search flow, chapter discovery reads paginated
+  chapter rows, and reader image extraction/downloads use the headers
+  required by the site.
+- #78 MangaPark is now available as a supported source through
+  `mangapark1.com`, including search, chapter-list parsing, reader page
+  extraction, CDN image downloads, and live scraper diagnostics.
+- Live scraper diagnostics now include staged parsing probes that make
+  source-specific breakage easier to confirm without running the full
+  application workflow.
+
+### Fixed
+- #74 MangaFire search now reads the current `/api/titles` JSON payload
+  instead of scraping the old browser search page, restoring title
+  discovery for queries such as `one piece`, `ao no hako`, and
+  `super no ura`.
+
 ## [0.3.1] - 2026-07-06
 
 ### Fixed

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.3.1"
+version = "0.3.2"
 description = "Automatic manga downloader with Kindle support"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Prepare the v0.3.2 release metadata and changelog.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #74
Closes #77
Closes #78