### PR TITLE
feat(scraper): add wto source support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- #79 wto.to (active Bato mirror) is now a supported source. It reuses
+  the Bato.to parsers and fetches HTML through Playwright because the
+  site sits behind a Cloudflare managed challenge; when the challenge
+  does not clear, the scraper degrades to empty results instead of
+  crashing. The multi-source search sweep skips it (challenge burns the
+  sweep budget), but add-by-URL routes it correctly. bato.to/batoto.to
+  registrations are unchanged.
+
 ## [0.3.2] - 2026-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Automatic manga downloader with a desktop app and a power-user CLI.**
 
-Track manga across 224 scrapers / 319 domains, read downloaded chapters
+Track manga across 227 scrapers / 322 domains, read downloaded chapters
 in the built-in reader, and optionally email them to your Kindle.
 Works offline once chapters are downloaded.
 
@@ -222,7 +222,7 @@ On macOS / Linux:
 | `config` | Interactive settings editor |
 | `cron install [--time 06:00]` | Schedule a daily `check --auto` job |
 | `cron status` / `cron remove` | Inspect / uninstall the cron job |
-| `sources` | List all 319 supported domains, marking which ones are healthy |
+| `sources` | List all 322 supported domains, marking which ones are healthy |
 | `export FILE` / `import FILE` | Back up or restore your library + state as JSON |
 | `tui` | Launch the in-terminal interactive view |
 

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -1,7 +1,7 @@
 # MeManga Setup & Usage Guide
 
 Automatic manga downloader with desktop GUI + Kindle support. Track
-manga from 224 scrapers / 319 domains, download chapters as
+manga from 227 scrapers / 322 domains, download chapters as
 PDF / EPUB / CBZ / ZIP / JPG / PNG / WEBP, and optionally email
 them to your Kindle.
 

--- a/docs/SUPPORTED_SOURCES.md
+++ b/docs/SUPPORTED_SOURCES.md
@@ -1,6 +1,6 @@
 # Supported Sources
 
-MeManga supports **224 scrapers** covering **319 domains**. This document lists all supported sources.
+MeManga supports **227 scrapers** covering **322 domains**. This document lists all supported sources.
 
 > Some sites listed below are unreachable as of the last audit
 > (mangakakalot.com / mangasee123.com / mangareader.to /
@@ -23,6 +23,7 @@ Large sites with extensive manga libraries.
 | mangafire.to | Playwright | VRF bypass + image descrambling |
 | mangapill.com | Requests | Fast, no Cloudflare |
 | bato.to, batoto.to | Requests | Community-driven |
+| wto.to | Playwright | Bato mirror, Cloudflare challenge (add by URL; search sweep skips it) |
 | comick.io, comick.dev | Requests | Clean API |
 | mangabuddy.com | Requests | Popular aggregator |
 | mangakatana.com | Playwright | General library |

--- a/memanga/scrapers/__init__.py
+++ b/memanga/scrapers/__init__.py
@@ -12,7 +12,7 @@ Working sources:
 - MangaReader (mangareader.to) - Large library, clean UI
 - MangaSee (mangasee123.com) - High quality scans
 - MangaBuddy (mangabuddy.com) - Popular aggregator
-- Bato.to (bato.to) - Community-driven
+- Bato.to (bato.to) - Community-driven; wto.to mirror via Playwright
 - Mangakakalot (mangakakalot.com) - Huge library
 - Manganato (manganato.com) - Same network as Kakalot
 - Mangago (mangago.me) - Large yaoi/shoujo collection
@@ -37,6 +37,7 @@ from .mangafire import MangaFireScraper
 from .mangasee import MangaSeeScraper
 from .mangabuddy import MangaBuddyScraper
 from .batoto import BatoToScraper
+from .wto import WTOScraper
 from .mangakakalot import MangakakalotScraper
 from .manganato import ManganatoScraper
 from .mangago import MangagoScraper
@@ -206,6 +207,9 @@ SCRAPERS = {
     # Bato.to
     "bato.to": BatoToScraper,
     "batoto.to": BatoToScraper,
+
+    # WTO - Bato mirror (same HTML, Cloudflare challenge via Playwright)
+    "wto.to": WTOScraper,
 
     # Mangakakalot
     "mangakakalot.com": MangakakalotScraper,

--- a/memanga/scrapers/wto.py
+++ b/memanga/scrapers/wto.py
@@ -1,0 +1,57 @@
+"""
+WTO scraper - Bato mirror
+https://wto.to
+
+wto.to serves the same Bato-style HTML as bato.to, so all parsing is
+inherited from BatoToScraper. The difference is transport: wto.to sits
+behind a Cloudflare managed challenge that 403s plain requests and
+cloudscraper, so HTML fetches go through Playwright instead.
+
+The challenge does not always auto-resolve for headless browsers.
+When that happens we return the challenge page as-is and the inherited
+parsers yield empty results instead of crashing; live health checks
+classify the domain as PROTECTED.
+"""
+
+import logging
+
+from .batoto import BatoToScraper
+from .playwright_base import PlaywrightScraper
+
+logger = logging.getLogger(__name__)
+
+
+def _is_cf_challenge(html: str) -> bool:
+    """True if the HTML is a Cloudflare interstitial, not real content."""
+    head = html[:3000].lower()
+    return any(
+        marker in head
+        for marker in (
+            "just a moment",
+            "cf-chl",
+            "performing security verification",
+            "cf-turnstile",
+            "ray id",
+        )
+    )
+
+
+class WTOScraper(BatoToScraper, PlaywrightScraper):
+    """Scraper for wto.to (Bato mirror behind Cloudflare)."""
+
+    name = "wto"
+    base_url = "https://wto.to"
+
+    def _get_html(self, url: str) -> str:
+        """Fetch HTML via Playwright so the Cloudflare challenge can run."""
+        html = self._get_page_content(url, wait_time=6000)
+        if _is_cf_challenge(html):
+            # Give the managed challenge one longer chance to auto-resolve.
+            html = self._get_page_content(url, wait_time=15000)
+        if _is_cf_challenge(html):
+            logger.warning(
+                "wto.to Cloudflare challenge did not clear for %s - "
+                "returning challenge page (parsers will find no content)",
+                url,
+            )
+        return html

--- a/memanga/search.py
+++ b/memanga/search.py
@@ -127,6 +127,11 @@ BROKEN_SEARCH_SOURCES = {
     # user can still add manga from these by URL.
     "manhuafast.com",
     "manhuaus.org",
+    # WTO (Bato mirror) - Cloudflare managed challenge that stays stuck
+    # on "Just a moment..." even for headless Firefox + stealth in
+    # probes. Its Playwright scraper is registered for add-by-URL, but
+    # a sweep slot would just burn its 60s budget on the challenge.
+    "wto.to",
     # Manganato.gg also serves the Cloudflare "Just a moment..." page
     # to plain requests + Playwright without a deep wait. Its existing
     # Playwright scraper times out at the 60s mark in practice.

--- a/tests/scrapers/fixtures/playwright_html/wto_manga.html
+++ b/tests/scrapers/fixtures/playwright_html/wto_manga.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="main">
+  <a href="/chapter/2600003">Chapter 1100: A New Dawn</a>
+  <a href="/chapter/2600002">Chapter 1099.5: Extra</a>
+  <a href="/chapter/2600001">Chapter 1099: The Calm</a>
+  <!-- Duplicate of chapter 1100 must be deduped -->
+  <a href="/chapter/2600003">Chapter 1100: A New Dawn</a>
+  <!-- Non-chapter link must be ignored -->
+  <a href="/series/72315/one-piece">Back to series</a>
+</div>
+</body>
+</html>

--- a/tests/scrapers/fixtures/playwright_html/wto_search.html
+++ b/tests/scrapers/fixtures/playwright_html/wto_search.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="series-list">
+  <div class="col item">
+    <div class="item-cover">
+      <a href="/series/72315/one-piece" title="One Piece">
+        <img data-src="//xfs-n01.xfsbb.com/thumb/one-piece.webp" alt="One Piece">
+      </a>
+    </div>
+    <div class="item-text">
+      <a class="item-title" href="/series/72315/one-piece">One Piece</a>
+    </div>
+  </div>
+  <div class="col item">
+    <div class="item-cover">
+      <a href="/series/65432/naruto" title="Naruto">
+        <img data-src="//xfs-n02.xfsbb.com/thumb/naruto.webp" alt="Naruto">
+      </a>
+    </div>
+    <div class="item-text">
+      <a class="item-title" href="/series/65432/naruto">Naruto</a>
+    </div>
+  </div>
+  <div class="col item">
+    <div class="item-cover">
+      <a href="/series/11111/one-piece-doujin" title="One Piece Doujin">
+        <img data-src="//xfs-n03.xfsbb.com/thumb/op-doujin.webp" alt="One Piece Doujin">
+      </a>
+    </div>
+    <div class="item-text">
+      <a class="item-title" href="/series/11111/one-piece-doujin">One Piece Doujin</a>
+    </div>
+  </div>
+  <!-- Non-series links must be ignored -->
+  <div class="item-text">
+    <a href="/browse">Browse all</a>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/scrapers/test_playwright_scrapers.py
+++ b/tests/scrapers/test_playwright_scrapers.py
@@ -15,6 +15,8 @@ import pytest
 
 from memanga.scrapers.mangabuddy import MangaBuddyScraper
 from memanga.scrapers.comix import ComixScraper
+from memanga.scrapers.batoto import BatoToScraper
+from memanga.scrapers.wto import WTOScraper, _is_cf_challenge
 from memanga.scrapers import get_scraper
 
 
@@ -121,6 +123,120 @@ class TestComixChapters:
 
 
 # ──────────────────────────────────────────────────────────────────────
+# WTO (wto.to) - Bato mirror. Parsing is inherited from BatoToScraper;
+# only the transport differs (Playwright, for the Cloudflare managed
+# challenge). Tests inject fixture HTML through _get_html, so they
+# exercise the exact parser wto.to relies on.
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def wto():
+    return WTOScraper()
+
+
+class TestWTORegistry:
+    def test_wto_domain_resolves_to_wto_scraper(self):
+        s = get_scraper("wto.to")
+        assert isinstance(s, WTOScraper)
+        assert s.base_url == "https://wto.to"
+
+    def test_wto_reuses_bato_parser(self):
+        assert issubclass(WTOScraper, BatoToScraper)
+
+    def test_bato_domains_unaffected(self):
+        # Mirror registration must not reroute or re-base the originals.
+        for domain in ("bato.to", "batoto.to"):
+            s = get_scraper(domain)
+            assert type(s) is BatoToScraper
+            assert s.base_url == "https://bato.to"
+
+
+class TestWTOSearch:
+    def test_parses_bato_series_cards(self, wto, patch_html, load_fixture):
+        patch_html(wto, load_fixture("playwright_html", "wto_search.html"))
+        results = wto.search("one piece")
+        titles = [r.title for r in results]
+        assert "One Piece" in titles
+        assert "Naruto" in titles
+        # Relative /series/ hrefs absolutized against the MIRROR domain
+        assert all(r.url.startswith("https://wto.to/series/") for r in results)
+        # Non-series links filtered out
+        assert not any("/browse" in r.url for r in results)
+
+    def test_dedupes_cover_and_text_links(self, wto, patch_html, load_fixture):
+        patch_html(wto, load_fixture("playwright_html", "wto_search.html"))
+        results = wto.search("one piece")
+        urls = [r.url for r in results]
+        assert len(urls) == len(set(urls))
+        assert len(results) == 3
+
+
+class TestWTOChapters:
+    def test_dedupes_and_sorts(self, wto, patch_html, load_fixture):
+        patch_html(wto, load_fixture("playwright_html", "wto_manga.html"))
+        chapters = wto.get_chapters("https://wto.to/series/72315/one-piece")
+        urls = [c.url for c in chapters]
+        assert len(urls) == len(set(urls))
+        assert len(chapters) == 3
+        # Ascending numeric order, decimal preserved
+        assert [c.number for c in chapters] == ["1099", "1099.5", "1100"]
+        # Relative /chapter/ hrefs absolutized against the mirror
+        assert all(u.startswith("https://wto.to/chapter/") for u in urls)
+
+
+class TestWTOPages:
+    def test_extracts_image_urls_from_script(self, wto, patch_html):
+        html = """
+        <html><body>
+        <script>
+        const imgList = ["https://xfs-n01.xfsbb.com/comic/7002/chapter-1100/001.webp",
+                         "https://xfs-n01.xfsbb.com/comic/7002/chapter-1100/002.png"];
+        </script>
+        </body></html>
+        """
+        patch_html(wto, html)
+        pages = wto.get_pages("https://wto.to/chapter/2600003")
+        assert len(pages) == 2
+        assert all(p.startswith("https://") for p in pages)
+
+
+class TestWTOCloudflareFallback:
+    CHALLENGE = "<html><head><title>Just a moment...</title></head></html>"
+    MANAGED = """
+    <html><body>
+    <h1>Performing security verification</h1>
+    <div class="cf-turnstile"></div>
+    <p>Ray ID: abc123</p>
+    </body></html>
+    """
+    REAL = "<html><body><div class='item-text'></div></body></html>"
+
+    def test_detects_challenge_markup(self):
+        assert _is_cf_challenge(self.CHALLENGE) is True
+        assert _is_cf_challenge(self.MANAGED) is True
+        assert _is_cf_challenge(self.REAL) is False
+
+    def test_retries_once_with_longer_wait(self, monkeypatch, wto):
+        calls = []
+        def fake_fetch(url, wait_time=0, **kwargs):
+            calls.append(wait_time)
+            return self.CHALLENGE if len(calls) == 1 else self.REAL
+        monkeypatch.setattr(wto, "_get_page_content", fake_fetch)
+        html = wto._get_html("https://wto.to/search?word=x")
+        assert html == self.REAL
+        assert len(calls) == 2
+        assert calls[1] > calls[0]
+
+    def test_persistent_challenge_degrades_to_empty_results(
+            self, monkeypatch, wto):
+        monkeypatch.setattr(wto, "_get_page_content",
+                             lambda *a, **k: self.CHALLENGE)
+        # No crash; parsers just find nothing in the interstitial.
+        assert wto.search("one piece") == []
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Smoke tests: every Playwright-based scraper imports + instantiates +
 # exposes the required methods. This catches typos and missing-import
 # bugs without paying the cost of spinning up a browser.
@@ -163,6 +279,7 @@ PLAYWRIGHT_DOMAINS = [
     "hentairead.com",
     "manganato.gg",
     "mangahere.onl",
+    "wto.to",
 ]
 
 


### PR DESCRIPTION
## Summary

Adds `wto.to` as a Playwright-backed Bato mirror source. The scraper reuses the existing Bato parsing logic, registers the domain for add-by-URL flows, and keeps broad multi-source search from spending its timeout budget on the Cloudflare managed challenge when headless access cannot clear it.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Tests

- `./venv/bin/python -m pytest tests/scrapers/test_playwright_scrapers.py tests/unit/test_search.py tests/scrapers/test_registry_coverage.py -q`
- Manual live probe against `https://wto.to/search?word=one+piece`: Cloudflare challenge remained active in headless Firefox, and the scraper degraded to 0 results without crashing.

## Related issues

Closes #79