### PR TITLE
fix(gui): avoid false offline network probe

### DIFF
--- a/memanga/gui/network_status.py
+++ b/memanga/gui/network_status.py
@@ -5,16 +5,25 @@ Why we don't trust ``requests.exceptions.ConnectionError`` alone:
     A scraper that hits the network will retry 3 times with exponential
     back-off before giving up. With 100+ scrapers fanned out in parallel,
     that's a 90-second freeze on the search bar (and the same on
-    "Check all") any time the user's WiFi blinks. We instead probe a
-    cheap anycast endpoint every few seconds and *publish* the result
+    "Check all") any time the user's WiFi blinks. We instead probe
+    cheap TCP endpoints every few seconds and *publish* the result
     so every page can short-circuit network work the moment we go
     offline — and re-enable it the moment we recover.
 
 Probe:
-    Open a TCP connection to Cloudflare's 1.1.1.1:53 with a 3-second
-    timeout. We don't speak DNS — we only care that the socket opens.
-    This avoids HTTP/DNS overhead and works even when the user has
-    a captive portal that intercepts HTTP.
+    Try a short list of TCP endpoints in order and treat the machine as
+    online as soon as one is reachable. The first candidate is
+    Cloudflare's 1.1.1.1:53 (cheap, no name lookup); if that fails we
+    fall back to HTTPS ports on well-known hostnames, because some
+    networks block outbound TCP/53 to public resolvers while normal
+    HTTPS traffic works fine (see issue #84). We never speak the
+    protocol — we only care that a socket opens.
+
+    A connection that is actively refused or blocked by local policy
+    still counts as online: getting a refusal back proves the network
+    path works, it just means that particular endpoint won't take the
+    connection. Only timeouts, unreachable-network errors and
+    name-resolution failures count as offline evidence.
 
 Events published:
     "network_online"  → emitted on the first probe AND on every offline
@@ -34,17 +43,26 @@ from typing import Optional
 
 # Probe parameters. Keep the offline interval short so the user gets
 # their UI back fast when the WiFi recovers; keep the online interval
-# loose so we don't spam DNS while everything is fine.
-PROBE_HOST = "1.1.1.1"
-PROBE_PORT = 53
+# loose so we don't spam probes while everything is fine.
+#
+# Endpoints are tried in order until one succeeds. 1.1.1.1:53 stays
+# first because it needs no DNS lookup; the :443 fallbacks cover
+# networks that block TCP/53 to public resolvers. Use content
+# hostnames (not resolver IPs) on :443 — Windows 11 reserves DoH
+# resolver IPs like 1.1.1.1:443 and refuses direct connections.
+PROBE_ENDPOINTS = (
+    ("1.1.1.1", 53),
+    ("cloudflare.com", 443),
+    ("github.com", 443),
+)
 PROBE_TIMEOUT = 3.0
 ONLINE_INTERVAL = 30.0      # re-check every 30 s while online
 OFFLINE_INTERVAL = 5.0      # re-check every 5 s while offline
 
 
 class NetworkMonitor:
-    """Background thread that pings a cheap anycast endpoint at a
-    cadence depending on the current online/offline state and
+    """Background thread that probes a small set of cheap endpoints at
+    a cadence depending on the current online/offline state and
     publishes transitions on the GUI EventBus.
     """
 
@@ -100,7 +118,7 @@ class NetworkMonitor:
                 slept += 0.5
 
     def _probe_and_publish(self):
-        online = _tcp_probe(PROBE_HOST, PROBE_PORT, PROBE_TIMEOUT)
+        online = _check_connectivity()
         with self._lock:
             changed = (self._online is None) or (self._online != online)
             prev = self._online
@@ -120,10 +138,29 @@ class NetworkMonitor:
             pass
 
 
+def _check_connectivity() -> bool:
+    """Probe endpoints in order; online as soon as one is reachable."""
+    for host, port in PROBE_ENDPOINTS:
+        if _tcp_probe(host, port, PROBE_TIMEOUT):
+            return True
+    return False
+
+
 def _tcp_probe(host: str, port: int, timeout: float) -> bool:
-    """Try to open a TCP socket. Returns True iff it connects."""
+    """Try to open a TCP socket to (host, port).
+
+    Returns True if the connection succeeds — or if it is actively
+    refused / blocked by policy (ConnectionRefusedError,
+    PermissionError). A refusal is a response: it proves the network
+    path works and only this endpoint won't accept the connection.
+
+    Returns False on name-resolution failure, unreachable network or
+    timeout — the errors a genuinely dead link produces.
+    """
     try:
         sock = socket.create_connection((host, port), timeout=timeout)
+    except (ConnectionRefusedError, PermissionError):
+        return True
     except (socket.gaierror, OSError):
         return False
     try:

--- a/tests/unit/gui/test_network_status.py
+++ b/tests/unit/gui/test_network_status.py
@@ -61,6 +61,84 @@ class TestNetworkMonitor:
 
 
 # ─────────────────────────────────────────────────────────────────────
+# Probe semantics (issue #84 — false offline on networks that block
+# TCP/53 to public resolvers while normal HTTPS works)
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestTcpProbe:
+    def _patch_connect(self, monkeypatch, exc):
+        import memanga.gui.network_status as ns
+
+        def _raise(*a, **k):
+            raise exc
+
+        monkeypatch.setattr(ns.socket, "create_connection", _raise)
+        return ns
+
+    def test_refused_connection_counts_as_online(self, monkeypatch):
+        # A refusal (e.g. RST for TCP/53 on filtered networks) proves
+        # the network path works — must not flip the app offline.
+        ns = self._patch_connect(monkeypatch, ConnectionRefusedError())
+        assert ns._tcp_probe("1.1.1.1", 53, 0.1) is True
+
+    def test_policy_blocked_connection_counts_as_online(self, monkeypatch):
+        # Windows 11 reserves DoH resolver IPs and returns WSAEACCES;
+        # local policy blocks are not offline evidence either.
+        ns = self._patch_connect(monkeypatch, PermissionError())
+        assert ns._tcp_probe("1.1.1.1", 443, 0.1) is True
+
+    def test_timeout_counts_as_offline(self, monkeypatch):
+        import socket
+        ns = self._patch_connect(monkeypatch, socket.timeout())
+        assert ns._tcp_probe("1.1.1.1", 53, 0.1) is False
+
+    def test_name_resolution_failure_counts_as_offline(self, monkeypatch):
+        import socket
+        ns = self._patch_connect(monkeypatch, socket.gaierror())
+        assert ns._tcp_probe("cloudflare.com", 443, 0.1) is False
+
+    def test_unreachable_network_counts_as_offline(self, monkeypatch):
+        import errno
+        ns = self._patch_connect(
+            monkeypatch, OSError(errno.ENETUNREACH, "unreachable"))
+        assert ns._tcp_probe("1.1.1.1", 53, 0.1) is False
+
+
+class TestCheckConnectivity:
+    def test_falls_back_to_https_when_tcp53_fails(self, monkeypatch):
+        from memanga.gui import network_status as ns
+        calls = []
+
+        def fake_probe(host, port, timeout):
+            calls.append((host, port))
+            return port == 443
+
+        monkeypatch.setattr(ns, "_tcp_probe", fake_probe)
+        assert ns._check_connectivity() is True
+        assert calls[0][1] == 53          # cheap endpoint tried first
+        assert calls[1][1] == 443         # then the HTTPS fallback
+
+    def test_stops_at_first_reachable_endpoint(self, monkeypatch):
+        from memanga.gui import network_status as ns
+        calls = []
+        monkeypatch.setattr(
+            ns, "_tcp_probe",
+            lambda h, p, t: calls.append((h, p)) or True)
+        assert ns._check_connectivity() is True
+        assert len(calls) == 1
+
+    def test_offline_only_when_every_endpoint_fails(self, monkeypatch):
+        from memanga.gui import network_status as ns
+        calls = []
+        monkeypatch.setattr(
+            ns, "_tcp_probe",
+            lambda h, p, t: bool(calls.append((h, p))))
+        assert ns._check_connectivity() is False
+        assert len(calls) == len(ns.PROBE_ENDPOINTS)
+
+
+# ─────────────────────────────────────────────────────────────────────
 # BackgroundWorker offline gates
 # ─────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Updates the GUI network monitor so it no longer treats a single blocked TCP/53 probe as global offline state. The probe now falls back to HTTPS hostnames and treats refused or policy-blocked connections as online evidence, while still reporting offline for timeout, DNS, and unreachable-network failures.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Tests

- `venv/bin/python -m pytest tests/unit/gui/test_network_status.py -q`
- `venv/bin/python -m pytest tests/unit/gui/test_workers.py -q`
- `python -m compileall -q memanga tests`
- Manual live probe: `1.1.1.1:53`, `cloudflare.com:443`, and `github.com:443` all returned reachable from the Pi.

## Related issues

Closes #84