### PR TITLE
chore(release): prepare v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-07-12
+
+### Fixed
+- #83 MangaDex API requests could fail with HTTP 400 because the shared
+  scraper session claimed a browser user agent without the `Sec-Fetch-*`
+  headers MangaDex expects. Default scraper headers now include those
+  browser fetch metadata headers, restoring MangaDex search and chapter
+  requests.
+- #84 The GUI could falsely report offline on connected networks because
+  the network probe used TCP port 53, which some Windows networks reject
+  even while normal HTTPS access works. The probe now checks an HTTPS
+  host on port 443 so connected users are not blocked by DNS-over-TCP
+  policy.
+
+### Acknowledgements
+- Special thanks to @Camponotus-vagus for the detailed issue diagnostics
+  and follow-up testing that helped shape the fixes.
+
 ## [0.3.2] - 2026-07-08
 
 ### Added

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.3.2"
+version = "0.3.3"
 description = "Automatic manga downloader with Kindle support"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Prepare the v0.3.3 patch release with version metadata updates, changelog notes for the MangaDex and network-probe fixes, and acknowledgement for issue diagnostics/testing help.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Docs
- [ ] Scraper added or fixed
- [x] Build / CI

## Checklist

- [ ] `pytest` passes locally
- [x] Targeted release tests pass locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Refs #83
Refs #84