### PR TITLE
chore(release): sync cli for v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,49 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-07-12
+
+### Fixed
+- #83 MangaDex API requests could fail with HTTP 400 because the shared
+  scraper session claimed a browser user agent without the `Sec-Fetch-*`
+  headers MangaDex expects. Default scraper headers now include those
+  browser fetch metadata headers, restoring MangaDex search and chapter
+  requests.
+
+### Acknowledgements
+- Special thanks to @Camponotus-vagus for the detailed issue diagnostics
+  and follow-up testing that helped shape the fixes.
+
+## [0.3.2] - 2026-07-08
+
+### Added
+- #77 Comix.to is now available as a supported source. Search runs
+  through the rendered search flow, chapter discovery reads paginated
+  chapter rows, and reader image extraction/downloads use the headers
+  required by the site.
+- #78 MangaPark is now available as a supported source through
+  `mangapark1.com`, including search, chapter-list parsing, reader page
+  extraction, CDN image downloads, and live scraper diagnostics.
+- Live scraper diagnostics now include staged parsing probes that make
+  source-specific breakage easier to confirm without running the full
+  application workflow.
+
+### Fixed
+- #74 MangaFire search now reads the current `/api/titles` JSON payload
+  instead of scraping the old browser search page, restoring title
+  discovery for queries such as `one piece`, `ao no hako`, and
+  `super no ura`.
+
+## [0.3.1] - 2026-07-06
+
+### Fixed
+- #71 MangaFire changed its chapter and page endpoints, so saved
+  MangaFire library entries could no longer fetch real chapter lists.
+  MangaFire now reads the current `/api` chapter and page payloads,
+  keeps old saved MangaFire URLs compatible, follows paginated chapter
+  lists, and deduplicates repeated chapter numbers before update checks
+  or downloads run.
+
 ## [0.3.0] - 2026-06-13
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,13 @@ pytest tests/unit
 
 # Live scraper health checks (hits real sites — slow, opt-in)
 pytest -m live tests/scrapers/live/
+
+# Curated end-to-end probes only — each walks search → chapters →
+# pages → image and a failure names the first broken stage
+pytest -m live tests/scrapers/live/test_live_parsing.py -v
+
+# Machine-readable report (per-stage details + failures_by_stage)
+pytest -m live tests/scrapers/live/ --health-report=health.json
 ```
 
 All checked-in tests should pass before you push.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 📖 MeManga (CLI)
+# MeManga (CLI)
 
 **Automatic manga downloader — command-line edition.**
 
@@ -9,6 +9,7 @@ engine and a cron-friendly CLI.
 
 <p align="center">
   <a href="https://github.com/meellm/MeManga/releases"><img alt="latest release" src="https://img.shields.io/github/v/release/meellm/MeManga"></a>
+  <a href="https://github.com/meellm/MeManga/releases"><img alt="release downloads" src="https://img.shields.io/github/downloads/meellm/MeManga/total?label=downloads"></a>
   <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-blue"></a>
   <img alt="platforms" src="https://img.shields.io/badge/Windows%20%7C%20macOS%20%7C%20Linux-supported-success">
   <img alt="python" src="https://img.shields.io/badge/python-3.10%2B-blue">
@@ -22,20 +23,20 @@ engine and a cron-friendly CLI.
 
 ---
 
-## ✨ Highlights
+## Highlights
 
-- 🤝 **Power-user CLI** — scriptable, cron-friendly, works on headless servers
-- 📚 **Library tracking** — read/unread state survives reboots
-- 🔍 **Multi-source search** — 15 popular aggregators pre-checked, ranked by reliability
-- 📥 **PDF / EPUB / CBZ / ZIP / JPG / PNG / WEBP** output
-- 📧 **Kindle delivery** — auto-send chapters by email after download
-- 🔄 **Backup sources** — fall back to a second source if the primary stops updating
-- 🌐 **Offline-aware** — gracefully fails on network actions when offline
-- 🔒 **No telemetry, no accounts, no cloud** — everything stays on your machine
+- **Power-user CLI** — scriptable, cron-friendly, works on headless servers
+- **Library tracking** — read/unread state survives reboots
+- **Multi-source search** — 15 popular aggregators pre-checked, ranked by reliability
+- **PDF / EPUB / CBZ / ZIP / JPG / PNG / WEBP** output
+- **Kindle delivery** — auto-send chapters by email after download
+- **Backup sources** — fall back to a second source if the primary stops updating
+- **Offline-aware** — gracefully fails on network actions when offline
+- **No telemetry, no accounts, no cloud** — everything stays on your machine
 
 ---
 
-## 🚀 Install
+## Install
 
 ```bash
 git clone -b cli https://github.com/meellm/MeManga.git
@@ -63,7 +64,7 @@ On macOS / Linux:
 
 ---
 
-## 🧭 First five minutes
+## First five minutes
 
 ```bash
 # 1. Track a manga (either interactive or one-shot)
@@ -83,7 +84,7 @@ library from both interchangeably.
 
 ---
 
-## 📜 Commands
+## Commands
 
 | Command | Purpose |
 |---|---|
@@ -166,7 +167,7 @@ split so they fail-loud with a size warning.
 
 ---
 
-## 🌐 Sources
+## Sources
 
 The default search sweep covers these 15 verified working aggregators
 (popularity order):
@@ -175,10 +176,12 @@ The default search sweep covers these 15 verified working aggregators
 |---|---|---|
 | mangadex.org | API | Largest fan-translation library |
 | mangapill.com | Requests | Fast, no Cloudflare |
-| mangafire.to | Playwright | VRF bypass + image descrambling |
+| mangapark1.com | Requests | Large mirror with live diagnostics |
+| mangafire.to | Requests | Current JSON APIs + image descrambling |
 | mangabuddy.com | Playwright | Popular aggregator |
 | weebcentral.com | Playwright | 1000+ series |
 | mangakatana.com | Playwright | General library |
+| comix.to | Playwright | Rendered search + reader extraction |
 | comick.io | Playwright | Clean API |
 | mangahub.io | Requests | Huge library |
 | mangahere.cc | Requests | Reliable mirror |
@@ -186,8 +189,6 @@ The default search sweep covers these 15 verified working aggregators
 | mangaclash.com | Playwright | Manhwa-heavy |
 | mangahere.onl | Playwright | Alternate mirror |
 | mangataro.org | Requests | ComicK replacement |
-| luminousscans.com | Requests | Scanlation focus |
-| tcbonepiecechapters.com | Requests | Jump titles (One Piece, JJK, MHA) |
 
 200+ more aggregators are in the registry — toggle them on via
 `python -m memanga sources`. See the
@@ -246,7 +247,7 @@ config + state files, so you can switch between them freely.
 
 ---
 
-## 🤝 Contributing
+## Contributing
 
 PRs welcome — bug fixes, new scrapers, CLI polish, all of it.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the dev setup, test

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.3"

--- a/memanga/scrapers/__init__.py
+++ b/memanga/scrapers/__init__.py
@@ -8,6 +8,7 @@ Working sources:
 - Mangakatana (mangakatana.com) - General library
 - MangaDex (mangadex.org) - Community uploads (skip Shueisha)
 - Mangapill (mangapill.com) - Large library, no Cloudflare
+- MangaPark (mangapark1.com) - Large library, simple requests
 - MangaReader (mangareader.to) - Large library, clean UI
 - MangaSee (mangasee123.com) - High quality scans
 - MangaBuddy (mangabuddy.com) - Popular aggregator
@@ -30,6 +31,7 @@ from .asurascans import AsuraScansScraper
 from .mangakatana import MangakatanataScraper
 from .mangadex import MangaDexScraper
 from .mangapill import MangapillScraper
+from .mangapark import MangaParkScraper
 from .mangareader import MangaReaderScraper
 from .mangafire import MangaFireScraper
 from .mangasee import MangaSeeScraper
@@ -65,6 +67,7 @@ from .mangahubus import MangaHubUsScraper
 from .onemanga import OneMangaScraper
 from .mangafreak import MangaFreakScraper
 from .comick import ComickScraper
+from .comix import ComixScraper
 from .fanfox import FanFoxScraper
 from .toonily import ToonilyScraper
 from .omegascans import OmegaScansScraper
@@ -184,6 +187,9 @@ SCRAPERS = {
 
     # Mangapill - Large library (no Cloudflare, simple requests)
     "mangapill.com": MangapillScraper,
+
+    # MangaPark - current working domain
+    "mangapark1.com": MangaParkScraper,
 
     # MangaReader.to
     "mangareader.to": MangaReaderScraper,
@@ -339,6 +345,9 @@ SCRAPERS = {
     # ComicK - Popular manga aggregator (Playwright + Cloudflare bypass)
     "comick.io": ComickScraper,
     "comick.dev": ComickScraper,
+
+    # Comix - Popular manga/manhwa aggregator (Playwright)
+    "comix.to": ComixScraper,
 
     # FanFox (MangaFox) - Large manga library (Playwright)
     "fanfox.net": FanFoxScraper,
@@ -665,10 +674,12 @@ def list_supported_sources():
 POPULAR_SOURCES = [
     "mangadex.org",
     "mangapill.com",
+    "mangapark1.com",
     "mangafire.to",
     "mangabuddy.com",
     "weebcentral.com",
     "mangakatana.com",
+    "comix.to",
     "comick.io",
     "mangahub.io",
     "mangahere.cc",

--- a/memanga/scrapers/comix.py
+++ b/memanga/scrapers/comix.py
@@ -1,0 +1,231 @@
+"""
+Comix.to scraper.
+
+Comix is a React SPA backed by protected JSON endpoints. The public pages
+render the data after the frontend initializes, so this scraper follows the
+existing Playwright pattern used by other protected aggregators.
+"""
+
+import os
+import re
+from pathlib import Path
+from typing import List
+from urllib.parse import urljoin
+
+from .base import Chapter, Manga
+from .playwright_base import PlaywrightScraper
+
+
+class ComixScraper(PlaywrightScraper):
+    """Scraper for Comix.to."""
+
+    name = "comix"
+    base_url = "https://comix.to"
+
+    def _parse_search_html(self, html: str) -> List[Manga]:
+        """Parse rendered browse/search HTML."""
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        by_url = {}
+
+        for link in soup.select('a[href*="/title/"]'):
+            href = link.get("href", "")
+            if not href or "/chapter-" in href:
+                continue
+
+            url = href if href.startswith("http") else urljoin(self.base_url, href)
+            entry = by_url.setdefault(url, {"title": "", "cover_url": None})
+
+            text = link.get_text(" ", strip=True)
+            if text and not entry["title"]:
+                entry["title"] = text
+
+            img = link.find("img")
+            if img and not entry["cover_url"]:
+                entry["cover_url"] = img.get("data-src") or img.get("src")
+                if not entry["title"]:
+                    entry["title"] = img.get("alt", "")
+
+        results = []
+        for url, data in by_url.items():
+            title = data["title"]
+            if not title:
+                title = url.rstrip("/").rsplit("/", 1)[-1]
+                title = re.sub(r"^[a-z0-9]+-", "", title).replace("-", " ").title()
+            results.append(Manga(
+                title=title,
+                url=url,
+                cover_url=data["cover_url"],
+            ))
+
+        return results[:20]
+
+    def _search_in_thread(self, query: str) -> List[Manga]:
+        """Drive the rendered browse search box."""
+        from playwright_stealth import Stealth
+
+        browser, context = self._get_browser_in_thread()
+        page = context.new_page()
+
+        try:
+            Stealth().apply_stealth_sync(page)
+            page.goto(f"{self.base_url}/browse", wait_until="domcontentloaded", timeout=45000)
+            page.wait_for_selector('input[type="search"]', timeout=20000)
+            page.fill('input[type="search"]', query)
+            page.wait_for_timeout(5000)
+            return self._parse_search_html(page.content())
+        finally:
+            page.close()
+
+    def search(self, query: str) -> List[Manga]:
+        """Search for manga by title."""
+        return self._run_serialized(self._search_in_thread, query, timeout=90)
+
+    def _parse_chapters_html(self, html: str) -> List[Chapter]:
+        """Parse rendered chapter-list HTML."""
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        chapters = []
+        seen = set()
+
+        for link in soup.select('a.mchap-row__primary, a[href*="/chapter-"]'):
+            href = link.get("href", "")
+            if not href or "chapter-" not in href:
+                continue
+
+            url = href if href.startswith("http") else urljoin(self.base_url, href)
+            if url in seen:
+                continue
+            seen.add(url)
+
+            text = link.get_text(" ", strip=True)
+            match = re.search(r"\bCh\.?\s*(\d+(?:\.\d+)?)", text, re.I)
+            if not match:
+                match = re.search(r"chapter-(\d+(?:\.\d+)?)", href, re.I)
+            number = match.group(1) if match else "0"
+
+            title = text
+            title = re.sub(r"^Ch\.?\s*\d+(?:\.\d+)?\s*", "", title, flags=re.I)
+            title = title.strip() or f"Chapter {number}"
+
+            chapters.append(Chapter(number=number, title=title, url=url))
+
+        return chapters
+
+    def _get_chapters_in_thread(self, manga_url: str) -> List[Chapter]:
+        """Collect rendered chapter rows across paginated chapter-list pages."""
+        from playwright_stealth import Stealth
+
+        # Comix exposes 20 chapter rows per rendered page. Five pages covers
+        # the newest 100 rows, which is enough for normal update checks while
+        # avoiding very slow first-time crawls on long-running series. Set
+        # MEMANGA_COMIX_MAX_CHAPTER_PAGES for deeper backfills.
+        max_pages = int(os.environ.get("MEMANGA_COMIX_MAX_CHAPTER_PAGES", "5"))
+        browser, context = self._get_browser_in_thread()
+        page = context.new_page()
+
+        try:
+            Stealth().apply_stealth_sync(page)
+
+            chapters = []
+            seen = set()
+            base = manga_url.split("?", 1)[0]
+
+            for page_num in range(1, max_pages + 1):
+                url = f"{base}?page={page_num}"
+                page.goto(url, wait_until="domcontentloaded", timeout=45000)
+                try:
+                    page.wait_for_selector(
+                        'a.mchap-row__primary, a[href*="/chapter-"]',
+                        timeout=12000 if page_num == 1 else 6000,
+                    )
+                except Exception:
+                    break
+
+                batch = self._parse_chapters_html(page.content())
+                new_count = 0
+                for chapter in batch:
+                    if chapter.url in seen:
+                        continue
+                    seen.add(chapter.url)
+                    chapters.append(chapter)
+                    new_count += 1
+
+                if new_count == 0 or len(batch) < 20:
+                    break
+
+            return sorted(chapters, key=lambda ch: ch.numeric)
+        finally:
+            page.close()
+
+    def get_chapters(self, manga_url: str) -> List[Chapter]:
+        """Get chapters for a manga."""
+        return self._run_serialized(
+            self._get_chapters_in_thread, manga_url, timeout=180,
+        )
+
+    def _get_pages_in_thread(self, chapter_url: str) -> List[str]:
+        """Extract reader image URLs from the rendered chapter page."""
+        from playwright_stealth import Stealth
+
+        browser, context = self._get_browser_in_thread()
+        page = context.new_page()
+
+        try:
+            Stealth().apply_stealth_sync(page)
+            page.goto(chapter_url, wait_until="domcontentloaded", timeout=45000)
+            page.wait_for_selector(".rpage-page__img, img", timeout=20000)
+
+            last_height = 0
+            for _ in range(20):
+                page.evaluate("window.scrollBy(0, 1200)")
+                page.wait_for_timeout(350)
+                height = page.evaluate("document.documentElement.scrollHeight")
+                if height == last_height:
+                    break
+                last_height = height
+
+            return page.evaluate("""
+                () => {
+                    const urls = [];
+                    const seen = new Set();
+                    document.querySelectorAll('.rpage-page__img, img').forEach(img => {
+                        const src = img.currentSrc || img.src || img.getAttribute('data-src') || '';
+                        if (!src || seen.has(src)) return;
+                        if (src.includes('avatar') || src.includes('logo') || src.includes('icon')) return;
+                        if (!img.classList.contains('rpage-page__img') && img.naturalHeight < 300) return;
+                        seen.add(src);
+                        urls.push(src);
+                    });
+                    return urls;
+                }
+            """)
+        finally:
+            page.close()
+
+    def get_pages(self, chapter_url: str) -> List[str]:
+        """Get all page image URLs for a chapter."""
+        return self._run_serialized(
+            self._get_pages_in_thread, chapter_url, timeout=120,
+        )
+
+    def download_image(self, url: str, path) -> bool:
+        """Download image with Comix reader headers."""
+        try:
+            response = self.session.get(
+                url,
+                headers={
+                    "User-Agent": self.session.headers.get("User-Agent", ""),
+                    "Referer": f"{self.base_url}/",
+                    "Accept": "image/avif,image/webp,image/apng,image/*,*/*;q=0.8",
+                },
+                timeout=30,
+            )
+            response.raise_for_status()
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            Path(path).write_bytes(response.content)
+            return True
+        except Exception:
+            return False

--- a/memanga/scrapers/mangadex.py
+++ b/memanga/scrapers/mangadex.py
@@ -16,6 +16,18 @@ class MangaDexScraper(BaseScraper):
     def __init__(self):
         super().__init__()
         self._rate_limit = 0.5  # MangaDex is generous with rate limits
+
+        # The MangaDex API rejects requests with HTTP 400 when the session
+        # claims a modern Chrome User-Agent (inherited from BaseScraper) but
+        # omits the Sec-Fetch-* metadata headers a real browser always sends
+        # for such requests. Send the values a browser uses for a same-origin
+        # fetch/XHR to the API, and ask for JSON explicitly.
+        self.session.headers.update({
+            "Accept": "application/json",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+        })
     
     def _extract_manga_id(self, url: str) -> Optional[str]:
         """Extract manga ID from MangaDex URL."""

--- a/memanga/scrapers/mangafire.py
+++ b/memanga/scrapers/mangafire.py
@@ -4,11 +4,11 @@ MangaFire.to scraper using the site's JSON API.
 MangaFire moved from server-rendered /manga/slug.hid pages with /ajax
 endpoints to an SPA under /title/hid-slug backed by a JSON API:
 
+- GET /api/titles?keyword={query}                              (search)
 - GET /api/titles/{hid}/chapters?language=en&limit=100&page=N  (chapter list)
 - GET /api/chapters/{chapter_id}                               (page image URLs)
 
-Both work with plain HTTP (no VRF token needed). Search still goes through
-a persistent Playwright Firefox (see VRFGenerator.search).
+All work with plain HTTP (no browser handshake needed).
 
 Image descrambling based on:
 - https://github.com/f4rh4d-4hmed/MangaFire-API
@@ -21,10 +21,9 @@ import time
 from io import BytesIO
 from typing import List, Optional, Dict, Tuple
 from pathlib import Path
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 from concurrent.futures import ThreadPoolExecutor
 
-from bs4 import BeautifulSoup
 from PIL import Image
 
 from .base import BaseScraper, Chapter, Manga
@@ -300,90 +299,6 @@ class VRFGenerator:
             self._get_chapter_pages_in_thread, chapter_url, timeout=120,
         )
 
-    # ------------------------------------------------------------------
-    # Search via persistent browser
-    # ------------------------------------------------------------------
-    # MangaFire returns 403 to plain HTTP (Cloudflare), so search must
-    # go through a real browser. Launching a fresh Firefox per call
-    # adds ~5-10 s of cold-start latency on top of the actual search
-    # work, which on slower networks pushes MangaFire past the point
-    # the GUI considers it usable. Reusing the persistent VRFGenerator
-    # browser drops per-search cost to ~0.5 s after warm-up.
-    def _search_in_thread(self, query: str) -> List[Manga]:
-        """Run a search using the persistent Firefox in this thread.
-
-        Must be called via `_run_serialized` (same lock as chapter-page
-        extraction) — otherwise concurrent calls would race on the same
-        thread-local `_vrf_thread_local.page`.
-        """
-        page = self._ensure_browser_in_thread()
-
-        results: List[Manga] = []
-        try:
-            # Hit the homepage so the search bar is available + Cloudflare
-            # cookies seed on first call. After the first warm-up this is
-            # cached and returns in <500 ms.
-            page.goto(
-                'https://mangafire.to/',
-                wait_until='domcontentloaded',
-                timeout=60000,
-            )
-            # The search bar redirects to /filter?keyword=…&vrf=<token>.
-            # The server-signed VRF token is not constructible locally, so
-            # the search bar is used instead of building the URL directly.
-            si = page.locator(
-                'input[placeholder*="Search"], input[name="keyword"]'
-            ).first
-            si.fill(query)
-            si.press('Enter')
-            page.wait_for_load_state('domcontentloaded', timeout=30000)
-            # Wait for the first result row OR give up after 10 s. Using
-            # wait_for_selector instead of a fixed sleep means fast
-            # responses come back fast and empty/blocked responses don't
-            # hold the lock longer than necessary.
-            try:
-                page.wait_for_selector(
-                    '.info a[href*="/manga/"]', timeout=10000,
-                )
-            except Exception:
-                pass
-
-            soup = BeautifulSoup(page.content(), 'html.parser')
-            seen_urls = set()
-            for link in soup.select('.info a[href*="/manga/"]'):
-                href = link.get('href', '')
-                title = link.get_text(strip=True)
-                if not title or len(title) < 2:
-                    continue
-                full_url = href if href.startswith('http') \
-                    else f"https://mangafire.to{href}"
-                if full_url in seen_urls:
-                    continue
-                seen_urls.add(full_url)
-                cover_url = None
-                parent = link.find_parent(class_='unit')
-                if parent:
-                    img = parent.select_one('.inner img')
-                    if img:
-                        cover_url = img.get('src')
-                results.append(Manga(
-                    title=title, url=full_url, cover_url=cover_url,
-                ))
-        except Exception as e:
-            print(f"[MangaFire] Search error (persistent browser): {e}")
-        return results[:10]
-
-    def search(self, query: str) -> List[Manga]:
-        """Search via the persistent VRFGenerator browser.
-
-        Public entry point — runs `_search_in_thread` under the same
-        executor lock as chapter-page extraction so they share the
-        thread-local browser without racing.
-        """
-        return self._run_serialized(
-            self._search_in_thread, query, timeout=60,
-        )
-
     def _close_in_thread(self):
         """Clean up browser resources - runs in executor thread."""
         try:
@@ -459,8 +374,7 @@ class MangaFireScraper(BaseScraper):
     # Supported languages
     LANGUAGES = ['en', 'es', 'es-la', 'fr', 'ja', 'pt', 'pt-br']
 
-    # Search now goes through VRFGenerator's persistent browser
-    # (see search() below), avoiding a per-scraper executor.
+    # Search uses the JSON API directly (see search() below).
     # Chapter-pages route through VRFGenerator's own _run_serialized.
 
     def __init__(self):
@@ -573,14 +487,37 @@ class MangaFireScraper(BaseScraper):
         return manga_id, lang, chap_num
 
     def search(self, query: str) -> List[Manga]:
-        """Search for manga via the persistent VRFGenerator browser.
+        """Search for manga via MangaFire's JSON API.
 
-        Routes through `get_vrf_generator()` (a process-wide singleton
-        that keeps Firefox open across calls) instead of launching a
-        fresh browser per query, so per-search latency stays under a
-        second once the browser is warm.
+        The browse page renders results client-side, but the SPA's own
+        /api/titles endpoint returns the search payload directly.
         """
-        return get_vrf_generator().search(query)
+        api_url = f"{self.base_url}/api/titles?keyword={quote(query, safe='')}"
+        data = self._api_get_json(api_url)
+        items = data.get('items')
+        if not isinstance(items, list):
+            raise MangaFireError(
+                f"MangaFire returned an invalid search response for {api_url}"
+            )
+
+        results: List[Manga] = []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            title = str(item.get('title') or '').strip()
+            path = item.get('url') or ''
+            if not title or not path:
+                continue
+            full_url = path if path.startswith('http') \
+                else f"{self.base_url}/{path.lstrip('/')}"
+            poster = item.get('poster') \
+                if isinstance(item.get('poster'), dict) else {}
+            cover_url = (poster.get('medium') or poster.get('large')
+                         or poster.get('small'))
+            results.append(Manga(
+                title=title, url=full_url, cover_url=cover_url,
+            ))
+        return results[:10]
 
     def _chapter_error_message(self, ajax_url: str, data: dict) -> str:
         """Build a concise error from MangaFire/Cloudflare AJAX envelopes."""

--- a/memanga/scrapers/mangapark.py
+++ b/memanga/scrapers/mangapark.py
@@ -1,0 +1,198 @@
+"""
+MangaPark scraper
+https://mangapark1.com
+
+MangaPark's older domains are unreliable from normal requests, while
+mangapark1.com currently serves the catalog without a browser challenge.
+Chapter lists come from the site's JSON endpoint, and page images need a
+Referer header when downloaded from the CDN.
+"""
+
+import re
+import logging
+from typing import List
+from urllib.parse import quote_plus
+from .base import BaseScraper, Chapter, Manga
+
+logger = logging.getLogger(__name__)
+
+
+class MangaParkScraper(BaseScraper):
+    """Scraper for MangaPark (mangapark1.com)."""
+
+    name = "mangapark"
+    base_url = "https://mangapark1.com"
+
+    def search(self, query: str) -> List[Manga]:
+        """Search for manga by title via /filter?keyword=..."""
+        from bs4 import BeautifulSoup
+
+        url = f"{self.base_url}/filter?keyword={quote_plus(query)}"
+        html = self._get_html(url)
+        soup = BeautifulSoup(html, "html.parser")
+
+        results = []
+        seen = set()
+        # Result cards are div.unit; each holds a poster link and a text
+        # title link, both pointing at /manga/<slug>.
+        for unit in soup.select("div.unit"):
+            link = unit.select_one('a[href*="/manga/"]')
+            if not link:
+                continue
+            href = link.get("href", "")
+            if not href or href in seen:
+                continue
+            seen.add(href)
+
+            manga_url = href if href.startswith("http") else f"{self.base_url}{href}"
+
+            img = unit.find("img")
+            # Poster link text is just a flag emoji; prefer the info-block
+            # text link, then the cover's alt attribute.
+            title = ""
+            for a in unit.select('a[href*="/manga/"]'):
+                text = a.get_text(strip=True)
+                if text and not a.find("img") and len(text) > 2:
+                    title = text
+                    break
+            if not title and img:
+                title = img.get("alt", "")
+            if not title:
+                title = href.rstrip("/").split("/")[-1].replace("-", " ").title()
+
+            cover_url = None
+            if img:
+                cover_url = img.get("data-src") or img.get("src")
+                if cover_url and cover_url.startswith("/"):
+                    cover_url = f"{self.base_url}{cover_url}"
+
+            if title and len(title) > 2:
+                results.append(Manga(
+                    title=title,
+                    url=manga_url,
+                    cover_url=cover_url,
+                ))
+
+        return results[:10]
+
+    def _slug_from_url(self, manga_url: str) -> str:
+        """Extract the comic slug from a /manga/<slug> URL."""
+        match = re.search(r"/manga/([^/?#]+)", manga_url)
+        if not match:
+            raise ValueError(f"Not a MangaPark manga URL: {manga_url}")
+        return match.group(1)
+
+    def get_chapters(self, manga_url: str) -> List[Chapter]:
+        """Get all chapters via the JSON chapter-list endpoint.
+
+        The manga page HTML only embeds the latest ~20 chapters; the
+        site's own "Load All Chapters" button calls this endpoint.
+        """
+        slug = self._slug_from_url(manga_url)
+        try:
+            data = self._get_json(
+                f"{self.base_url}/get-chapter-list",
+                params={"slug": slug},
+                headers={"X-Requested-With": "XMLHttpRequest"},
+            )
+            entries = data.get("data", []) if data.get("success") else []
+        except Exception as e:
+            logger.debug(f"Chapter-list endpoint failed for {slug}: {e}")
+            entries = []
+
+        chapters = []
+        seen = set()
+        for entry in entries:
+            chapter_slug = entry.get("chapter_slug")
+            if not chapter_slug or chapter_slug in seen:
+                continue
+            seen.add(chapter_slug)
+
+            num = entry.get("chapter_num")
+            if isinstance(num, float) and num.is_integer():
+                num = int(num)
+            number = str(num) if num is not None else ""
+            if not number:
+                match = re.search(r"(\d+\.?\d*)", chapter_slug)
+                number = match.group(1) if match else chapter_slug
+
+            chapters.append(Chapter(
+                number=number,
+                title=entry.get("chapter_name"),
+                url=f"{self.base_url}/read/{slug}/{chapter_slug}",
+                date=entry.get("updated_at"),
+            ))
+
+        if not chapters:
+            chapters = self._chapters_from_html(manga_url, slug)
+
+        return sorted(chapters)
+
+    def _chapters_from_html(self, manga_url: str, slug: str) -> List[Chapter]:
+        """Fallback: scrape /read/<slug>/... links off the manga page."""
+        from bs4 import BeautifulSoup
+
+        html = self._get_html(manga_url)
+        soup = BeautifulSoup(html, "html.parser")
+
+        chapters = []
+        seen = set()
+        for link in soup.select(f'a[href*="/read/{slug}/"]'):
+            href = link.get("href", "")
+            if not href or href in seen:
+                continue
+            seen.add(href)
+
+            chapter_url = href if href.startswith("http") else f"{self.base_url}{href}"
+            text = link.get("title") or link.get_text(strip=True)
+            match = re.search(r"chapter[_\s-]*(\d+\.?\d*)", text, re.I) \
+                or re.search(r"(\d+\.?\d*)", text) \
+                or re.search(r"chapter[_\s-]*(\d+)(?:-(\d+))?", href, re.I)
+            if match and len(match.groups()) > 1 and match.group(2):
+                number = f"{match.group(1)}.{match.group(2)}"
+            else:
+                number = match.group(1) if match else text
+
+            chapters.append(Chapter(
+                number=number,
+                title=text or None,
+                url=chapter_url,
+            ))
+
+        return chapters
+
+    def get_pages(self, chapter_url: str) -> List[str]:
+        """Get page image URLs from the reader page.
+
+        Pages are lazyload <img data-src> tags inside div.pages; the
+        CDN URLs are server-rendered, no JS needed.
+        """
+        from bs4 import BeautifulSoup
+
+        html = self._get_html(chapter_url)
+        soup = BeautifulSoup(html, "html.parser")
+
+        pages = []
+        seen = set()
+        for img in soup.select("div.pages img"):
+            src = img.get("data-src") or img.get("src")
+            if not src or "/assets/" in src or src in seen:
+                continue
+            seen.add(src)
+            pages.append(src)
+
+        return pages
+
+    def download_image(self, url: str, path) -> bool:
+        """Download image with Referer — the CDN 403s without it."""
+        from pathlib import Path
+
+        try:
+            response = self._request(url, headers={"Referer": f"{self.base_url}/"})
+            path = Path(path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(response.content)
+            return True
+        except Exception as e:
+            logger.debug(f"Failed to download {url}: {e}")
+            return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.3.0"
+version = "0.3.3"
 description = "Automatic manga downloader with Kindle support (CLI)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/scrapers/fixtures/mangapark/chapter.html
+++ b/tests/scrapers/fixtures/mangapark/chapter.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="cdn-thumb-domain" content="https://cdn2.holdingyouclose.xyz">
+</head>
+<body>
+<img src="/assets/images/manga-park.webp" alt="MangaPark Logo">
+<div class="pages longstrip">
+  <div class="page fit-w">
+    <div class="img loaded"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp" data-src='https://cdn2.holdingyouclose.xyz/one-piece/1/0.webp' data-number="0"></div>
+  </div>
+  <div class="page fit-w">
+    <div class="img loaded"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp" data-src='https://cdn2.holdingyouclose.xyz/one-piece/1/1.webp' data-number="1"></div>
+  </div>
+  <!-- duplicate of page 1: must be deduped -->
+  <div class="page fit-w">
+    <div class="img loaded"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp" data-src='https://cdn2.holdingyouclose.xyz/one-piece/1/1.webp' data-number="1"></div>
+  </div>
+  <div class="page fit-w">
+    <div class="img loaded"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp" data-src='https://cdn2.holdingyouclose.xyz/one-piece/1/2.webp' data-number="2"></div>
+  </div>
+  <!-- placeholder-only img: must be skipped -->
+  <div class="page fit-w">
+    <div class="img"><img class="fit-w lazyload image-thumb" src="/assets/images/image-default-bbato.webp"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/scrapers/fixtures/mangapark/chapter_list.json
+++ b/tests/scrapers/fixtures/mangapark/chapter_list.json
@@ -1,0 +1,11 @@
+{
+  "success": true,
+  "data": [
+    {"comic_id": 4280, "chapter_id": 1241, "chapter_name": "Chapter 1187", "chapter_slug": "chapter-1187", "updated_at": "2026-07-03 03:21:33", "chapter_num": 1187},
+    {"comic_id": 4280, "chapter_id": 1139, "chapter_name": "Chapter 1186", "chapter_slug": "chapter-1186", "updated_at": "2026-06-28 03:40:34", "chapter_num": 1186},
+    {"comic_id": 4280, "chapter_id": 901, "chapter_name": "Chapter 10.5", "chapter_slug": "chapter-10-5", "updated_at": "2026-06-01 00:00:00", "chapter_num": 10.5},
+    {"comic_id": 4280, "chapter_id": 12, "chapter_name": "Chapter 1", "chapter_slug": "chapter-1", "updated_at": "2026-05-01 00:00:00", "chapter_num": 1.0},
+    {"comic_id": 4280, "chapter_id": 12, "chapter_name": "Chapter 1", "chapter_slug": "chapter-1", "updated_at": "2026-05-01 00:00:00", "chapter_num": 1.0}
+  ],
+  "total": 5
+}

--- a/tests/scrapers/fixtures/mangapark/manga.html
+++ b/tests/scrapers/fixtures/mangapark/manga.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="tab-content" data-name="chapter">
+  <div class="list-body">
+    <ul id="chapter-list" class="scroll-sm">
+      <li class="item" data-number="1241">
+        <a href="https://mangapark1.com/read/one-piece/chapter-1187" title="Chapter 1187"><span>Chapter 1187: </span> <span>4 day ago</span></a>
+      </li>
+      <li class="item" data-number="1139">
+        <a href="https://mangapark1.com/read/one-piece/chapter-1186" title="Chapter 1186"><span>Chapter 1186: </span> <span>9 day ago</span></a>
+      </li>
+      <li class="item" data-number="901">
+        <a href="https://mangapark1.com/read/one-piece/chapter-10-5" title="Chapter 10.5"><span>Chapter 10.5: </span> <span>1 year ago</span></a>
+      </li>
+      <li class="item text-center load-all-btn">
+        <button id="load-all-chapters-btn" data-comic-slug="one-piece">Load All Chapters</button>
+      </li>
+    </ul>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/scrapers/fixtures/mangapark/search.html
+++ b/tests/scrapers/fixtures/mangapark/search.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="original card-lg">
+  <div class="unit item-4280">
+    <div class="inner">
+      <a href="https://mangapark1.com/manga/one-piece" class="poster" style="position:relative;">
+        <div><img src="/assets/images/image-default-bbato.webp" data-src="https://cdn2.holdingyouclose.xyz/thumb/one-piece.webp" alt="One Piece" class="lazyload image-thumb" referrerpolicy="origin"></div>
+        <span class="lang-flag-badge" title="EN">🇬🇧</span>
+      </a>
+      <div class="info">
+        <div><a class="type" href="https://mangapark1.com/type/manga" style="margin-right:4px;">Manga</a></div>
+        <a href="https://mangapark1.com/manga/one-piece">One Piece</a>
+        <ul class="content" data-name="chap">
+          <li><a href="https://mangapark1.com/read/one-piece/chapter-1187" title="Chapter 1187"><span>Chapter 1187</span> <span>4 day ago</span></a></li>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="unit item-4281">
+    <div class="inner">
+      <a href="https://mangapark1.com/manga/one-piece-official-colored" class="poster">
+        <div><img src="/assets/images/image-default-bbato.webp" data-src="https://cdn2.holdingyouclose.xyz/thumb/one-piece-official-colored.webp" alt="One Piece (Official Colored)" class="lazyload image-thumb"></div>
+        <span class="lang-flag-badge" title="EN">🇬🇧</span>
+      </a>
+      <div class="info">
+        <div><a class="type" href="https://mangapark1.com/type/manga">Manga</a></div>
+        <a href="https://mangapark1.com/manga/one-piece-official-colored">One Piece (Official Colored)</a>
+      </div>
+    </div>
+  </div>
+  <!-- duplicate URL: must be deduped -->
+  <div class="unit item-4280">
+    <div class="inner">
+      <a href="https://mangapark1.com/manga/one-piece" class="poster">
+        <div><img src="/assets/images/image-default-bbato.webp" data-src="https://cdn2.holdingyouclose.xyz/thumb/one-piece.webp" alt="One Piece" class="lazyload image-thumb"></div>
+      </a>
+    </div>
+  </div>
+  <!-- no info text link: title must fall back to img alt -->
+  <div class="unit item-5000">
+    <div class="inner">
+      <a href="https://mangapark1.com/manga/chopperman-yuke-yuke-minna-no-chopper-sensei" class="poster">
+        <div><img src="/assets/images/image-default-bbato.webp" data-src="https://cdn2.holdingyouclose.xyz/thumb/chopperman.webp" alt="Chopperman - Yuke Yuke! Minna no Chopper-sensei" class="lazyload image-thumb"></div>
+        <span class="lang-flag-badge" title="EN">🇬🇧</span>
+      </a>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/scrapers/live/_helpers.py
+++ b/tests/scrapers/live/_helpers.py
@@ -8,8 +8,10 @@ Python rather than only as pytest fixtures.
 from __future__ import annotations
 
 import socket
+import tempfile
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import pytest
 import requests
@@ -23,15 +25,51 @@ STATUS_HTTP_ERROR = "HTTP_ERROR"
 STATUS_STALE = "STALE"
 STATUS_SKIP = "SKIP"
 
+# Pipeline stage constants — each curated probe walks these in order,
+# so a failure names the first stage that broke.
+STAGE_REACHABILITY = "reachability"
+STAGE_SEARCH = "search"
+STAGE_CHAPTERS = "chapters"
+STAGE_PAGES = "pages"
+STAGE_IMAGE = "image"
+
+PIPELINE_STAGES = (
+    STAGE_REACHABILITY, STAGE_SEARCH, STAGE_CHAPTERS, STAGE_PAGES, STAGE_IMAGE,
+)
+
 
 @dataclass
 class HealthResult:
     """One row in the per-run health report."""
     domain: str
     status: str
+    stage: str = ""  # first pipeline stage that failed ("" = none / n.a.)
     detail: str = ""
     elapsed_ms: float = 0.0
     extra: dict = field(default_factory=dict)
+
+
+@dataclass
+class StageResult:
+    """Outcome of one pipeline stage for one domain."""
+    stage: str
+    status: str
+    detail: str = ""
+    elapsed_ms: float = 0.0
+
+
+class StageFailure(Exception):
+    """Raised by ScraperPipeline when a stage fails.
+
+    Carries the failed stage plus everything that already passed, so
+    the test can report "search OK, chapters OK, pages BROKEN" instead
+    of one opaque STALE.
+    """
+
+    def __init__(self, failed: StageResult, stages: list):
+        self.failed = failed
+        self.stages = stages  # all stages run so far, failed one last
+        super().__init__(f"[{failed.status}:{failed.stage}] {failed.detail}")
 
 
 LIVE_TIMEOUT = 15  # seconds
@@ -42,7 +80,16 @@ LIVE_HEADERS = {
     ),
     "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
     "Accept-Language": "en-US,en;q=0.5",
+    # A real browser always sends Sec-Fetch-* metadata. Some APIs (e.g.
+    # api.mangadex.org) reject a Chrome User-Agent that omits them with
+    # HTTP 400, so send the values a top-level navigation would use.
+    "Sec-Fetch-Dest": "document",
+    "Sec-Fetch-Mode": "navigate",
+    "Sec-Fetch-Site": "none",
 }
+
+# Enough to hold any of the magic byte signatures below.
+_MIN_IMAGE_BYTES = 1024
 
 
 def probe_url(url: str, timeout: float = LIVE_TIMEOUT) -> HealthResult:
@@ -53,15 +100,18 @@ def probe_url(url: str, timeout: float = LIVE_TIMEOUT) -> HealthResult:
         resp = requests.get(url, headers=LIVE_HEADERS, timeout=timeout,
                               allow_redirects=True)
     except requests.exceptions.SSLError as e:
-        return HealthResult(domain, STATUS_DEAD, f"ssl error: {e!s}",
+        return HealthResult(domain, STATUS_DEAD, STAGE_REACHABILITY,
+                              f"ssl error: {e!s}",
                               (time.monotonic() - t0) * 1000)
     except (requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
             socket.gaierror) as e:
-        return HealthResult(domain, STATUS_DEAD, f"connection error: {e!s}",
+        return HealthResult(domain, STATUS_DEAD, STAGE_REACHABILITY,
+                              f"connection error: {e!s}",
                               (time.monotonic() - t0) * 1000)
     except requests.exceptions.RequestException as e:
-        return HealthResult(domain, STATUS_HTTP_ERROR, f"request error: {e!s}",
+        return HealthResult(domain, STATUS_HTTP_ERROR, STAGE_REACHABILITY,
+                              f"request error: {e!s}",
                               (time.monotonic() - t0) * 1000)
 
     elapsed = (time.monotonic() - t0) * 1000
@@ -71,23 +121,23 @@ def probe_url(url: str, timeout: float = LIVE_TIMEOUT) -> HealthResult:
         body_lower = resp.text[:2000].lower()
         if any(s in body_lower for s in
                 ("cloudflare", "cf-ray", "just a moment", "ddos protection")):
-            return HealthResult(domain, STATUS_PROTECTED,
+            return HealthResult(domain, STATUS_PROTECTED, STAGE_REACHABILITY,
                                   f"HTTP {resp.status_code} (Cloudflare-style)",
                                   elapsed)
-        return HealthResult(domain, STATUS_HTTP_ERROR,
+        return HealthResult(domain, STATUS_HTTP_ERROR, STAGE_REACHABILITY,
                               f"HTTP {resp.status_code}", elapsed)
 
     if resp.status_code >= 400:
-        return HealthResult(domain, STATUS_HTTP_ERROR,
+        return HealthResult(domain, STATUS_HTTP_ERROR, STAGE_REACHABILITY,
                               f"HTTP {resp.status_code}", elapsed)
 
     # Suspicious tiny body
     if len(resp.text) < 200:
-        return HealthResult(domain, STATUS_STALE,
+        return HealthResult(domain, STATUS_STALE, STAGE_REACHABILITY,
                               f"HTTP 200 but body only {len(resp.text)} bytes",
                               elapsed)
 
-    return HealthResult(domain, STATUS_OK,
+    return HealthResult(domain, STATUS_OK, "",
                           f"HTTP {resp.status_code} ({len(resp.text)} bytes)",
                           elapsed)
 
@@ -105,17 +155,156 @@ def assert_alive(result: HealthResult):
         pytest.fail(f"[STALE] {result.domain}: {result.detail}")
 
 
-def assert_parsed_something(scraper_call, *args, min_items: int = 1):
-    """Call scraper_call(*args); fail if it returns 0 results.
+def looks_like_image(data: bytes) -> bool:
+    """True if the byte prefix matches a known image format signature."""
+    return (
+        data.startswith(b"\xff\xd8\xff")            # JPEG
+        or data.startswith(b"\x89PNG\r\n\x1a\n")    # PNG
+        or data.startswith((b"GIF87a", b"GIF89a"))  # GIF
+        or (data[:4] == b"RIFF" and data[8:12] == b"WEBP")
+        or data[4:12] in (b"ftypavif", b"ftypheic")
+        or data.startswith(b"BM")                   # BMP
+    )
 
-    Wraps exceptions into STALE-style failures so they show up in the
-    report cleanly rather than as stack traces.
+
+def scraper_base_url(scraper) -> str:
+    """Configured base URL, whichever attribute the scraper family uses."""
+    return (getattr(scraper, "BASE_URL", None)
+            or getattr(scraper, "base_url", None) or "")
+
+
+class ScraperPipeline:
+    """Runs one scraper's user-visible stages in order against the live
+    site: search → chapters → pages → image download.
+
+    Each stage records a StageResult; the first failure raises
+    StageFailure carrying everything that already passed, so pytest
+    output and the JSON report can pinpoint the broken stage.
     """
-    try:
-        result = scraper_call(*args)
-    except Exception as e:
-        pytest.fail(f"[STALE] scraper raised: {type(e).__name__}: {e!s}")
-    if not result or len(result) < min_items:
-        pytest.fail(f"[STALE] scraper returned {len(result) if result else 0} items, "
-                     f"expected ≥ {min_items} (HTML structure may have changed)")
-    return result
+
+    def __init__(self, scraper, domain: str):
+        self.scraper = scraper
+        self.domain = domain
+        self.stages: list[StageResult] = []
+
+    # ── internals ────────────────────────────────────────────────
+
+    def _fail(self, stage: str, detail: str, elapsed_ms: float = 0.0,
+              status: str = STATUS_STALE):
+        failed = StageResult(stage, status, detail, elapsed_ms)
+        self.stages.append(failed)
+        raise StageFailure(failed, self.stages) from None
+
+    def _pass(self, stage: str, detail: str, elapsed_ms: float):
+        self.stages.append(StageResult(stage, STATUS_OK, detail, elapsed_ms))
+
+    def _call(self, stage: str, label: str, fn, *args):
+        """Call fn(*args); classify exceptions by stage + cause."""
+        t0 = time.monotonic()
+        try:
+            out = fn(*args)
+        except (requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout, socket.gaierror) as e:
+            self._fail(stage, f"{label} → connection error: {e!s}",
+                       (time.monotonic() - t0) * 1000, STATUS_DEAD)
+        except requests.exceptions.HTTPError as e:
+            self._fail(stage, f"{label} → HTTP error: {e!s}",
+                       (time.monotonic() - t0) * 1000, STATUS_HTTP_ERROR)
+        except Exception as e:
+            self._fail(stage,
+                       f"{label} raised {type(e).__name__}: {e!s} "
+                       f"(HTML structure may have changed)",
+                       (time.monotonic() - t0) * 1000)
+        return out, (time.monotonic() - t0) * 1000
+
+    # ── stages ───────────────────────────────────────────────────
+
+    def search(self, query: str, min_results: int = 1) -> list:
+        label = f"search({query!r})"
+        results, ms = self._call(STAGE_SEARCH, label, self.scraper.search, query)
+        if not results or len(results) < min_results:
+            self._fail(STAGE_SEARCH,
+                       f"{label} returned {len(results) if results else 0} "
+                       f"results, expected ≥ {min_results}", ms)
+        first = results[0]
+        if not getattr(first, "url", ""):
+            self._fail(STAGE_SEARCH,
+                       f"{label} → first result {first.title!r} has empty url", ms)
+        self._pass(STAGE_SEARCH,
+                   f"{label} → {len(results)} results "
+                   f"(first: {first.title!r} {first.url})", ms)
+        return results
+
+    def chapters(self, manga_url: str, min_chapters: int = 1) -> list:
+        label = f"get_chapters({manga_url})"
+        chapters, ms = self._call(STAGE_CHAPTERS, label,
+                                    self.scraper.get_chapters, manga_url)
+        if not chapters or len(chapters) < min_chapters:
+            self._fail(STAGE_CHAPTERS,
+                       f"{label} returned "
+                       f"{len(chapters) if chapters else 0} chapters, "
+                       f"expected ≥ {min_chapters}", ms)
+        first = chapters[0]
+        if not getattr(first, "url", ""):
+            self._fail(STAGE_CHAPTERS,
+                       f"{label} → chapter {first.number!r} has empty url", ms)
+        self._pass(STAGE_CHAPTERS,
+                   f"{label} → {len(chapters)} chapters "
+                   f"(#{chapters[0].number} … #{chapters[-1].number})", ms)
+        return chapters
+
+    def pages(self, chapter) -> list:
+        label = f"get_pages(ch {chapter.number!r} {chapter.url})"
+        pages, ms = self._call(STAGE_PAGES, label,
+                                 self.scraper.get_pages, chapter.url)
+        if not pages:
+            self._fail(STAGE_PAGES, f"{label} returned 0 page URLs", ms)
+        first = pages[0]
+        if not isinstance(first, str) or not (
+                first.startswith(("http://", "https://", "//"))):
+            self._fail(STAGE_PAGES,
+                       f"{label} → first page URL looks wrong: {first!r}", ms)
+        self._pass(STAGE_PAGES,
+                   f"{label} → {len(pages)} page URLs (first: {first})", ms)
+        return pages
+
+    def image(self, page_url: str):
+        """Download the first page image via the scraper's own
+        download_image() (the production path, incl. Referer headers)
+        and verify the bytes are a real image."""
+        if page_url.startswith("//"):
+            page_url = "https:" + page_url
+        t0 = time.monotonic()
+        with tempfile.TemporaryDirectory(prefix="memanga-live-") as tmp:
+            path = Path(tmp) / "probe.img"
+            ok = self.scraper.download_image(page_url, path)
+            ms = (time.monotonic() - t0) * 1000
+            if not ok:
+                self._fail(STAGE_IMAGE,
+                           f"download_image({page_url}) returned False "
+                           f"({self._image_hint(page_url)})", ms)
+            data = path.read_bytes() if path.exists() else b""
+            if len(data) < _MIN_IMAGE_BYTES:
+                self._fail(STAGE_IMAGE,
+                           f"download_image({page_url}) wrote only "
+                           f"{len(data)} bytes", ms)
+            if not looks_like_image(data):
+                self._fail(STAGE_IMAGE,
+                           f"download_image({page_url}) wrote {len(data)} "
+                           f"bytes but not image data "
+                           f"(starts with {data[:12]!r})", ms)
+            self._pass(STAGE_IMAGE,
+                       f"downloaded first page ({len(data)} bytes, "
+                       f"valid image) from {page_url}", ms)
+
+    def _image_hint(self, url: str) -> str:
+        """download_image() swallows errors — re-probe for a diagnosis."""
+        try:
+            resp = self.scraper.session.get(
+                url, timeout=LIVE_TIMEOUT, stream=True)
+            hint = (f"direct GET → HTTP {resp.status_code}, "
+                    f"Content-Type: {resp.headers.get('Content-Type')}")
+            resp.close()
+            return hint
+        except Exception as e:
+            return f"direct GET failed: {type(e).__name__}: {e!s}"

--- a/tests/scrapers/live/conftest.py
+++ b/tests/scrapers/live/conftest.py
@@ -14,13 +14,18 @@ Capture a JSON report:
 
     pytest -m live tests/scrapers/live/ --health-report=health.json
 
-Failures are classified in the test name so you can scan the output:
+Failures are classified so you can scan the output:
   - DEAD        : DNS lookup failed, connection refused, timeout
   - PROTECTED   : Cloudflare/anti-bot 403/503 (site exists, blocked us)
   - HTTP_ERROR  : 4xx/5xx response
   - STALE       : site responded but the scraper extracted nothing
                   (likely the HTML structure changed)
   - OK          : reachable + scraper extracted real data
+
+Curated pipeline probes (test_live_parsing.py) additionally name the
+first broken stage — reachability, search, chapters, pages or image —
+both in the pytest failure message ("[STALE:pages] domain: ...") and
+in the JSON report's `stage` field / per-stage `extra.stages` rows.
 """
 
 from __future__ import annotations
@@ -74,6 +79,17 @@ def health_recorder():
     return _record
 
 
+def _count_failures_by_stage() -> dict:
+    from _helpers import STATUS_OK, STATUS_SKIP, STATUS_PROTECTED
+    counts: dict = {}
+    for r in _RESULTS:
+        # PROTECTED is informational, not a failure (see assert_alive).
+        if r.status not in (STATUS_OK, STATUS_SKIP, STATUS_PROTECTED) \
+                and r.stage:
+            counts[r.stage] = counts.get(r.stage, 0) + 1
+    return counts
+
+
 def pytest_sessionfinish(session, exitstatus):
     path = session.config.getoption("--health-report")
     if not path or not _RESULTS:
@@ -92,6 +108,9 @@ def pytest_sessionfinish(session, exitstatus):
             "stale": sum(1 for r in _RESULTS if r.status == STATUS_STALE),
             "skip": sum(1 for r in _RESULTS if r.status == STATUS_SKIP),
         },
+        # Which pipeline stage failures happened at (curated probes
+        # only — broad reachability rows always say "reachability").
+        "failures_by_stage": _count_failures_by_stage(),
         "results": [asdict(r) for r in _RESULTS],
     }
     Path(path).write_text(json.dumps(out, indent=2), encoding="utf-8")

--- a/tests/scrapers/live/test_live_parsing.py
+++ b/tests/scrapers/live/test_live_parsing.py
@@ -1,15 +1,21 @@
-"""End-to-end parsing health checks against live sites.
+"""End-to-end pipeline health checks against live sites.
 
 Reachability alone isn't enough — a site can be up while its HTML
-changed in a way that breaks the parser. This file actually invokes
-each scraper's search() / get_chapters() / get_pages() against the
-real site and fails when the parser returns zero results (likely
-indicates the site's structure drifted).
+changed in a way that breaks the parser. Each probe here walks the
+same stages a real download does, in order, against the live site:
+
+    reachability → search → chapters → pages → image
+
+and fails on the FIRST broken stage, so the pytest output (and the
+--health-report JSON) tells you *which part* of the scraper is broken,
+e.g. `[STALE:pages] mangapill.com: get_pages(...) returned 0 page
+URLs` — not just a generic STALE.
 
 We can't maintain a known-good URL per domain forever, so this file
 is deliberately curated — it tests a focused set of high-traffic
 sources + every scraper template family (one representative per
-template).
+template). Broad one-request-per-domain coverage lives in
+test_live_reachability.py.
 
 Skipped by default. Opt in with:
     pytest -m live tests/scrapers/live/test_live_parsing.py -v
@@ -21,143 +27,140 @@ Single source:
 
 from __future__ import annotations
 
+from dataclasses import dataclass, asdict
+
 import pytest
 
 from memanga.scrapers import get_scraper
 
 from _helpers import (  # injected onto sys.path by conftest.py
-    HealthResult, STATUS_OK, STATUS_STALE, STATUS_PROTECTED, STATUS_DEAD,
-    probe_url, assert_alive, assert_parsed_something, LIVE_TIMEOUT,
+    HealthResult, StageResult, StageFailure, ScraperPipeline,
+    STATUS_OK, STATUS_STALE, STATUS_PROTECTED, STATUS_DEAD, STATUS_HTTP_ERROR,
+    STAGE_REACHABILITY,
+    probe_url, scraper_base_url,
 )
 
 
 # ─────────────────────────────────────────────────────────────────────
-# Per-source health probes.
+# Per-source probe specs.
 #
-# Each probe is a callable that takes the scraper instance and either:
-#   - returns silently on success
-#   - calls pytest.fail / pytest.skip with a classified message
+# query=None means a single-manga template site: skip search and get
+# chapters straight from the configured base URL.
 #
-# Keep these LIGHT — one search + one get_chapters per probe is plenty.
-# Avoid get_pages on Playwright sites (too slow + brittle for CI).
+# Keep these LIGHT — the full pipeline is ~4 requests per source
+# (search, chapters, pages, one image). Disable later stages where a
+# site makes them too slow/brittle (e.g. check_pages=False for
+# Playwright-rendered readers).
 # ─────────────────────────────────────────────────────────────────────
 
 
-def _probe_search_then_chapters(scraper, query: str, *,
-                                  expect_results: int = 1,
-                                  expect_chapters: int = 1,
-                                  do_chapters: bool = True):
-    """search(query) → ≥1 result; first result's chapters → ≥1 chapter."""
-    results = assert_parsed_something(scraper.search, query,
-                                        min_items=expect_results)
-    if not do_chapters:
-        return
-    first = results[0]
-    assert_parsed_something(scraper.get_chapters, first.url,
-                              min_items=expect_chapters)
+@dataclass(frozen=True)
+class ProbeSpec:
+    description: str
+    query: str | None = None      # None → single-manga template site
+    check_chapters: bool = True
+    check_pages: bool = True
+    check_image: bool = True
 
 
-def _probe_single_manga_chapters(scraper):
-    """For single-manga template sites: chapters from the configured base."""
-    base = getattr(scraper, "BASE_URL", None) or getattr(scraper, "base_url", "")
-    assert_parsed_something(scraper.get_chapters, base, min_items=1)
-
-
-# Domain → (description, probe-fn). Curated list of sites we test
-# end-to-end. Easy to expand: just add another entry.
 PARSING_PROBES = {
-    # ── Aggregators (search + chapters) ──
-    "mangadex.org": (
-        "API client", lambda s: _probe_search_then_chapters(s, "one piece"),
-    ),
-    "mangapill.com": (
-        "Simple HTTP aggregator",
-        lambda s: _probe_search_then_chapters(s, "one piece"),
-    ),
-    "tcbonepiecechapters.com": (
-        "TCB Scans (project list)",
-        lambda s: _probe_search_then_chapters(s, "one piece"),
-    ),
-    "mangakakalot.com": (
-        "Mangakakalot",
-        lambda s: _probe_search_then_chapters(s, "naruto"),
-    ),
-    "manganato.com": (
-        "Manganato",
-        lambda s: _probe_search_then_chapters(s, "naruto"),
-    ),
-    "mangahub.io": (
-        "MangaHub", lambda s: _probe_search_then_chapters(s, "one piece"),
-    ),
+    # ── Aggregators (full pipeline) ──
+    # "one piece" is fully external on MangaDex (MangaPlus) → 0 readable
+    # chapters, so probe a title that is actually hosted there.
+    "mangadex.org": ProbeSpec("API client", query="chainsaw man"),
+    "mangapill.com": ProbeSpec("Simple HTTP aggregator", query="one piece"),
+    "mangapark1.com": ProbeSpec("MangaPark", query="one piece"),
+    "tcbonepiecechapters.com": ProbeSpec("TCB Scans (project list)",
+                                           query="one piece"),
+    "mangakakalot.com": ProbeSpec("Mangakakalot", query="naruto"),
+    "manganato.com": ProbeSpec("Manganato", query="naruto"),
+    "mangahub.io": ProbeSpec("MangaHub", query="one piece"),
+    "comix.to": ProbeSpec("Comix.to", query="kubera"),
 
     # ── One representative per template family ──
-    "dddmanga.com": (
-        "NuxtSSR template (single-manga)",
-        _probe_single_manga_chapters,
-    ),
-    "akiramanga.com": (
-        "OGImageMeta template (single-manga)",
-        _probe_single_manga_chapters,
-    ),
-    "overlord-manga.online": (
-        "LaiondCDN template (single-manga)",
-        _probe_single_manga_chapters,
-    ),
-    "hxhmanga.com": (
-        "Mangosm template (single-manga)",
-        _probe_single_manga_chapters,
-    ),
-    "hiperdex.com": (
-        "WordPress Madara template (aggregator)",
-        lambda s: _probe_search_then_chapters(s, "solo leveling"),
-    ),
+    "dddmanga.com": ProbeSpec("NuxtSSR template (single-manga)"),
+    "akiramanga.com": ProbeSpec("OGImageMeta template (single-manga)"),
+    "overlord-manga.online": ProbeSpec("LaiondCDN template (single-manga)"),
+    "hxhmanga.com": ProbeSpec("Mangosm template (single-manga)"),
+    "hiperdex.com": ProbeSpec("WordPress Madara template (aggregator)",
+                                query="solo leveling"),
 
     # ── ReadManga base family ──
-    "readsnk.com": (
-        "ReadManga base (Attack on Titan)",
-        lambda s: _probe_search_then_chapters(s, "attack on titan",
-                                                do_chapters=False),
-    ),
+    # Search-only: chapter listing needs a manga URL slug this site's
+    # search results don't provide reliably.
+    "readsnk.com": ProbeSpec("ReadManga base (Attack on Titan)",
+                               query="attack on titan",
+                               check_chapters=False),
 }
+
+
+def _fail_message(domain: str, failure: StageFailure) -> str:
+    """Multi-line failure: broken stage first, then what already passed."""
+    lines = [f"[{failure.failed.status}:{failure.failed.stage}] "
+             f"{domain}: {failure.failed.detail}"]
+    for s in failure.stages:
+        if s is failure.failed:
+            mark = "FAIL"
+        elif s.status == STATUS_OK:
+            mark = "OK"
+        else:
+            mark = "WARN"
+        lines.append(f"  {mark} {s.stage:12s} {s.detail}  ({s.elapsed_ms:.0f}ms)")
+    return "\n".join(lines)
 
 
 @pytest.mark.live
 @pytest.mark.health
-@pytest.mark.parametrize("domain,description,probe",
-                          [(d, desc, fn) for d, (desc, fn) in PARSING_PROBES.items()],
+@pytest.mark.parametrize("domain,spec",
+                          list(PARSING_PROBES.items()),
                           ids=list(PARSING_PROBES.keys()))
-def test_scraper_parses_live_site(domain, description, probe, health_recorder):
-    """Full end-to-end check: reachability + parser still extracts data."""
+def test_scraper_pipeline_live(domain, spec, health_recorder):
+    """Stage-by-stage check: reachability, search, chapters, pages, image."""
     # 1. Reachability first — fail fast if the site is dead.
-    base = f"https://{domain}"
-    reach = probe_url(base)
-    if reach.status == STATUS_DEAD:
-        health_recorder(reach)
-        pytest.fail(f"[DEAD] {domain}: {reach.detail}")
-    if reach.status == STATUS_PROTECTED:
-        # Real scraper bypasses Cloudflare — still try the probe.
-        pass
+    reach = probe_url(f"https://{domain}")
+    stages = [StageResult(STAGE_REACHABILITY, reach.status, reach.detail,
+                            reach.elapsed_ms)]
+    if reach.status not in (STATUS_OK, STATUS_PROTECTED):
+        health_recorder(HealthResult(
+            domain, reach.status, STAGE_REACHABILITY, reach.detail,
+            reach.elapsed_ms, extra={"stages": [asdict(s) for s in stages]}))
+        pytest.fail(f"[{reach.status}:reachability] {domain}: {reach.detail}")
+    # PROTECTED is not fatal — the real scraper bypasses Cloudflare,
+    # so still run the pipeline and let its stages decide.
 
-    # 2. Run the probe. Wraps any exception into STALE-style failure.
+    # 2. Walk the pipeline; first broken stage raises StageFailure.
     scraper = get_scraper(domain)
+    pipe = ScraperPipeline(scraper, domain)
+    pipe.stages = stages
+    failure = None
     try:
-        probe(scraper)
-        result = HealthResult(domain, STATUS_OK, description,
-                                reach.elapsed_ms)
-    except pytest.skip.Exception:
-        raise
-    except (pytest.fail.Exception, AssertionError) as e:
-        result = HealthResult(domain, STATUS_STALE, str(e), reach.elapsed_ms)
-        health_recorder(result)
-        raise
-    except Exception as e:
-        result = HealthResult(domain, STATUS_STALE,
-                                f"{type(e).__name__}: {e}", reach.elapsed_ms)
-        health_recorder(result)
-        raise
+        if spec.query is None:
+            manga_url = scraper_base_url(scraper)
+        else:
+            results = pipe.search(spec.query)
+            manga_url = results[0].url
+        if spec.check_chapters:
+            chapters = pipe.chapters(manga_url)
+            if spec.check_pages:
+                pages = pipe.pages(chapters[0])
+                if spec.check_image:
+                    pipe.image(pages[0])
+    except StageFailure as e:
+        health_recorder(HealthResult(
+            domain, e.failed.status, e.failed.stage, e.failed.detail,
+            reach.elapsed_ms,
+            extra={"stages": [asdict(s) for s in e.stages]}))
+        failure = e
 
+    if failure:
+        pytest.fail(_fail_message(domain, failure), pytrace=False)
+
+    result = HealthResult(
+        domain, STATUS_OK, "", spec.description, reach.elapsed_ms,
+        extra={"stages": [asdict(s) for s in pipe.stages]})
     health_recorder(result)
-    print(f"[{result.status:9s}] {domain:38s} {description}")
+    ran = ", ".join(s.stage for s in pipe.stages)
+    print(f"[{result.status:9s}] {domain:38s} {spec.description} ({ran})")
 
 
 # ─────────────────────────────────────────────────────────────────────
@@ -188,10 +191,12 @@ def test_zzz_health_summary_report():  # name puts it last alphabetically
 
     by_status: dict[str, list[str]] = {}
     for r in _RESULTS:
-        by_status.setdefault(r.status, []).append(r.domain)
+        label = f"{r.domain} (broke at: {r.stage})" if r.stage else r.domain
+        by_status.setdefault(r.status, []).append(label)
 
     lines = ["", "=" * 60, "SCRAPER HEALTH SUMMARY", "=" * 60]
-    for status in (STATUS_OK, STATUS_PROTECTED, STATUS_STALE, STATUS_DEAD):
+    for status in (STATUS_OK, STATUS_PROTECTED, STATUS_STALE,
+                     STATUS_HTTP_ERROR, STATUS_DEAD):
         domains = by_status.get(status, [])
         lines.append(f"{status:10s}: {len(domains):4d}")
         for d in sorted(domains):

--- a/tests/scrapers/test_mangadex_api.py
+++ b/tests/scrapers/test_mangadex_api.py
@@ -12,6 +12,34 @@ def scraper():
     return MangaDexScraper()
 
 
+class TestSessionHeaders:
+    """MangaDex's API returns HTTP 400 for a browser-style User-Agent that
+    omits Sec-Fetch-* metadata. The scraper must send those headers (and ask
+    for JSON) on every request via the shared session."""
+
+    def test_sends_sec_fetch_and_json_accept(self, scraper):
+        headers = scraper.session.headers
+        assert headers["Accept"] == "application/json"
+        assert headers["Sec-Fetch-Dest"] == "empty"
+        assert headers["Sec-Fetch-Mode"] == "cors"
+        assert headers["Sec-Fetch-Site"] == "same-origin"
+
+    def test_headers_reach_the_request(self, monkeypatch, scraper, fake_response):
+        seen = {}
+
+        def fake_get(url, **kwargs):
+            # session.headers are merged into the request by requests itself,
+            # so assert against the session that will be used for the call.
+            seen["headers"] = dict(scraper.session.headers)
+            return fake_response(json_data={"data": []})
+
+        monkeypatch.setattr(scraper.session, "get", fake_get)
+        scraper.search("one piece")
+
+        assert seen["headers"]["Accept"] == "application/json"
+        assert seen["headers"]["Sec-Fetch-Mode"] == "cors"
+
+
 class TestExtractIDs:
     def test_manga_id(self, scraper):
         assert scraper._extract_manga_id(

--- a/tests/scrapers/test_mangapark.py
+++ b/tests/scrapers/test_mangapark.py
@@ -1,0 +1,124 @@
+"""HTML/JSON-fixture tests for MangaParkScraper (mangapark1.com)."""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers.mangapark import MangaParkScraper
+
+
+@pytest.fixture
+def scraper():
+    return MangaParkScraper()
+
+
+class TestSearch:
+    def test_parses_units_and_dedupes(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("mangapark", "search.html"))
+        results = scraper.search("one piece")
+        # 3 unique manga URLs after dedup of the repeated one-piece card
+        assert len(results) == 3
+        by_url = {r.url: r for r in results}
+        assert "https://mangapark1.com/manga/one-piece" in by_url
+        assert by_url["https://mangapark1.com/manga/one-piece"].title == "One Piece"
+        assert by_url["https://mangapark1.com/manga/one-piece"].cover_url == \
+            "https://cdn2.holdingyouclose.xyz/thumb/one-piece.webp"
+
+    def test_title_falls_back_to_img_alt(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("mangapark", "search.html"))
+        results = scraper.search("chopper")
+        titles = [r.title for r in results]
+        # Card with no info-block text link uses the cover alt text
+        assert "Chopperman - Yuke Yuke! Minna no Chopper-sensei" in titles
+
+    def test_no_results(self, scraper, patch_html):
+        patch_html(scraper, "<html><body></body></html>")
+        assert scraper.search("nothing") == []
+
+
+class TestGetChapters:
+    def test_uses_json_endpoint(self, scraper, patch_json, load_json_fixture):
+        patch_json(scraper, load_json_fixture("mangapark", "chapter_list.json"))
+        chapters = scraper.get_chapters("https://mangapark1.com/manga/one-piece")
+        # 4 unique chapters after dedup of the repeated chapter-1 entry
+        assert len(chapters) == 4
+        # Sorted ascending
+        nums = [c.numeric for c in chapters]
+        assert nums == sorted(nums)
+        # Integer-valued floats normalised: 1.0 -> "1"
+        assert chapters[0].number == "1"
+        # Decimal chapters preserved
+        assert any(c.number == "10.5" for c in chapters)
+        # URLs built from slug + chapter_slug
+        assert chapters[-1].url == \
+            "https://mangapark1.com/read/one-piece/chapter-1187"
+        assert chapters[-1].date == "2026-07-03 03:21:33"
+
+    def test_falls_back_to_html_when_endpoint_fails(
+            self, scraper, monkeypatch, patch_html, load_fixture):
+        def boom(*a, **k):
+            raise IOError("endpoint down")
+        monkeypatch.setattr(scraper, "_get_json", boom)
+        patch_html(scraper, load_fixture("mangapark", "manga.html"))
+        chapters = scraper.get_chapters("https://mangapark1.com/manga/one-piece")
+        assert len(chapters) == 3
+        assert any(c.number == "10.5" for c in chapters)
+        assert all("/read/one-piece/" in c.url for c in chapters)
+
+    def test_rejects_non_manga_url(self, scraper):
+        with pytest.raises(ValueError):
+            scraper.get_chapters("https://mangapark1.com/blog")
+
+
+class TestGetPages:
+    def test_extracts_cdn_urls_skips_placeholders(
+            self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("mangapark", "chapter.html"))
+        pages = scraper.get_pages(
+            "https://mangapark1.com/read/one-piece/chapter-1")
+        # 3 unique pages: duplicate and /assets/ placeholder excluded
+        assert pages == [
+            "https://cdn2.holdingyouclose.xyz/one-piece/1/0.webp",
+            "https://cdn2.holdingyouclose.xyz/one-piece/1/1.webp",
+            "https://cdn2.holdingyouclose.xyz/one-piece/1/2.webp",
+        ]
+
+    def test_no_pages(self, scraper, patch_html):
+        patch_html(scraper, "<html><body></body></html>")
+        assert scraper.get_pages("https://mangapark1.com/read/x/chapter-1") == []
+
+
+class TestDownloadImage:
+    def test_sends_referer_and_writes_file(
+            self, monkeypatch, scraper, tmp_path, fake_response):
+        captured = {}
+
+        def fake_request(url, **kwargs):
+            captured.update(kwargs)
+            return fake_response(content=b"imgdata" * 100)
+
+        monkeypatch.setattr(scraper, "_request", fake_request)
+        ok = scraper.download_image(
+            "https://cdn2.holdingyouclose.xyz/one-piece/1/0.webp",
+            tmp_path / "p.webp")
+        assert ok is True
+        assert (tmp_path / "p.webp").read_bytes() == b"imgdata" * 100
+        assert captured["headers"]["Referer"] == "https://mangapark1.com/"
+
+    def test_failure_returns_false(self, monkeypatch, scraper, tmp_path):
+        def boom(*a, **k):
+            raise IOError("nope")
+        monkeypatch.setattr(scraper, "_request", boom)
+        assert scraper.download_image("https://x", tmp_path / "p.webp") is False
+
+
+class TestRegistry:
+    def test_domain_resolves_to_scraper(self):
+        from memanga.scrapers import get_scraper
+        s = get_scraper("mangapark1.com")
+        assert isinstance(s, MangaParkScraper)
+
+    def test_www_prefix_resolves(self):
+        from memanga.scrapers import get_scraper
+        s = get_scraper("www.mangapark1.com")
+        assert isinstance(s, MangaParkScraper)

--- a/tests/scrapers/test_playwright_scrapers.py
+++ b/tests/scrapers/test_playwright_scrapers.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import pytest
 
 from memanga.scrapers.mangabuddy import MangaBuddyScraper
+from memanga.scrapers.comix import ComixScraper
 from memanga.scrapers import get_scraper
 
 
@@ -78,6 +79,48 @@ class TestMangaBuddyDownload:
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Comix.to
+# ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def comix():
+    return ComixScraper()
+
+
+class TestComixSearch:
+    def test_extracts_rendered_title_links(self, comix):
+        html = """
+        <a href="/title/45nl-kubera"><img src="https://static.comix.to/k.jpg"></a>
+        <a href="/title/45nl-kubera">Kubera</a>
+        <a href="/title/793e-arelyn-is-sick-and-tired">Arelyn Is Sick and Tired</a>
+        """
+        results = comix._parse_search_html(html)
+        assert [r.title for r in results] == [
+            "Kubera",
+            "Arelyn Is Sick and Tired",
+        ]
+        assert results[0].url == "https://comix.to/title/45nl-kubera"
+        assert results[0].cover_url == "https://static.comix.to/k.jpg"
+
+
+class TestComixChapters:
+    def test_extracts_chapter_rows(self, comix):
+        html = """
+        <a class="mchap-row__primary"
+           href="/title/45nl-kubera/10512172-chapter-705">Ch.705 S3-423</a>
+        <a class="mchap-row__primary"
+           href="/title/45nl-kubera/10308843-chapter-704">Ch.704 S3-422</a>
+        """
+        chapters = comix._parse_chapters_html(html)
+        assert [c.number for c in chapters] == ["705", "704"]
+        assert chapters[0].title == "S3-423"
+        assert chapters[0].url == (
+            "https://comix.to/title/45nl-kubera/10512172-chapter-705"
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
 # Smoke tests: every Playwright-based scraper imports + instantiates +
 # exposes the required methods. This catches typos and missing-import
 # bugs without paying the cost of spinning up a browser.
@@ -102,6 +145,7 @@ PLAYWRIGHT_DOMAINS = [
     "mangatown.com",
     "manhuaus.org",
     "comick.io",
+    "comix.to",
     "fanfox.net",
     "toonily.me",
     "omegascans.org",

--- a/tests/unit/scrapers/test_base_interface.py
+++ b/tests/unit/scrapers/test_base_interface.py
@@ -187,48 +187,60 @@ class TestGetScraperRegistry:
             assert hasattr(s, m), f"{domain} scraper missing {m}"
 
 
-class TestMangaFireSearchUsesPersistentBrowser:
-    """Regression: launching a fresh Firefox per call adds ~5-10 s of
-    cold-start latency, which on slower networks pushes MangaFire past
-    the search worker's per-source budget and the source never makes
-    it into the result list. search() must route through VRFGenerator,
-    which keeps Firefox open across calls (chapter-page extraction
-    already does this; search joins the same persistent browser).
+class TestMangaFireSearchUsesJsonApi:
+    """Regression (issue #74): the old flow drove the homepage search bar
+    through the persistent Playwright browser and scraped
+    `.info a[href*="/manga/"]` result links. The browse page the search
+    bar redirects to renders results client-side under /title/hid-slug
+    links, so that selector matched nothing and every search returned 0
+    results. search() must hit GET /api/titles?keyword=... over plain HTTP
+    instead - no browser involved at all.
     """
 
-    def test_search_delegates_to_vrf_generator(self, monkeypatch):
+    class _FakeResponse:
+        status_code = 200
+
+        def __init__(self, payload):
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    class _FakeSession:
+        def __init__(self, payload):
+            self._payload = payload
+            self.urls = []
+
+        def get(self, url, **kwargs):
+            self.urls.append(url)
+            return TestMangaFireSearchUsesJsonApi._FakeResponse(self._payload)
+
+    def test_search_hits_titles_api_with_encoded_keyword(self):
         from memanga.scrapers import mangafire as mf
-
-        captured = {"called_with": None, "n": 0}
-
-        class _FakeVRF:
-            def search(self, query):
-                captured["called_with"] = query
-                captured["n"] += 1
-                return [mf.Manga(title="Stub", url="https://x/m")]
-
-        monkeypatch.setattr(mf, "get_vrf_generator", lambda: _FakeVRF())
 
         scraper = mf.MangaFireScraper()
-        results = scraper.search("Blue Lock")
+        scraper.session = self._FakeSession({
+            "items": [{
+                "title": "Blue Lock",
+                "url": "/title/abc-blue-lock",
+                "poster": {"medium": "https://cdn.example/bl@280.jpg"},
+            }],
+            "meta": {"total": 1},
+        })
 
-        assert captured["n"] == 1
-        assert captured["called_with"] == "Blue Lock"
-        assert results and results[0].title == "Stub"
+        results = scraper.search("blue lock/2")
 
-    def test_search_does_not_launch_new_firefox(self, monkeypatch):
-        """Hard guard: calling MangaFireScraper.search() must NOT
-        invoke `playwright.firefox.launch` directly. Re-introducing the
-        per-call launch pattern fails this test.
+        assert scraper.session.urls == [
+            "https://mangafire.to/api/titles?keyword=blue%20lock%2F2",
+        ]
+        assert results and results[0].url == "https://mangafire.to/title/abc-blue-lock"
+
+    def test_search_does_not_launch_firefox(self, monkeypatch):
+        """Hard guard: calling MangaFireScraper.search() must NOT start
+        Playwright at all - search works over plain HTTP.
         """
         from memanga.scrapers import mangafire as mf
-        # Stub the VRF generator so the real persistent browser doesn't
-        # spin up either — we only care that no fresh launch happens.
-        monkeypatch.setattr(
-            mf, "get_vrf_generator",
-            lambda: type("V", (), {"search": lambda self, q: []})(),
-        )
-        # Trap any direct sync_playwright().start() call.
+
         called = {"n": 0}
 
         class _BoomPW:
@@ -237,7 +249,7 @@ class TestMangaFireSearchUsesPersistentBrowser:
             firefox = type("_F", (), {
                 "launch": staticmethod(
                     lambda *a, **k: (_ for _ in ()).throw(
-                        AssertionError("search must not launch a fresh Firefox"),
+                        AssertionError("search must not launch Firefox"),
                     )
                 ),
             })()
@@ -248,8 +260,9 @@ class TestMangaFireSearchUsesPersistentBrowser:
         monkeypatch.setattr(pwapi, "sync_playwright", lambda: _BoomPW())
 
         scraper = mf.MangaFireScraper()
+        scraper.session = self._FakeSession({"items": [], "meta": {}})
         scraper.search("x")
-        assert called["n"] == 0, "search should reuse VRF browser, not launch a new one"
+        assert called["n"] == 0, "search must stay browser-free"
 
 
 class TestWeebCentralSearchHitsDataEndpoint:

--- a/tests/unit/scrapers/test_mangafire.py
+++ b/tests/unit/scrapers/test_mangafire.py
@@ -158,6 +158,89 @@ class TestMangaFireGetPages:
         assert pages == ["https://cdn.example/002.jpg"]
 
 
+class TestMangaFireSearch:
+    """Issue #74: search must use GET /api/titles?keyword=... - the old
+    browser-driven homepage search scraped `/manga/` result links that
+    the browse page no longer renders, so it always found 0 results.
+    """
+
+    def test_parses_api_items_into_manga(self):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={
+                "items": [
+                    {
+                        "title": "One Piece",
+                        "url": "/title/dkw-one-piece",
+                        "poster": {
+                            "small": "https://cdn.example/op@100.jpg",
+                            "medium": "https://cdn.example/op@280.jpg",
+                        },
+                    },
+                    {
+                        # No medium poster - falls back to large.
+                        "title": "One Piece Academy",
+                        "url": "https://mangafire.to/title/1qz0v-one-piece-academy",
+                        "poster": {"large": "https://cdn.example/opa.jpg"},
+                    },
+                    {"title": "", "url": "/title/x-skipped-no-title"},
+                    {"title": "Skipped, no URL"},
+                    "not-a-dict",
+                ],
+                "meta": {"total": 4},
+            }),
+        ])
+
+        results = scraper.search("one piece")
+
+        assert [(m.title, m.url, m.cover_url) for m in results] == [
+            ("One Piece", "https://mangafire.to/title/dkw-one-piece",
+             "https://cdn.example/op@280.jpg"),
+            ("One Piece Academy",
+             "https://mangafire.to/title/1qz0v-one-piece-academy",
+             "https://cdn.example/opa.jpg"),
+        ]
+
+    def test_caps_results_at_ten(self):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={
+                "items": [
+                    {"title": f"Manga {i}", "url": f"/title/h{i}-manga-{i}"}
+                    for i in range(20)
+                ],
+            }),
+        ])
+
+        assert len(scraper.search("manga")) == 10
+
+    def test_invalid_search_payload_raises(self):
+        from memanga.scrapers.mangafire import MangaFireError, MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={"message": "shape changed"}),
+        ])
+
+        with pytest.raises(MangaFireError, match="invalid search response"):
+            scraper.search("one piece")
+
+    def test_http_error_raises_instead_of_empty_list(self):
+        from memanga.scrapers.mangafire import MangaFireError, MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(status_code=503, payload={}),
+        ])
+
+        with pytest.raises(MangaFireError, match="HTTP 503"):
+            scraper.search("one piece")
+
+
 class TestVRFBrowserInitAtomicity:
     """Issue #28: a failed firefox.launch() must surface the real error,
     not a masking AttributeError on a half-initialised thread-local.


### PR DESCRIPTION
## Summary
- sync the CLI branch with v0.3.1-v0.3.3 scraper fixes and release metadata
- add CLI-facing changelog notes for the post-v0.3.0 releases
- adapt the CLI README default source table for GUI-free users

## Tests
- venv/bin/python -m pytest tests/scrapers/test_mangadex_api.py tests/scrapers/test_mangapark.py tests/scrapers/test_playwright_scrapers.py tests/unit/scrapers/test_base_interface.py tests/unit/scrapers/test_mangafire.py tests/unit/cli -q
- venv/bin/python -m pytest -m live tests/scrapers/live/test_live_parsing.py -k "mangadex or mangafire or comix or mangapark" -q
- venv/bin/python -m compileall -q memanga tests

Refs #71
Refs #74
Refs #77
Refs #78
Refs #83