### PR TITLE
fix(scraper): restore MangaDex API requests

### DIFF
--- a/memanga/scrapers/mangadex.py
+++ b/memanga/scrapers/mangadex.py
@@ -16,6 +16,18 @@ class MangaDexScraper(BaseScraper):
     def __init__(self):
         super().__init__()
         self._rate_limit = 0.5  # MangaDex is generous with rate limits
+
+        # The MangaDex API rejects requests with HTTP 400 when the session
+        # claims a modern Chrome User-Agent (inherited from BaseScraper) but
+        # omits the Sec-Fetch-* metadata headers a real browser always sends
+        # for such requests. Send the values a browser uses for a same-origin
+        # fetch/XHR to the API, and ask for JSON explicitly.
+        self.session.headers.update({
+            "Accept": "application/json",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+        })
     
     def _extract_manga_id(self, url: str) -> Optional[str]:
         """Extract manga ID from MangaDex URL."""

--- a/tests/scrapers/live/_helpers.py
+++ b/tests/scrapers/live/_helpers.py
@@ -80,6 +80,12 @@ LIVE_HEADERS = {
     ),
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     "Accept-Language": "en-US,en;q=0.5",
+    # A real browser always sends Sec-Fetch-* metadata. Some APIs (e.g.
+    # api.mangadex.org) reject a Chrome User-Agent that omits them with
+    # HTTP 400, so send the values a top-level navigation would use.
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
 }
 
 # Enough to hold any of the magic byte signatures below.

--- a/tests/scrapers/live/test_live_parsing.py
+++ b/tests/scrapers/live/test_live_parsing.py
@@ -65,7 +65,9 @@ class ProbeSpec:
 
 PARSING_PROBES = {
     # ── Aggregators (full pipeline) ──
-    "mangadex.org": ProbeSpec("API client", query="one piece"),
+    # "one piece" is fully external on MangaDex (MangaPlus) → 0 readable
+    # chapters, so probe a title that is actually hosted there.
+    "mangadex.org": ProbeSpec("API client", query="chainsaw man"),
     "mangapill.com": ProbeSpec("Simple HTTP aggregator", query="one piece"),
     "mangapark1.com": ProbeSpec("MangaPark", query="one piece"),
     "tcbonepiecechapters.com": ProbeSpec("TCB Scans (project list)",

--- a/tests/scrapers/test_mangadex_api.py
+++ b/tests/scrapers/test_mangadex_api.py
@@ -12,6 +12,34 @@ def scraper():
     return MangaDexScraper()
 
 
+class TestSessionHeaders:
+    """MangaDex's API returns HTTP 400 for a browser-style User-Agent that
+    omits Sec-Fetch-* metadata. The scraper must send those headers (and ask
+    for JSON) on every request via the shared session."""
+
+    def test_sends_sec_fetch_and_json_accept(self, scraper):
+        headers = scraper.session.headers
+        assert headers["Accept"] == "application/json"
+        assert headers["Sec-Fetch-Dest"] == "empty"
+        assert headers["Sec-Fetch-Mode"] == "cors"
+        assert headers["Sec-Fetch-Site"] == "same-origin"
+
+    def test_headers_reach_the_request(self, monkeypatch, scraper, fake_response):
+        seen = {}
+
+        def fake_get(url, **kwargs):
+            # session.headers are merged into the request by requests itself,
+            # so assert against the session that will be used for the call.
+            seen["headers"] = dict(scraper.session.headers)
+            return fake_response(json_data={"data": []})
+
+        monkeypatch.setattr(scraper.session, "get", fake_get)
+        scraper.search("one piece")
+
+        assert seen["headers"]["Accept"] == "application/json"
+        assert seen["headers"]["Sec-Fetch-Mode"] == "cors"
+
+
 class TestExtractIDs:
     def test_manga_id(self, scraper):
         assert scraper._extract_manga_id(


### PR DESCRIPTION
## Summary

Restores MangaDex API requests by sending the JSON and Fetch Metadata headers MangaDex now expects when a browser-style User-Agent is used. The live MangaDex health probe now targets a MangaDex-hosted title so it validates the full downloadable path instead of an external-only result.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Tests

- `./venv/bin/python -m pytest tests/scrapers/test_mangadex_api.py tests/scrapers/test_base_helpers.py tests/unit/scrapers/test_scraper_registry.py -q`
- `./venv/bin/python -m pytest tests/unit/test_search.py tests/unit/test_downloader.py tests/unit/test_downloader_pipeline.py -q`
- `./venv/bin/python -m pytest -m live tests/scrapers/live/test_live_reachability.py -k mangadex.org -ra -q`
- `./venv/bin/python -m pytest -m live tests/scrapers/live/test_live_parsing.py -k mangadex.org -ra -q`
- Manual live MangaDex download probe: search, chapter discovery, page extraction, single image download, and `download_chapter` output succeeded.

## Related issues

Closes #83
