### PR TITLE
Add configurable post-processing after downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Hit **Re-check health** to ping every enabled source and see their status.
 
 - **General** — output format (PDF/EPUB/CBZ/…), download folder, theme, concurrency
 - **Kindle / Email** — Gmail App Password setup for sending chapters to your Kindle
-- **Advanced** — fallback-source delay, cron, cache management
+- **Advanced** — fallback-source delay, post-processing, cron, cache management
 
 <p align="center">
   <img src="docs/screenshots/settings-kindle.png" alt="Settings page — Kindle/Email tab" width="900">

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -23,6 +23,7 @@ them to your Kindle.
 - [Downloading From a Specific Chapter](#downloading-from-a-specific-chapter)
 - [Managing Status](#managing-status)
 - [Changing Output Format](#changing-output-format)
+- [Post-Processing After Download](#post-processing-after-download)
 - [Setting Up Kindle Email](#setting-up-kindle-email)
 - [Backup Sources](#backup-sources)
 - [Updating Manga Details](#updating-manga-details)
@@ -531,6 +532,96 @@ Download one manga in CBZ:
 
 ```bash
 run check -t "One Piece" --format cbz --auto
+```
+
+---
+
+## Post-Processing After Download
+
+MeManga can run a command of your choice after each chapter's output
+file (or image folder) is created - for converting, compressing, copying to an
+archive, or triggering another tool.
+
+Post-processing is **disabled by default**.
+
+> ⚠️ The command runs on your machine. Only enable commands you trust and
+> understand.
+
+### Enable it
+
+In the desktop app, open **Settings -> Advanced -> Post-Processing**, enable
+the command, then save settings.
+
+In the CLI, run the config wizard and answer the post-processing prompts:
+
+```bash
+run config
+```
+
+Or edit `~/.config/memanga/config.yaml` directly:
+
+```yaml
+delivery:
+  post_processing:
+    enabled: true
+    command: 'cp -R {output_path} /mnt/archive/'
+    fail_on_error: false
+```
+
+### Available values
+
+Each value is available both as a `{placeholder}` in the command string and as
+an environment variable:
+
+| Placeholder | Environment variable | Meaning |
+|-------------|----------------------|---------|
+| `{output_path}` | `MEMANGA_OUTPUT_PATH` | Final file or folder path |
+| `{title}` | `MEMANGA_MANGA_TITLE` | Manga title |
+| `{chapter}` | `MEMANGA_CHAPTER` | Chapter number |
+| `{source}` | `MEMANGA_SOURCE` | Source the chapter came from |
+| `{format}` | `MEMANGA_OUTPUT_FORMAT` | Output format (`pdf`, `cbz`, `jpg`, …) |
+| `{is_dir}` | `MEMANGA_IS_DIR` | `1` if the output is a folder (image formats), else `0` |
+
+The hook receives the final output path whether it is an archive/document file
+(`pdf`, `epub`, `cbz`, `zip`) or an image folder (`jpg`, `png`, `webp`).
+The command is split into arguments and run directly, without a shell.
+Placeholder values are substituted after splitting, so manga metadata cannot
+become shell syntax. For shell features like pipes, redirects, or globbing,
+invoke a shell explicitly and prefer the `MEMANGA_*` environment variables.
+
+### Failure behavior
+
+- `fail_on_error: false` (default) - a failed command prints a warning but the
+  chapter is still recorded as downloaded.
+- `fail_on_error: true` - a failed command marks the chapter as failed, so it
+  shows up under `run failed` for retry. During CLI checks, backup-source
+  handling applies the same way it does for other download failures.
+
+A command is considered failed if it exits non-zero, times out (10 minute
+limit), or can't be launched.
+
+### Examples
+
+Copy every download into an archive directory:
+
+```yaml
+command: 'cp -R {output_path} /mnt/archive/'
+```
+
+Optimize a CBZ/ZIP or run a script with the passed environment variables:
+
+```yaml
+command: '/home/me/scripts/process-chapter.sh'
+```
+
+```bash
+#!/usr/bin/env bash
+# process-chapter.sh
+echo "Finished $MEMANGA_MANGA_TITLE chapter $MEMANGA_CHAPTER ($MEMANGA_OUTPUT_FORMAT)"
+if [ "$MEMANGA_IS_DIR" = "1" ]; then
+  # image-folder output, e.g. compress each image
+  find "$MEMANGA_OUTPUT_PATH" -name '*.png' -print
+fi
 ```
 
 ---

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -24,6 +24,24 @@ delivery:
   delete_after_send: false  # Delete PDF after sending to Kindle (email mode only)
   output_format: pdf  # "pdf", "epub", "cbz", "zip", "jpg", "png", or "webp"
 
+  # Optional post-processing command, run after each chapter's output
+  # file/folder is created. Disabled by default. Only enable commands you trust.
+  # The command is split into arguments and run directly, without a shell.
+  # Placeholder values are substituted after splitting. Scripts can read the
+  # MEMANGA_* environment variables instead.
+  #
+  # Available placeholders (also passed as MEMANGA_* environment variables):
+  #   {output_path} MEMANGA_OUTPUT_PATH   - final file or folder path
+  #   {title}       MEMANGA_MANGA_TITLE   - manga title
+  #   {chapter}     MEMANGA_CHAPTER       - chapter number
+  #   {source}      MEMANGA_SOURCE        - source the chapter came from
+  #   {format}      MEMANGA_OUTPUT_FORMAT - output format
+  #   {is_dir}      MEMANGA_IS_DIR        - "1" if output is a folder, else "0"
+  post_processing:
+    enabled: false
+    command: ""            # e.g. 'cp -R {output_path} /mnt/archive/'
+    fail_on_error: false   # true = a failed command marks the chapter failed
+
 # Email settings (only needed if delivery.mode = "email")
 email:
   kindle_email: ""        # your-kindle@kindle.com

--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -418,7 +418,8 @@ def cmd_check(args):
     download_dir = config.download_dir
     output_format = getattr(args, 'format', None) or config.output_format
     email_cfg = config.get("email", {})
-    
+    post_processing = config.get("delivery.post_processing")
+
     for manga in manga_list:
         title = manga["title"]
         status = manga.get("status", "reading")
@@ -494,7 +495,7 @@ def cmd_check(args):
 
                     console.print(f"     [dim]⬇️  Downloading {ch_label}...{source_info}[/dim]")
                     max_retries = getattr(args, 'retries', 3)
-                    file_path = download_chapter(manga, ch, download_dir, output_format, max_retries=max_retries)
+                    file_path = download_chapter(manga, ch, download_dir, output_format, max_retries=max_retries, post_processing=post_processing)
                     is_image_folder = file_path.is_dir()
 
                     if is_image_folder:
@@ -550,7 +551,7 @@ def cmd_check(args):
                             backup_tried = True
                             console.print(f"     [yellow]⚠️  Primary failed ({e}), trying backup ({backup_ch.source})...[/yellow]")
                             try:
-                                file_path = download_chapter(manga, backup_ch, download_dir, output_format, max_retries=max_retries)
+                                file_path = download_chapter(manga, backup_ch, download_dir, output_format, max_retries=max_retries, post_processing=post_processing)
                                 is_image_folder = file_path.is_dir()
                                 if is_image_folder:
                                     console.print(f"     [green]✅ Saved from backup: {file_path.parent.name}/{file_path.name}/[/green]")
@@ -620,6 +621,13 @@ def cmd_status(args):
         table.add_row("Kindle email", config.get("email.kindle_email") or "[red]not set[/red]")
         table.add_row("Sender email", config.get("email.sender_email") or "[red]not set[/red]")
     
+    pp_enabled = bool(config.get("delivery.post_processing.enabled"))
+    pp_status = "enabled" if pp_enabled else "disabled"
+    table.add_row(
+        "Post-processing",
+        f"[{'green' if pp_enabled else 'dim'}]{pp_status}[/]",
+    )
+
     cron_status = "enabled" if config.get("cron.enabled") else "disabled"
     cron_time = config.get("cron.time", "06:00")
     table.add_row("Cron", f"[{'green' if cron_status == 'enabled' else 'dim'}]{cron_status}[/] ({cron_time})")
@@ -724,6 +732,40 @@ def cmd_config(args):
         config.set("delivery.output_format", "png")
     elif fmt_choice == "7":
         config.set("delivery.output_format", "webp")
+
+    # Post-processing hook (optional, disabled by default)
+    pp_enabled = bool(config.get("delivery.post_processing.enabled"))
+    console.print(
+        f"\n[bold]Post-processing[/bold] (current: "
+        f"[cyan]{'enabled' if pp_enabled else 'disabled'}[/cyan])"
+    )
+    console.print(
+        "[dim]Run a command after each chapter is saved. "
+        "Only enable commands you trust.[/dim]"
+    )
+    if Confirm.ask("Enable post-processing command?", default=pp_enabled):
+        console.print(
+            "[dim]Placeholders: {output_path} {title} {chapter} {source} "
+            "{format} {is_dir} (also as MEMANGA_* env vars).[/dim]"
+        )
+        console.print(
+            "[dim]Commands run directly, without a shell. Invoke a shell "
+            "explicitly for pipes, redirects, or globbing. Scripts should "
+            "prefer MEMANGA_* env vars.[/dim]"
+        )
+        pp_command = Prompt.ask(
+            "Command",
+            default=config.get("delivery.post_processing.command", "")
+        )
+        pp_fail = Confirm.ask(
+            "Mark chapter as failed if the command fails?",
+            default=config.get("delivery.post_processing.fail_on_error", False)
+        )
+        config.set("delivery.post_processing.enabled", True)
+        config.set("delivery.post_processing.command", pp_command)
+        config.set("delivery.post_processing.fail_on_error", pp_fail)
+    else:
+        config.set("delivery.post_processing.enabled", False)
 
     config.save()
     console.print("\n[green]✅ Configuration saved![/green]")
@@ -1267,6 +1309,7 @@ def cmd_failed(args):
         download_dir = config.download_dir
         output_format = config.output_format
         email_cfg = config.get("email", {})
+        post_processing = config.get("delivery.post_processing")
         retried = 0
         succeeded = 0
 
@@ -1304,7 +1347,7 @@ def cmd_failed(args):
                 console.print(f"  [dim]⬇️  Retrying {manga_title} Chapter {chapter_num}...[/dim]")
                 retried += 1
                 try:
-                    file_path = download_chapter(manga, ch_obj, download_dir, output_format)
+                    file_path = download_chapter(manga, ch_obj, download_dir, output_format, post_processing=post_processing)
                     is_image_folder = file_path.is_dir()
                     if is_image_folder:
                         console.print(f"  [green]✅ Saved: {file_path.parent.name}/{file_path.name}/[/green]")
@@ -1334,7 +1377,7 @@ def cmd_failed(args):
                     if backup_ch:
                         console.print(f"  [yellow]⚠️  Primary failed, trying backup ({backup_ch.source})...[/yellow]")
                         try:
-                            file_path = download_chapter(manga, backup_ch, download_dir, output_format)
+                            file_path = download_chapter(manga, backup_ch, download_dir, output_format, post_processing=post_processing)
                             state.add_downloaded_chapter(manga_title, chapter_num)
                             state.clear_failed_chapter(manga_title, chapter_num)
                             label = f"{file_path.parent.name}/{file_path.name}/" if file_path.is_dir() else file_path.name

--- a/memanga/config.py
+++ b/memanga/config.py
@@ -59,6 +59,14 @@ class Config:
                 "delete_after_send": False,  # Delete file after sending to Kindle
                 "output_format": "pdf",  # "pdf", "epub", "cbz", "zip", "jpg", "png", or "webp"
                 "naming_template": "{title} - Chapter {chapter}",  # File naming pattern
+                "post_processing": {
+                    # Optional command run after each chapter's output
+                    # file/folder is created. Disabled by default. See docs
+                    # for available placeholders/env vars.
+                    "enabled": False,
+                    "command": "",
+                    "fail_on_error": False,  # True marks the chapter failed
+                },
             },
             "email": {
                 "kindle_email": "",

--- a/memanga/downloader.py
+++ b/memanga/downloader.py
@@ -10,8 +10,13 @@ Handles:
 """
 
 import io
+import os
+import re
+import signal
+import shlex
 import time
 import atexit
+import subprocess
 import tempfile
 import shutil
 import uuid
@@ -56,6 +61,9 @@ OutputFormat = Literal["pdf", "epub", "cbz", "zip", "jpg", "png", "webp"]
 
 # Default days to wait before falling back to backup source
 DEFAULT_FALLBACK_DELAY_DAYS = 2
+
+# How long a post-processing command may run before it's killed (seconds).
+POST_PROCESSING_TIMEOUT = 600
 
 
 class DownloaderError(Exception):
@@ -387,6 +395,7 @@ def download_chapter(
     naming_template: Optional[str] = None,
     cancel_event=None,
     max_retries: int = 3,
+    post_processing: Optional[Dict[str, Any]] = None,
 ) -> Optional[Path]:
     """
     Download a chapter and convert to PDF or EPUB.
@@ -402,6 +411,12 @@ def download_chapter(
             InterruptedError before/during page fetching to abort the download.
         max_retries: Number of times to retry failed page downloads
             (with exponential back-off). 0 to disable.
+        post_processing: Optional ``delivery.post_processing`` config dict
+            ({"enabled", "command", "fail_on_error"}). When enabled, the
+            command is run after the output file/folder is created. If
+            ``fail_on_error`` is set, a command failure raises
+            :class:`DownloaderError` so normal failed-chapter handling applies;
+            otherwise it only prints a warning.
 
     Returns:
         Path to downloaded file, or None if failed
@@ -599,8 +614,274 @@ def download_chapter(
                 _images_to_pdf(image_paths, output_path)
             except Exception as e:
                 raise DownloaderError(f"Failed to create PDF: {e}")
-        
+
+        # Run the user's post-processing hook (if configured) after the
+        # output exists but before the caller records the chapter as
+        # downloaded, so a fail_on_error failure surfaces normally.
+        _run_post_processing(
+            post_processing,
+            output_path=output_path,
+            title=title,
+            chapter_num=chapter.number,
+            source=source,
+            output_format=output_format,
+        )
+
         return output_path
+
+
+def _run_post_processing(
+    post_processing: Optional[Dict[str, Any]],
+    output_path: Path,
+    title: str,
+    chapter_num: str,
+    source: str,
+    output_format: str,
+):
+    """Run the optional user post-processing command for a finished chapter.
+
+    The command is split into argv and run directly, not through a shell.
+    Useful values are passed both as ``{placeholder}`` substitutions in command
+    arguments and as ``MEMANGA_*`` environment variables:
+
+    - ``{output_path}`` / ``MEMANGA_OUTPUT_PATH`` - final file or folder path
+    - ``{title}`` / ``MEMANGA_MANGA_TITLE`` - manga title
+    - ``{chapter}`` / ``MEMANGA_CHAPTER`` - chapter number
+    - ``{source}`` / ``MEMANGA_SOURCE`` - source the chapter came from
+    - ``{format}`` / ``MEMANGA_OUTPUT_FORMAT`` - output format
+    - ``{is_dir}`` / ``MEMANGA_IS_DIR`` - "1" if output is a folder, else "0"
+
+    Placeholder values are substituted after argv parsing, so metadata cannot
+    become shell syntax. For shell features such as pipes or redirects, invoke
+    a shell explicitly and prefer the ``MEMANGA_*`` environment variables.
+
+    A non-zero exit, timeout, or launch error is treated as failure: if
+    ``fail_on_error`` is set the failure is re-raised as
+    :class:`DownloaderError`; otherwise a warning is printed and the download
+    stays successful.
+    """
+    if not post_processing or not post_processing.get("enabled"):
+        return
+
+    command = (post_processing.get("command") or "").strip()
+    if not command:
+        return
+
+    fail_on_error = bool(post_processing.get("fail_on_error"))
+    is_dir = "1" if output_path.is_dir() else "0"
+    output_path_str = str(output_path)
+    title = str(title)
+    chapter_num = str(chapter_num)
+    source = str(source)
+    output_format = str(output_format)
+
+    replacements = {
+        "output_path": output_path_str,
+        "title": title,
+        "chapter": chapter_num,
+        "source": source,
+        "format": output_format,
+        "is_dir": is_dir,
+    }
+
+    def _fail(message: str):
+        if fail_on_error:
+            raise DownloaderError(message)
+        print(f"  [Warning] {message}")
+
+    try:
+        command_args = _split_post_processing_command(command)
+    except ValueError as e:
+        _fail(f"Post-processing command could not be parsed: {e}")
+        return
+    if not command_args:
+        return
+
+    resolved_args = [
+        _substitute_post_processing_placeholders(arg, replacements)
+        for arg in command_args
+    ]
+
+    env = os.environ.copy()
+    env.update({
+        "MEMANGA_OUTPUT_PATH": output_path_str,
+        "MEMANGA_MANGA_TITLE": title,
+        "MEMANGA_CHAPTER": chapter_num,
+        "MEMANGA_SOURCE": source,
+        "MEMANGA_OUTPUT_FORMAT": output_format,
+        "MEMANGA_IS_DIR": is_dir,
+    })
+
+    try:
+        result = _run_post_processing_command(
+            resolved_args,
+            env=env,
+            timeout=POST_PROCESSING_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        _fail(
+            f"Post-processing command timed out after "
+            f"{POST_PROCESSING_TIMEOUT}s"
+        )
+        return
+    except Exception as e:
+        _fail(f"Post-processing command failed to start: {e}")
+        return
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        message = f"Post-processing command exited with code {result.returncode}"
+        if detail:
+            message += f": {detail}"
+        _fail(message)
+
+
+def _run_post_processing_command(
+    args: List[str],
+    env: Dict[str, str],
+    timeout: int,
+) -> subprocess.CompletedProcess:
+    """Run a post-processing command and terminate its process tree on timeout."""
+    kwargs: Dict[str, Any] = {}
+    if os.name == "nt":
+        kwargs["creationflags"] = (
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            | getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+        )
+    else:
+        kwargs["start_new_session"] = True
+
+    process = subprocess.Popen(
+        args,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        **kwargs,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        # The process tree is killed first, then we drain the pipes with a
+        # bounded wait. If a surviving grandchild still holds the pipe handles
+        # open, communicate() would block forever, so every drain here has its
+        # own timeout and we ultimately abandon the output rather than hang.
+        _terminate_process_tree(process)
+        stdout, stderr = _drain_after_timeout(process)
+        exc.output = stdout
+        exc.stderr = stderr
+        raise exc
+
+    return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+
+
+def _drain_after_timeout(
+    process: subprocess.Popen,
+    drain_timeout: int = 5,
+) -> tuple:
+    """Read remaining output from a killed process without ever blocking.
+
+    Returns ``(stdout, stderr)``. If the pipes cannot be drained even after a
+    second kill, they are force-closed and ``(None, None)`` is returned so the
+    caller never waits on a wedged child that inherited the handles.
+    """
+    try:
+        return process.communicate(timeout=drain_timeout)
+    except subprocess.TimeoutExpired:
+        pass
+
+    process.kill()
+    try:
+        return process.communicate(timeout=drain_timeout)
+    except subprocess.TimeoutExpired:
+        pass
+
+    for stream in (process.stdout, process.stderr):
+        if stream is not None:
+            try:
+                stream.close()
+            except Exception:
+                pass
+    return None, None
+
+
+_POST_PROCESSING_PLACEHOLDER_RE = re.compile(
+    r"\{(output_path|title|chapter|source|format|is_dir)\}"
+)
+
+
+def _substitute_post_processing_placeholders(
+    arg: str,
+    replacements: Dict[str, str],
+) -> str:
+    """Replace placeholders once, without expanding placeholder text in values."""
+    return _POST_PROCESSING_PLACEHOLDER_RE.sub(
+        lambda match: replacements[match.group(1)],
+        arg,
+    )
+
+
+def _split_post_processing_command(command: str) -> List[str]:
+    """Split a command string into argv without damaging Windows paths."""
+    if os.name != "nt":
+        return shlex.split(command)
+
+    args: List[str] = []
+    current: List[str] = []
+    in_quotes = False
+    quote_char = ""
+
+    for ch in command:
+        if ch in ("'", '"'):
+            if in_quotes and ch == quote_char:
+                in_quotes = False
+                quote_char = ""
+            elif not in_quotes:
+                in_quotes = True
+                quote_char = ch
+            else:
+                current.append(ch)
+        elif ch.isspace() and not in_quotes:
+            if current:
+                args.append("".join(current))
+                current = []
+        else:
+            current.append(ch)
+
+    if in_quotes:
+        raise ValueError("No closing quotation")
+    if current:
+        args.append("".join(current))
+    return args
+
+
+def _terminate_process_tree(process: subprocess.Popen) -> bool:
+    """Terminate a process and its children where the platform supports it."""
+    if process.poll() is not None:
+        return True
+    if os.name == "nt":
+        try:
+            result = subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if result.returncode == 0:
+                return True
+        except Exception:
+            pass
+    else:
+        try:
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            return True
+        except Exception:
+            pass
+    try:
+        process.kill()
+        return True
+    except Exception:
+        return False
 
 
 def _image_to_jpeg_bytes(img_path: Path) -> tuple:

--- a/memanga/gui/app.py
+++ b/memanga/gui/app.py
@@ -279,6 +279,7 @@ class MeMangaApp(QMainWindow):
             fmt=self.config.output_format, path=path, size_mb=size_mb,
         )
         self.app_state.add_downloaded_chapter(title, str(chapter))
+        self.app_state.clear_failed_chapter(title, str(chapter))
 
         # Badge update depends on mode:
         #   auto   → batch download flushes the whole badge at once

--- a/memanga/gui/pages/detail.py
+++ b/memanga/gui/pages/detail.py
@@ -1153,6 +1153,7 @@ class DetailPage(BasePage):
                 kindle_cfg = None
 
         naming_template = self.app.config.get("delivery.naming_template")
+        post_processing = self.app.config.get("delivery.post_processing")
 
         self.app.worker.download_chapter(
             manga=self._manga, chapter=chapter,
@@ -1160,6 +1161,7 @@ class DetailPage(BasePage):
             output_format=self.app.config.output_format,
             state=self.app.app_state, kindle_cfg=kindle_cfg,
             naming_template=naming_template,
+            post_processing=post_processing,
         )
 
         # Visual feedback: disable the button and relabel until completion

--- a/memanga/gui/pages/downloads.py
+++ b/memanga/gui/pages/downloads.py
@@ -561,6 +561,7 @@ class DownloadsPage(BasePage):
 
         global_kindle = self.app.config.delivery_mode == "email" and self.app.config.email_enabled
         naming_template = self.app.config.get("delivery.naming_template")
+        post_processing = self.app.config.get("delivery.post_processing")
 
         skipped = 0
         for r in to_queue:
@@ -592,6 +593,7 @@ class DownloadsPage(BasePage):
                     output_format=self.app.config.output_format,
                     state=self.app.app_state, kindle_cfg=kindle_cfg,
                     naming_template=naming_template,
+                    post_processing=post_processing,
                 )
         if skipped:
             Toast(self, f"Skipped {skipped} chapter(s) already on disk", kind="info")

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -533,6 +533,49 @@ class SettingsPage(BasePage):
 
         f.addSpacing(T.PAD_XL)
 
+        # Post-processing
+        self._section(f, "Post-Processing")
+
+        self._post_processing_check = QCheckBox("Run a command after each chapter download")
+        self._post_processing_check.setChecked(
+            self.app.config.get("delivery.post_processing.enabled", False)
+        )
+        self._post_processing_check.toggled.connect(
+            self._refresh_post_processing_enabled
+        )
+        f.addWidget(self._post_processing_check)
+
+        self._post_processing_command = self._labeled_entry(
+            f,
+            "Command:",
+            self.app.config.get("delivery.post_processing.command", ""),
+            "python scripts/after_download.py {output_path}",
+        )
+        self._post_processing_command.setToolTip(
+            "Runs after the final chapter file or folder is created"
+        )
+
+        self._post_processing_fail_check = QCheckBox(
+            "Mark download failed if the command exits with an error"
+        )
+        self._post_processing_fail_check.setChecked(
+            self.app.config.get("delivery.post_processing.fail_on_error", False)
+        )
+        f.addWidget(self._post_processing_fail_check)
+
+        pp_hint = QLabel(
+            "Available placeholders: {output_path}, {title}, {chapter}, "
+            "{source}, {format}, {is_dir}. The same values are also exposed "
+            "as MEMANGA_* environment variables. Commands run directly; invoke "
+            "a shell explicitly if you need shell features."
+        )
+        pp_hint.setWordWrap(True)
+        pp_hint.setProperty("role", "hint")
+        f.addWidget(pp_hint)
+        self._refresh_post_processing_enabled()
+
+        f.addSpacing(T.PAD_XL)
+
         # Import/Export
         self._section(f, "Import / Export")
         ie_row = QHBoxLayout()
@@ -589,6 +632,11 @@ class SettingsPage(BasePage):
         # Refresh cache size on display.
         from PySide6.QtCore import QTimer
         QTimer.singleShot(100, self._refresh_cache_size)
+
+    def _refresh_post_processing_enabled(self):
+        enabled = self._post_processing_check.isChecked()
+        self._post_processing_command.setEnabled(enabled)
+        self._post_processing_fail_check.setEnabled(enabled)
 
     def _refresh_cache_size(self):
         """Compute the on-disk size of the cover cache and update the label."""
@@ -774,6 +822,18 @@ class SettingsPage(BasePage):
             cron_time = "06:00"
         cfg.set("cron.enabled", self._cron_check.isChecked())
         cfg.set("cron.time", cron_time)
+        cfg.set(
+            "delivery.post_processing.enabled",
+            self._post_processing_check.isChecked(),
+        )
+        cfg.set(
+            "delivery.post_processing.command",
+            self._post_processing_command.text().strip(),
+        )
+        cfg.set(
+            "delivery.post_processing.fail_on_error",
+            self._post_processing_fail_check.isChecked(),
+        )
 
         cfg.save()
         Toast(self, "Settings saved", kind="success")

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -584,12 +584,21 @@ class SettingsPage(BasePage):
         )
         f.addWidget(self._post_processing_check)
 
-        self._post_processing_command = self._labeled_entry(
-            f,
-            "Command:",
-            self.app.config.get("delivery.post_processing.command", ""),
-            "python scripts/after_download.py {output_path}",
+        command_row = QHBoxLayout()
+        command_lbl = QLabel("Command:")
+        command_lbl.setStyleSheet(f"font-size: {T.FONT_SIZE_SM}pt;")
+        command_row.addWidget(command_lbl)
+
+        self._post_processing_command = QLineEdit(
+            self.app.config.get("delivery.post_processing.command", "")
         )
+        self._post_processing_command.setMinimumHeight(36)
+        self._post_processing_command.setMinimumWidth(280)
+        self._post_processing_command.setPlaceholderText(
+            "python scripts/after_download.py {output_path}"
+        )
+        command_row.addWidget(self._post_processing_command, 1)
+        f.addLayout(command_row)
         self._post_processing_command.setToolTip(
             "Runs after the final chapter file or folder is created"
         )
@@ -605,7 +614,7 @@ class SettingsPage(BasePage):
         pp_hint = QLabel(
             "Available placeholders: {output_path}, {title}, {chapter}, "
             "{source}, {format}, {is_dir}. The same values are also exposed "
-            "as MEMANGA_* environment variables. Commands run directly; invoke "
+            "as MEMANGA_* environment variables.\nCommands run directly; invoke "
             "a shell explicitly if you need shell features."
         )
         pp_hint.setWordWrap(True)

--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -318,7 +318,7 @@ class BackgroundWorker:
     # ------------------------------------------------------------------
 
     def download_chapter(self, manga, chapter, output_dir, output_format, state,
-                         kindle_cfg=None, naming_template=None):
+                         kindle_cfg=None, naming_template=None, post_processing=None):
         """Queue a chapter download."""
         task_id = f"{manga['title']}:{chapter.number}"
         # Refuse to enqueue while offline — the request would just
@@ -346,6 +346,7 @@ class BackgroundWorker:
             "state": state,
             "kindle_cfg": kindle_cfg,
             "naming_template": naming_template,
+            "post_processing": post_processing,
             "cancel": cancel,
         }
 
@@ -419,6 +420,7 @@ class BackgroundWorker:
                 progress_callback=progress_cb,
                 naming_template=item.get("naming_template"),
                 cancel_event=item["cancel"],
+                post_processing=item.get("post_processing"),
             )
 
             # Kindle delivery
@@ -449,6 +451,18 @@ class BackgroundWorker:
         except Exception as e:
             print(f"[Download] ERROR: {manga['title']} Ch.{chapter.number}: {e}", flush=True)
             traceback.print_exc()
+            state = item.get("state")
+            if state is not None and hasattr(state, "add_failed_chapter"):
+                source = getattr(chapter, "source", None) or manga.get("source", "?")
+                try:
+                    state.add_failed_chapter(
+                        manga["title"],
+                        chapter.number,
+                        source,
+                        str(e),
+                    )
+                except Exception:
+                    traceback.print_exc()
             self._events.publish("download_error", {
                 "task_id": task_id, "error": str(e),
                 "title": manga["title"], "chapter": chapter.number,

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -275,7 +275,8 @@ def test_issue_40_pause_resume_keeps_queue(app_window, qapp, monkeypatch):
 
     def fake_download_chapter(manga, chapter, output_dir, output_format,
                                state, progress_callback=None,
-                               naming_template=None, cancel_event=None):
+                               naming_template=None, cancel_event=None,
+                               **kwargs):
         gates[f"{manga['title']}:{chapter.number}"].wait(timeout=10)
         return None
 

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -29,6 +29,16 @@ def test_pages_handle_theme_switch(app_window, qapp, theme):
         theme.set_theme("dark", qapp); qapp.processEvents()
 
 
+def test_download_complete_clears_failed_chapter(app_window, qapp):
+    app_window.app_state.add_failed_chapter("M", "1", "mock.test", "boom")
+    assert "1" in app_window.app_state.get_failed_chapters("M")
+
+    app_window._on_download_complete({"title": "M", "chapter": "1", "path": ""})
+    qapp.processEvents()
+
+    assert "1" not in app_window.app_state.get_failed_chapters("M")
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Library
 # ─────────────────────────────────────────────────────────────────────────
@@ -227,6 +237,25 @@ class TestSettingsPage:
         page._save()
         # No exception = passes. Config got at least one write.
         assert app_window.config.get("delivery.output_format") is not None
+
+    def test_save_writes_post_processing_settings(self, app_window, qapp):
+        page = app_window._pages["settings"]
+        page._post_processing_check.setChecked(True)
+        page._post_processing_command.setText(
+            "python scripts/after_download.py {output_path}"
+        )
+        page._post_processing_fail_check.setChecked(True)
+
+        page._save()
+
+        assert app_window.config.get("delivery.post_processing.enabled") is True
+        assert app_window.config.get("delivery.post_processing.command") == (
+            "python scripts/after_download.py {output_path}"
+        )
+        assert (
+            app_window.config.get("delivery.post_processing.fail_on_error")
+            is True
+        )
 
     def test_template_preview_substitutes(self, app_window, qapp):
         page = app_window._pages["settings"]

--- a/tests/unit/gui/test_workers.py
+++ b/tests/unit/gui/test_workers.py
@@ -80,7 +80,8 @@ class TestPauseResumeQueue:
 
         def fake_download_chapter(manga, chapter, output_dir, output_format,
                                    state, progress_callback=None,
-                                   naming_template=None, cancel_event=None):
+                                   naming_template=None, cancel_event=None,
+                                   **kwargs):
             tid = f"{manga['title']}:{chapter.number}"
             with h._lock:
                 h.running.add(tid)
@@ -177,6 +178,89 @@ class TestCancelFlags:
 
     def test_cancel_download_unknown_is_noop(self, worker):
         worker.cancel_download("never-existed")
+
+
+class TestDownloadChapter:
+    def test_forwards_post_processing_config(self, worker, monkeypatch):
+        import time
+        import types
+        from pathlib import Path
+        import memanga.downloader as dl
+
+        seen = {}
+
+        def fake_download_chapter(**kwargs):
+            seen.update(kwargs)
+            return Path("/tmp/out/M/Chapter 1.cbz")
+
+        monkeypatch.setattr(dl, "download_chapter", fake_download_chapter)
+
+        post_processing = {
+            "enabled": True,
+            "command": "echo ok",
+            "fail_on_error": True,
+        }
+        worker.download_chapter(
+            {"title": "M"},
+            types.SimpleNamespace(number="1"),
+            "/tmp/out",
+            "cbz",
+            None,
+            post_processing=post_processing,
+        )
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not seen:
+            time.sleep(0.02)
+
+        assert seen["post_processing"] is post_processing
+
+    def test_download_error_records_failed_chapter(self, worker, monkeypatch,
+                                                   event_bus):
+        import time
+        import types
+        import memanga.downloader as dl
+
+        class FakeState:
+            def __init__(self):
+                self.failed = []
+
+            def add_failed_chapter(self, *args):
+                self.failed.append(args)
+
+        def fake_download_chapter(**kwargs):
+            raise dl.DownloaderError("post-processing command exited with code 3")
+
+        monkeypatch.setattr(dl, "download_chapter", fake_download_chapter)
+
+        errors = []
+        event_bus.subscribe("download_error", errors.append)
+        state = FakeState()
+        chapter = types.SimpleNamespace(number="1", source="mock.test")
+
+        worker.download_chapter(
+            {"title": "M", "source": "mock.test"},
+            chapter,
+            "/tmp/out",
+            "cbz",
+            state,
+            post_processing={
+                "enabled": True,
+                "command": "exit 3",
+                "fail_on_error": True,
+            },
+        )
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not state.failed:
+            time.sleep(0.02)
+        event_bus.poll()
+
+        assert state.failed == [
+            ("M", "1", "mock.test",
+             "post-processing command exited with code 3")
+        ]
+        assert errors
 
 
 class TestPingSources:

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -4,6 +4,9 @@ sanitization, format conversion, fallback delay logic."""
 from __future__ import annotations
 
 import types
+import sys
+import time
+import shutil
 from pathlib import Path
 
 import pytest
@@ -148,6 +151,306 @@ class TestNamingTemplate:
             naming_template="{title}__ch{chapter}",
         )
         assert "MyManga__ch1" in Path(path).stem
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# download_chapter — issue #89: optional post-processing hook
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestPostProcessing:
+    """Verify the configurable post-download command hook."""
+
+    @pytest.fixture
+    def fake_state(self):
+        class S:
+            def add_downloaded_chapter(self, *a, **k): pass
+            def is_chapter_downloaded(self, *a, **k): return False
+            def get_pending_backup(self, *a, **k): return None
+            def set_pending_backup(self, *a, **k): pass
+            def clear_pending_backup(self, *a, **k): pass
+        return S()
+
+    def _manga_and_chapter(self):
+        manga = {"title": "PPManga", "url": "https://mock.test/m",
+                 "source": "mock.test"}
+        chapter = types.SimpleNamespace(
+            number="3", title="", url="https://mock.test/c/3",
+            source="mock.test", source_url="https://mock.test/c/3",
+            is_backup=False,
+        )
+        return manga, chapter
+
+    def test_disabled_by_default_does_not_run(self, tmp_path,
+                                              patch_get_scraper, fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "ran.txt"
+        pp = {"enabled": False, "command": f'touch "{marker}"',
+              "fail_on_error": False}
+        download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                         post_processing=pp)
+        assert not marker.exists()
+
+    def test_none_config_is_noop(self, tmp_path, patch_get_scraper, fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        # Simply must not raise when no config is passed.
+        path = download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                                post_processing=None)
+        assert path is not None
+
+    def test_successful_command_runs(self, tmp_path, patch_get_scraper,
+                                     fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "ran.txt"
+        pp = {
+            "enabled": True,
+            "command": (
+                f'"{sys.executable}" -c '
+                f'"from pathlib import Path; Path({str(marker)!r}).touch()"'
+            ),
+            "fail_on_error": True,
+        }
+        download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                         post_processing=pp)
+        assert marker.exists()
+
+    def test_placeholders_and_env_vars(self, tmp_path, patch_get_scraper,
+                                       fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        out_marker = tmp_path / "placeholders.txt"
+        env_marker = tmp_path / "env.txt"
+        script = tmp_path / "record_post_processing.py"
+        script.write_text(
+            "import os, sys\n"
+            "from pathlib import Path\n"
+            "Path(sys.argv[1]).write_text('|'.join(sys.argv[3:]))\n"
+            "Path(sys.argv[2]).write_text('|'.join([\n"
+            "    os.environ['MEMANGA_MANGA_TITLE'],\n"
+            "    os.environ['MEMANGA_CHAPTER'],\n"
+            "    os.environ['MEMANGA_OUTPUT_FORMAT'],\n"
+            "    os.environ['MEMANGA_IS_DIR'],\n"
+            "]))\n"
+            "assert Path(os.environ['MEMANGA_OUTPUT_PATH']).exists()\n"
+        )
+        command = (
+            f'"{sys.executable}" "{script}" "{out_marker}" "{env_marker}" '
+            "{title} {chapter} {source} {format} {is_dir}"
+        )
+        pp = {"enabled": True, "command": command, "fail_on_error": True}
+        download_chapter(manga, chapter, tmp_path, "cbz", fake_state,
+                         post_processing=pp)
+        assert out_marker.read_text().strip() == "PPManga|3|mock.test|cbz|0"
+        assert env_marker.read_text().strip() == "PPManga|3|cbz|0"
+
+    def test_image_folder_output_is_dir_flag(self, tmp_path, patch_get_scraper,
+                                             fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "isdir.txt"
+        script = tmp_path / "check_dir.py"
+        script.write_text(
+            "import os\n"
+            "from pathlib import Path\n"
+            "Path(os.environ['MEMANGA_OUTPUT_PATH']).is_dir() or exit(1)\n"
+            f"Path({str(marker)!r}).write_text(os.environ['MEMANGA_IS_DIR'])\n"
+        )
+        # For an image folder, is_dir should be "1" and the path a directory.
+        command = f'"{sys.executable}" "{script}"'
+        pp = {"enabled": True, "command": command, "fail_on_error": True}
+        path = download_chapter(manga, chapter, tmp_path, "jpg", fake_state,
+                                post_processing=pp)
+        assert Path(path).is_dir()
+        assert marker.read_text().strip() == "1"
+
+    def test_fail_on_error_false_only_warns(self, tmp_path, patch_get_scraper,
+                                            fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        pp = {
+            "enabled": True,
+            "command": f'"{sys.executable}" -c "import sys; sys.exit(1)"',
+            "fail_on_error": False,
+        }
+        # Should NOT raise — download stays successful.
+        path = download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                                post_processing=pp)
+        assert path is not None and Path(path).exists()
+
+    def test_fail_on_error_true_raises(self, tmp_path, patch_get_scraper,
+                                       fake_state):
+        from memanga.downloader import download_chapter, DownloaderError
+        manga, chapter = self._manga_and_chapter()
+        pp = {
+            "enabled": True,
+            "command": f'"{sys.executable}" -c "import sys; sys.exit(3)"',
+            "fail_on_error": True,
+        }
+        with pytest.raises(DownloaderError):
+            download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                             post_processing=pp)
+
+    def test_empty_command_is_noop(self, tmp_path, patch_get_scraper,
+                                   fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        pp = {"enabled": True, "command": "   ", "fail_on_error": True}
+        path = download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                                post_processing=pp)
+        assert path is not None
+
+    def test_placeholder_values_are_not_shell_evaluated(self, tmp_path,
+                                                        patch_get_scraper,
+                                                        fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "placeholder.txt"
+        injected = tmp_path / "injected.txt"
+        manga["title"] = f"PPManga; touch {injected}"
+        script = tmp_path / "write_arg.py"
+        script.write_text(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "Path(sys.argv[1]).write_text(sys.argv[2])\n"
+        )
+
+        pp = {
+            "enabled": True,
+            "command": f'"{sys.executable}" "{script}" "{marker}" {{title}}',
+            "fail_on_error": True,
+        }
+
+        download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                         post_processing=pp)
+
+        assert marker.read_text() == manga["title"]
+        assert not injected.exists()
+
+    def test_placeholder_values_are_not_reexpanded(self, tmp_path,
+                                                   patch_get_scraper,
+                                                   fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "placeholder.txt"
+        script = tmp_path / "write_arg.py"
+        script.write_text(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "Path(sys.argv[1]).write_text(sys.argv[2])\n"
+        )
+        manga["title"] = "Title {source}"
+
+        pp = {
+            "enabled": True,
+            "command": f'"{sys.executable}" "{script}" "{marker}" {{title}}',
+            "fail_on_error": True,
+        }
+
+        download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                         post_processing=pp)
+
+        assert marker.read_text() == "Title {source}"
+
+    def test_timeout_stops_explicit_shell_children(self, tmp_path,
+                                                   patch_get_scraper,
+                                                   fake_state,
+                                                   monkeypatch):
+        sh = shutil.which("sh")
+        if not sh:
+            pytest.skip("requires POSIX sh")
+
+        import memanga.downloader as dl
+        from memanga.downloader import download_chapter, DownloaderError
+
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "late.txt"
+        monkeypatch.setattr(dl, "POST_PROCESSING_TIMEOUT", 1)
+
+        pp = {
+            "enabled": True,
+            "command": f'"{sh}" -c "sleep 3; touch {marker}"',
+            "fail_on_error": True,
+        }
+
+        with pytest.raises(DownloaderError, match="timed out"):
+            download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                             post_processing=pp)
+
+        time.sleep(3.5)
+        assert not marker.exists()
+
+
+class TestPostProcessingCommandSplit:
+    def test_windows_paths_keep_backslashes(self, monkeypatch):
+        import memanga.downloader as dl
+
+        monkeypatch.setattr(dl.os, "name", "nt")
+
+        assert dl._split_post_processing_command(
+            r'python C:\Tools\after_download.py {output_path}'
+        ) == ["python", r"C:\Tools\after_download.py", "{output_path}"]
+        assert dl._split_post_processing_command(
+            r'"C:\Program Files\Tool\hook.exe" "{output_path}"'
+        ) == [r"C:\Program Files\Tool\hook.exe", "{output_path}"]
+        assert dl._split_post_processing_command(
+            r'python --input="C:\Program Files\x" --out="{output_path}"'
+        ) == ["python", r"--input=C:\Program Files\x", "--out={output_path}"]
+
+
+class TestPostProcessingDrainAfterTimeout:
+    """The timeout cleanup must stay bounded even if draining keeps blocking."""
+
+    class _FakeStream:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _WedgedProcess:
+        """A process whose pipes never reach EOF, mimicking a stuck grandchild."""
+
+        def __init__(self):
+            import subprocess as sp
+            self._sp = sp
+            self.communicate_calls = 0
+            self.kill_calls = 0
+            self.stdout = TestPostProcessingDrainAfterTimeout._FakeStream()
+            self.stderr = TestPostProcessingDrainAfterTimeout._FakeStream()
+
+        def communicate(self, timeout=None):
+            self.communicate_calls += 1
+            raise self._sp.TimeoutExpired(cmd="hook", timeout=timeout)
+
+        def kill(self):
+            self.kill_calls += 1
+
+    def test_gives_up_and_closes_pipes_instead_of_hanging(self):
+        import memanga.downloader as dl
+
+        proc = self._WedgedProcess()
+        stdout, stderr = dl._drain_after_timeout(proc, drain_timeout=0)
+
+        assert (stdout, stderr) == (None, None)
+        assert proc.kill_calls == 1
+        assert proc.communicate_calls == 2
+        assert proc.stdout.closed and proc.stderr.closed
+
+    def test_returns_output_when_drain_succeeds(self):
+        import memanga.downloader as dl
+
+        class _CleanProcess:
+            def communicate(self, timeout=None):
+                return "out", "err"
+
+            def kill(self):  # pragma: no cover - should not be called
+                raise AssertionError("kill should not run on a clean drain")
+
+        stdout, stderr = dl._drain_after_timeout(_CleanProcess(), drain_timeout=5)
+        assert (stdout, stderr) == ("out", "err")
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds an optional post-processing hook that runs after each chapter output is created. The hook is disabled by default, supports both archive files and image folders, and exposes useful context through placeholders and MEMANGA_* environment variables.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [x] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #89