### PR TITLE
feat(downloader): embed ComicInfo metadata in CBZ

### DIFF
--- a/memanga/downloader.py
+++ b/memanga/downloader.py
@@ -577,7 +577,8 @@ def download_chapter(
         elif output_format == "cbz":
             output_path = manga_dir / f"{base_name}.cbz"
             try:
-                _images_to_cbz(image_paths, output_path)
+                comicinfo_xml = _build_comicinfo_xml(manga, chapter, len(image_paths))
+                _images_to_cbz(image_paths, output_path, comicinfo_xml)
             except Exception as e:
                 raise DownloaderError(f"Failed to create CBZ: {e}")
         elif output_format == "zip":
@@ -762,11 +763,103 @@ def _images_to_pdf(image_paths: List[Path], output_path: Path):
     output_path.write_bytes(pdf_bytes)
 
 
-def _images_to_cbz(image_paths: List[Path], output_path: Path):
+def _parse_comicinfo_date(date_str: Optional[str]) -> Optional[Tuple[int, int, int]]:
+    """Best-effort parse of a chapter/source date into (year, month, day).
+
+    Chapter dates arrive in many shapes across scrapers (ISO 8601 from API
+    sources like ``publishAt``, free-form text elsewhere). Returns ``None``
+    when nothing usable can be extracted so the caller simply omits the
+    Year/Month/Day fields.
+    """
+    if not date_str:
+        return None
+    text = str(date_str).strip()
+    if not text:
+        return None
+
+    # ISO 8601 first (covers the trailing "...Z" suffix common to API sources).
+    try:
+        iso_text = text[:-1] + "+00:00" if text.endswith("Z") else text
+        dt = datetime.fromisoformat(iso_text)
+        return dt.year, dt.month, dt.day
+    except ValueError:
+        pass
+
+    for fmt in (
+        "%Y-%m-%d", "%Y/%m/%d", "%d-%m-%Y", "%m/%d/%Y",
+        "%B %d, %Y", "%b %d, %Y", "%d %B %Y", "%d %b %Y",
+    ):
+        try:
+            dt = datetime.strptime(text, fmt)
+            return dt.year, dt.month, dt.day
+        except ValueError:
+            continue
+    return None
+
+
+def _build_comicinfo_xml(
+    manga: Dict[str, Any],
+    chapter: Chapter,
+    page_count: int,
+) -> bytes:
+    """Build a ComicInfo.xml document from already-known metadata.
+
+    Only fields MeManga already has on hand (the tracked manga config and
+    the ``Chapter`` object) are written; no extra network requests are
+    made. Optional fields with no data are omitted entirely. Serialization
+    and XML escaping are handled by ElementTree.
+    """
+    from xml.etree.ElementTree import Element, SubElement, tostring
+
+    root = Element("ComicInfo", {
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+    })
+
+    def add(tag: str, value: Any):
+        if value is None:
+            return
+        text = str(value).strip()
+        if not text:
+            return
+        SubElement(root, tag).text = text
+
+    chapter_title = getattr(chapter, "title", None)
+    add("Title", chapter_title or f"Chapter {chapter.number}")
+    add("Series", manga.get("title"))
+    add("Number", chapter.number)
+
+    add("Summary", manga.get("description"))
+
+    parsed = _parse_comicinfo_date(getattr(chapter, "date", None))
+    if parsed:
+        year, month, day = parsed
+        add("Year", year)
+        add("Month", month)
+        add("Day", day)
+
+    add("Writer", manga.get("author"))
+
+    # Web: prefer the specific chapter URL, fall back to the manga URL.
+    add("Web", getattr(chapter, "url", "") or manga.get("url", ""))
+    add("PageCount", page_count)
+
+    return tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def _images_to_cbz(
+    image_paths: List[Path],
+    output_path: Path,
+    comicinfo_xml: Optional[bytes] = None,
+):
     """Convert a list of images to a CBZ (Comic Book ZIP) archive.
 
     Images are stored as-is (no re-encoding) with sequential names
     for correct reading order.
+
+    When ``comicinfo_xml`` is provided it is written to the archive root as
+    ``ComicInfo.xml`` so offline libraries and e-readers can read chapter
+    metadata. Page names and order are unaffected.
     """
     import zipfile
 
@@ -777,6 +870,8 @@ def _images_to_cbz(image_paths: List[Path], output_path: Path):
         for i, img_path in enumerate(image_paths):
             ext = img_path.suffix.lower() or '.jpg'
             cbz.write(img_path, f"page_{i:03d}{ext}")
+        if comicinfo_xml is not None:
+            cbz.writestr("ComicInfo.xml", comicinfo_xml)
 
 
 def _images_to_folder(image_paths: List[Path], output_dir: Path, img_format: str):

--- a/tests/unit/test_downloader_pipeline.py
+++ b/tests/unit/test_downloader_pipeline.py
@@ -244,6 +244,114 @@ class TestImagesToCbz:
         except Exception:
             pass
 
+    def test_embeds_comicinfo_at_root_without_disturbing_pages(
+            self, jpg_paths, tmp_path):
+        # ComicInfo.xml must sit at the archive root and must NOT be counted
+        # among the page entries or change their names/order.
+        from memanga.downloader import _images_to_cbz
+        out = tmp_path / "ch.cbz"
+        _images_to_cbz(jpg_paths, out, comicinfo_xml=b"<ComicInfo/>")
+        with zipfile.ZipFile(out) as zf:
+            names = zf.namelist()
+            assert "ComicInfo.xml" in names
+            pages = [n for n in names if n != "ComicInfo.xml"]
+            assert len(pages) == 3
+            assert all(n.startswith("page_") for n in pages)
+            assert pages == sorted(pages)
+            assert zf.read("ComicInfo.xml") == b"<ComicInfo/>"
+
+    def test_no_metadata_keeps_plain_archive(self, jpg_paths, tmp_path):
+        # Omitting metadata must leave the archive exactly as before.
+        from memanga.downloader import _images_to_cbz
+        out = tmp_path / "plain.cbz"
+        _images_to_cbz(jpg_paths, out)
+        with zipfile.ZipFile(out) as zf:
+            assert "ComicInfo.xml" not in zf.namelist()
+
+
+class TestComicInfoXml:
+    """ComicInfo.xml generation from metadata already on hand,
+    with no extra network requests."""
+
+    @staticmethod
+    def _parse(xml_bytes):
+        import xml.etree.ElementTree as ET
+        root = ET.fromstring(xml_bytes)
+        assert root.tag == "ComicInfo"
+        return {child.tag: child.text for child in root}
+
+    def test_basic_fields_always_present(self):
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        manga = {"title": "Berserk"}
+        ch = Chapter(number="5", title=None, url="https://x.test/c/5")
+        fields = self._parse(_build_comicinfo_xml(manga, ch, page_count=12))
+        assert fields["Series"] == "Berserk"
+        # No chapter title: falls back to "Chapter <number>".
+        assert fields["Title"] == "Chapter 5"
+        assert fields["Number"] == "5"
+        assert fields["PageCount"] == "12"
+        assert fields["Web"] == "https://x.test/c/5"
+
+    def test_optional_fields_written_when_available(self):
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        import xml.etree.ElementTree as ET
+        manga = {
+            "title": "Berserk",
+            "description": "A wandering swordsman.",
+            "author": "Kentaro Miura",
+            "url": "https://x.test/manga",
+        }
+        ch = Chapter(number="5", title="The Golden Age",
+                     url="https://x.test/c/5", date="2016-05-06")
+        fields = self._parse(_build_comicinfo_xml(manga, ch, page_count=20))
+        assert fields["Title"] == "The Golden Age"
+        assert fields["Summary"] == "A wandering swordsman."
+        assert fields["Writer"] == "Kentaro Miura"
+        assert fields["Year"] == "2016"
+        assert fields["Month"] == "5"
+        assert fields["Day"] == "6"
+        root = ET.fromstring(_build_comicinfo_xml(manga, ch, page_count=20))
+        assert [child.tag for child in root] == [
+            "Title", "Series", "Number", "Summary", "Year", "Month",
+            "Day", "Writer", "Web", "PageCount",
+        ]
+
+    def test_missing_optional_fields_are_omitted(self):
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        manga = {"title": "Berserk"}
+        ch = Chapter(number="5", url="")
+        fields = self._parse(_build_comicinfo_xml(manga, ch, page_count=1))
+        # No description/author/date/url: those tags simply don't appear.
+        for absent in ("Summary", "Writer", "Year", "Month", "Day", "Web"):
+            assert absent not in fields
+
+    def test_special_characters_are_escaped(self):
+        # Raw XML metacharacters must be escaped by the serializer and
+        # survive a round-trip parse without corrupting the document.
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        manga = {"title": 'Fist of the <North> & "Star"',
+                 "author": "A & B"}
+        ch = Chapter(number="1", title="Ch <1> & more", url="https://x.test/?a=1&b=2")
+        xml_bytes = _build_comicinfo_xml(manga, ch, page_count=3)
+        assert b"&amp;" in xml_bytes  # escaped, not raw
+        fields = self._parse(xml_bytes)  # must still parse cleanly
+        assert fields["Series"] == 'Fist of the <North> & "Star"'
+        assert fields["Title"] == "Ch <1> & more"
+        assert fields["Writer"] == "A & B"
+        assert fields["Web"] == "https://x.test/?a=1&b=2"
+
+    def test_year_omitted_for_unparseable_date(self):
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        manga = {"title": "X"}
+        ch = Chapter(number="1", date="an hour ago")
+        fields = self._parse(_build_comicinfo_xml(manga, ch, page_count=1))
+        assert "Year" not in fields
+
 
 class TestImagesToPdf:
     def test_creates_valid_pdf(self, jpg_paths, tmp_path):


### PR DESCRIPTION
## Summary
- Add root-level ComicInfo.xml metadata to CBZ downloads using existing manga/chapter data.
- Preserve page file naming/order and keep ZIP/PDF/EPUB/image-folder output unchanged.
- Add regression coverage for ComicInfo serialization, escaping, optional fields, dates, and tag ordering.

Closes #90

## Changes
- Build ComicInfo.xml with ElementTree from metadata already available during download.
- Pass ComicInfo only through the CBZ path while leaving ZIP as a plain archive.
- Add focused downloader pipeline tests for CBZ metadata behavior.

## Testing
- `venv/bin/python -m pytest tests/unit/test_downloader_pipeline.py tests/unit/test_downloader.py -q` (`56 passed`)
- `venv/bin/python -m compileall -q memanga tests`
- `git diff --check`
- Manual CBZ inspection through `download_chapter(..., "cbz")` with a fake scraper verified page entries plus root `ComicInfo.xml`, and parsed escaped XML fields.