### PR TITLE
Add partial chapter tolerance

### DIFF
--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -38,6 +38,26 @@ state = State()
 VALID_STATUSES = ["reading", "on-hold", "dropped", "completed"]
 
 
+def _partial_threshold_arg(value):
+    """argparse type for --partial-threshold: a percentage in [0, 100].
+
+    Rejects non-numeric or out-of-range input at parse time so both
+    `config` and `check` give a clear error instead of silently clamping
+    on the command line (issue #86).
+    """
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(
+            f"invalid threshold {value!r}: expected a number"
+        )
+    if not (0.0 <= num <= 100.0):
+        raise argparse.ArgumentTypeError(
+            f"threshold must be between 0 and 100, got {num:g}"
+        )
+    return num
+
+
 def _get_status_display(manga: Dict[str, Any]) -> str:
     """Get formatted status display."""
     status = manga.get("status", "reading")
@@ -418,7 +438,18 @@ def cmd_check(args):
     download_dir = config.download_dir
     output_format = getattr(args, 'format', None) or config.output_format
     email_cfg = config.get("email", {})
-    
+
+    # Partial-chapter tolerance (issue #86). Config is the source of truth;
+    # `check` flags can override it for a single run.
+    allow_partial = config.partial_enabled
+    if getattr(args, 'allow_partial', False):
+        allow_partial = True
+    if getattr(args, 'no_partial', False):
+        allow_partial = False
+    partial_threshold = getattr(args, 'partial_threshold', None)
+    if partial_threshold is None:
+        partial_threshold = config.partial_threshold
+
     for manga in manga_list:
         title = manga["title"]
         status = manga.get("status", "reading")
@@ -486,6 +517,61 @@ def cmd_check(args):
                 if not should_download:
                     continue
 
+                max_retries = getattr(args, 'retries', 3)
+
+                # Captures partial-download details from download_chapter so
+                # we can surface which pages are missing without parsing the
+                # log line. Reset per attempt.
+                partial_info = {}
+
+                def _capture_partial(failed_pages, total, _info=partial_info):
+                    _info["failed_pages"] = failed_pages
+                    _info["total"] = total
+
+                def _deliver_email(file_path):
+                    """Send to Kindle if configured (skips image folders)."""
+                    if not (delivery_mode == "email" and email_cfg.get("kindle_email")):
+                        return
+                    if file_path.is_dir():
+                        console.print("     [dim]📧 Skipped email (image folders cannot be emailed)[/dim]")
+                        return
+                    console.print("     [dim]📧 Sending to Kindle...[/dim]")
+                    try:
+                        send_to_kindle(
+                            pdf_path=file_path,
+                            kindle_email=email_cfg["kindle_email"],
+                            sender_email=email_cfg["sender_email"],
+                            smtp_server=email_cfg.get("smtp_server", "smtp.gmail.com"),
+                            smtp_port=email_cfg.get("smtp_port", 587),
+                            app_password=get_app_password(config),
+                        )
+                        console.print("     [green]📬 Sent to Kindle![/green]")
+                        if config.get("delivery.delete_after_send", False):
+                            file_path.unlink()
+                            console.print("     [dim]🗑️  Deleted local copy[/dim]")
+                    except EmailError as email_e:
+                        console.print(f"     [red]📧 Email failed: {email_e}[/red]")
+
+                def _announce_saved(file_path, from_backup, partial):
+                    """Print the save line and, for partials, warn + log which
+                    pages are missing so headless runs leave a trail."""
+                    label = f"{file_path.parent.name}/{file_path.name}/" if file_path.is_dir() else file_path.name
+                    src = " from backup" if from_backup else ""
+                    if partial:
+                        miss = partial.get("failed_pages", [])
+                        total = partial.get("total", 0)
+                        console.print(
+                            f"     [yellow]⚠️  Saved partial{src}: {label} — "
+                            f"{len(miss)}/{total} page(s) missing (pages {miss})[/yellow]"
+                        )
+                        state.add_notification(
+                            "warn",
+                            f"'{title}' Chapter {ch.number} saved as partial: "
+                            f"{len(miss)}/{total} page(s) missing (pages {miss}).",
+                        )
+                    else:
+                        console.print(f"     [green]✅ Saved{src}: {label}[/green]")
+
                 try:
                     # Show source info if from backup
                     source_info = ""
@@ -493,39 +579,24 @@ def cmd_check(args):
                         source_info = f" [yellow](from backup: {ch.source})[/yellow]"
 
                     console.print(f"     [dim]⬇️  Downloading {ch_label}...{source_info}[/dim]")
-                    max_retries = getattr(args, 'retries', 3)
-                    file_path = download_chapter(manga, ch, download_dir, output_format, max_retries=max_retries)
-                    is_image_folder = file_path.is_dir()
 
-                    if is_image_folder:
-                        console.print(f"     [green]✅ Saved: {file_path.parent.name}/{file_path.name}/[/green]")
-                    else:
-                        console.print(f"     [green]✅ Saved: {file_path.name}[/green]")
+                    # Only accept a partial straight away when there's no
+                    # backup to try first — otherwise we prefer a complete
+                    # download from the backup (issue #86 direction).
+                    is_from_backup = isinstance(ch, ChapterWithSource) and ch.is_backup
+                    has_backup = (not is_from_backup) and len(_get_sources_from_manga(manga)) > 1
+                    primary_allow_partial = allow_partial and not has_backup
 
-                    # Email if configured (skip for image folders)
-                    if delivery_mode == "email" and email_cfg.get("kindle_email"):
-                        if is_image_folder:
-                            console.print(f"     [dim]📧 Skipped email (image folders cannot be emailed)[/dim]")
-                        else:
-                            console.print(f"     [dim]📧 Sending to Kindle...[/dim]")
-                            try:
-                                send_to_kindle(
-                                    pdf_path=file_path,
-                                    kindle_email=email_cfg["kindle_email"],
-                                    sender_email=email_cfg["sender_email"],
-                                    smtp_server=email_cfg.get("smtp_server", "smtp.gmail.com"),
-                                    smtp_port=email_cfg.get("smtp_port", 587),
-                                    app_password=get_app_password(config),
-                                )
-                                console.print(f"     [green]📬 Sent to Kindle![/green]")
-
-                                # Delete after send if configured
-                                if config.get("delivery.delete_after_send", False):
-                                    file_path.unlink()
-                                    console.print(f"     [dim]🗑️  Deleted local copy[/dim]")
-
-                            except EmailError as e:
-                                console.print(f"     [red]📧 Email failed: {e}[/red]")
+                    partial_info.clear()
+                    file_path = download_chapter(
+                        manga, ch, download_dir, output_format,
+                        max_retries=max_retries,
+                        allow_partial=primary_allow_partial,
+                        partial_threshold=partial_threshold,
+                        on_partial=_capture_partial,
+                    )
+                    _announce_saved(file_path, from_backup=False, partial=dict(partial_info))
+                    _deliver_email(file_path)
 
                     # Update state
                     state.add_downloaded_chapter(title, ch.number)
@@ -542,39 +613,82 @@ def cmd_check(args):
                     ch_source = ch.source if isinstance(ch, ChapterWithSource) else "unknown"
                     is_from_backup = isinstance(ch, ChapterWithSource) and ch.is_backup
 
-                    # Auto-fallback to backup source when the primary source fails
-                    backup_tried = False
+                    backup_ch = None
                     if not is_from_backup:
                         backup_ch = _find_chapter_on_backup(manga, ch.number)
-                        if backup_ch:
-                            backup_tried = True
-                            console.print(f"     [yellow]⚠️  Primary failed ({e}), trying backup ({backup_ch.source})...[/yellow]")
-                            try:
-                                file_path = download_chapter(manga, backup_ch, download_dir, output_format, max_retries=max_retries)
-                                is_image_folder = file_path.is_dir()
-                                if is_image_folder:
-                                    console.print(f"     [green]✅ Saved from backup: {file_path.parent.name}/{file_path.name}/[/green]")
-                                else:
-                                    console.print(f"     [green]✅ Saved from backup: {file_path.name}[/green]")
-                                state.add_downloaded_chapter(title, ch.number)
-                                state.clear_pending_backup(title, ch.number)
-                                state.clear_failed_chapter(title, ch.number)
-                                total_downloaded += 1
-                            except DownloaderError as backup_e:
-                                console.print(f"     [red]❌ Backup also failed: {backup_e}[/red]")
-                                state.add_failed_chapter(
-                                    title, ch.number,
-                                    f"{ch_source}+{backup_ch.source}",
-                                    f"Primary: {e}; Backup: {backup_e}",
-                                )
-                                total_failed += 1
 
-                    if not backup_tried:
-                        # No backup available (or this chapter was already from backup source)
-                        console.print(f"     [red]❌ Failed: {e}[/red]")
-                        state.add_failed_chapter(title, ch.number, ch_source, str(e))
+                    saved = False
+                    backup_e = None
+
+                    # 1) Try a complete download from the backup source.
+                    if backup_ch:
+                        console.print(f"     [yellow]⚠️  Primary failed ({e}), trying backup ({backup_ch.source})...[/yellow]")
+                        try:
+                            file_path = download_chapter(
+                                manga, backup_ch, download_dir, output_format,
+                                max_retries=max_retries,
+                            )
+                            _announce_saved(file_path, from_backup=True, partial=None)
+                            _deliver_email(file_path)
+                            state.add_downloaded_chapter(title, ch.number)
+                            state.clear_pending_backup(title, ch.number)
+                            state.clear_failed_chapter(title, ch.number)
+                            total_downloaded += 1
+                            saved = True
+                        except DownloaderError as be:
+                            backup_e = be
+                            console.print(f"     [red]❌ Backup also failed: {be}[/red]")
+
+                    # 2) Both sources failed to deliver a complete chapter.
+                    #    If partial tolerance is on, salvage the best partial
+                    #    (backup first, then primary) within the threshold.
+                    if not saved and allow_partial:
+                        salvage = []
+                        if backup_ch:
+                            salvage.append((backup_ch, True))
+                        # Skip the primary here if we already tried it with
+                        # partial enabled above (no backup case).
+                        if not primary_allow_partial:
+                            salvage.append((ch, False))
+                        for cand, from_backup in salvage:
+                            partial_info.clear()
+                            try:
+                                file_path = download_chapter(
+                                    manga, cand, download_dir, output_format,
+                                    max_retries=max_retries,
+                                    allow_partial=True,
+                                    partial_threshold=partial_threshold,
+                                    on_partial=_capture_partial,
+                                )
+                            except DownloaderError:
+                                continue
+                            _announce_saved(file_path, from_backup=from_backup, partial=dict(partial_info))
+                            _deliver_email(file_path)
+                            state.add_downloaded_chapter(title, ch.number)
+                            state.clear_pending_backup(title, ch.number)
+                            state.clear_failed_chapter(title, ch.number)
+                            total_downloaded += 1
+                            saved = True
+                            break
+
+                    # 3) Nothing worked — record the failure.
+                    if not saved:
+                        if backup_ch and backup_e is not None:
+                            console.print(f"     [red]❌ Failed: {e}[/red]")
+                            state.add_failed_chapter(
+                                title, ch.number,
+                                f"{ch_source}+{backup_ch.source}",
+                                f"Primary: {e}; Backup: {backup_e}",
+                                failed_pages=getattr(e, "failed_pages", None),
+                            )
+                        else:
+                            console.print(f"     [red]❌ Failed: {e}[/red]")
+                            state.add_failed_chapter(
+                                title, ch.number, ch_source, str(e),
+                                failed_pages=getattr(e, "failed_pages", None),
+                            )
                         total_failed += 1
-                    
+
         except DownloaderError as e:
             console.print(f"  [red]└─ Error: {e}[/red]")
         except Exception as e:
@@ -650,7 +764,27 @@ def cmd_config(args):
         console.print(Panel("[bold]Current Configuration[/bold]", border_style="cyan"))
         console.print(yaml.dump(display, default_flow_style=False))
         return
-    
+
+    # Non-interactive config for partial-chapter tolerance (issue #86).
+    # When any of these flags are given, persist them and return without
+    # dropping into the interactive prompt flow.
+    partial = getattr(args, "partial", None)
+    threshold = getattr(args, "partial_threshold", None)
+    if partial is not None or threshold is not None:
+        if partial is not None:
+            config.set("partial_chapters.enabled", partial == "on")
+        if threshold is not None:
+            # Already validated to [0, 100] by the argparse type.
+            config.set("partial_chapters.threshold_percent", float(threshold))
+        config.save()
+
+        state_str = "enabled" if config.partial_enabled else "disabled"
+        console.print(
+            f"[green]✅ Partial-chapter tolerance {state_str}[/green] "
+            f"[dim](threshold: {config.partial_threshold:g}%)[/dim]"
+        )
+        return
+
     console.print(Panel("[bold]⚙️  Configure MeManga[/bold]", border_style="yellow"))
     console.print()
     
@@ -724,6 +858,35 @@ def cmd_config(args):
         config.set("delivery.output_format", "png")
     elif fmt_choice == "7":
         config.set("delivery.output_format", "webp")
+
+    # Partial-chapter tolerance (issue #86)
+    current_partial = config.partial_enabled
+    state_str = "enabled" if current_partial else "disabled"
+    console.print(
+        f"\n[bold]Partial-Chapter Tolerance[/bold] (current: [cyan]{state_str}[/cyan])"
+    )
+    console.print(
+        "[dim]Keep a chapter that is missing a few pages instead of discarding it.[/dim]"
+    )
+    if Confirm.ask("Enable partial-chapter tolerance?", default=current_partial):
+        config.set("partial_chapters.enabled", True)
+        threshold = Prompt.ask(
+            "Max % of pages allowed to fail",
+            default=str(config.partial_threshold),
+        )
+        try:
+            value = float(threshold)
+        except (TypeError, ValueError):
+            console.print("[yellow]⚠️  Invalid number, keeping previous threshold.[/yellow]")
+        else:
+            clamped = max(0.0, min(100.0, value))
+            if clamped != value:
+                console.print(
+                    f"[yellow]⚠️  Threshold must be 0-100; clamped to {clamped:g}%.[/yellow]"
+                )
+            config.set("partial_chapters.threshold_percent", clamped)
+    else:
+        config.set("partial_chapters.enabled", False)
 
     config.save()
     console.print("\n[green]✅ Configuration saved![/green]")
@@ -1561,6 +1724,12 @@ Examples:
     p_check.add_argument("--force-suspicious", action="store_true", help="Accept a chapter batch even if it was flagged as suspicious")
     p_check.add_argument("--format", choices=["pdf", "epub", "cbz", "zip", "jpg", "png", "webp"], help="Output format (overrides config)")
     p_check.add_argument("--retries", type=int, default=3, metavar="N", help="Retry failed page downloads N times (default: 3, 0 to disable)")
+    # Partial-chapter tolerance (issue #86) — config is the source of truth;
+    # these override it for a single run.
+    partial_grp = p_check.add_mutually_exclusive_group()
+    partial_grp.add_argument("--allow-partial", action="store_true", help="Keep a chapter with a few missing pages instead of discarding it (issue #86)")
+    partial_grp.add_argument("--no-partial", action="store_true", help="Force-discard any chapter with missing pages, even if partial tolerance is enabled in config")
+    p_check.add_argument("--partial-threshold", type=_partial_threshold_arg, metavar="PCT", help="Max %% of pages allowed to fail before a partial is refused, 0-100 (default: config value)")
     p_check.set_defaults(func=cmd_check)
     
     # status
@@ -1570,6 +1739,16 @@ Examples:
     # config
     p_config = subparsers.add_parser("config", help="Configure settings")
     p_config.add_argument("--show", action="store_true", help="Show current config")
+    # Non-interactive partial-chapter tolerance controls (issue #86). When
+    # omitted, `config` stays interactive.
+    p_config.add_argument(
+        "--partial", choices=["on", "off"],
+        help="Enable/disable partial-chapter tolerance without prompting",
+    )
+    p_config.add_argument(
+        "--partial-threshold", type=_partial_threshold_arg, metavar="PCT",
+        help="Persist the max %% of pages allowed to fail (0-100)",
+    )
     p_config.set_defaults(func=cmd_config)
     
     # cron

--- a/memanga/config.py
+++ b/memanga/config.py
@@ -76,6 +76,14 @@ class Config:
                 "auto_check": True,
                 "auto_check_interval": 3600,
             },
+            # Partial-chapter tolerance (issue #86). Off by default: any
+            # missing page still aborts the chapter and discards output.
+            # When enabled, a chapter whose failure rate is within
+            # threshold_percent is kept with only the pages that succeeded.
+            "partial_chapters": {
+                "enabled": False,
+                "threshold_percent": 5,  # max % of pages allowed to fail
+            },
         }
     
     def reload(self):
@@ -178,6 +186,22 @@ class Config:
     @property
     def output_format(self):
         return self.get("delivery.output_format", "pdf")
+
+    @property
+    def partial_enabled(self):
+        """Whether partial-chapter tolerance is turned on (issue #86)."""
+        return bool(self.get("partial_chapters.enabled", False))
+
+    @property
+    def partial_threshold(self):
+        """Max share of pages allowed to fail before a partial is refused,
+        as a percentage clamped to [0, 100]. Falls back to 5 for garbage or
+        out-of-range values persisted by an older/hand-edited config."""
+        try:
+            value = float(self.get("partial_chapters.threshold_percent", 5))
+        except (TypeError, ValueError):
+            return 5.0
+        return max(0.0, min(100.0, value))
 
 
 _KEYRING_SERVICE = "memanga"

--- a/memanga/downloader.py
+++ b/memanga/downloader.py
@@ -59,8 +59,18 @@ DEFAULT_FALLBACK_DELAY_DAYS = 2
 
 
 class DownloaderError(Exception):
-    """Base exception for downloader errors."""
-    pass
+    """Base exception for downloader errors.
+
+    Incomplete-download failures carry structured detail so callers can
+    record/act on them without parsing the message string:
+    ``failed_pages`` (1-indexed page numbers) and ``total_pages``.
+    Both are ``None`` for errors unrelated to per-page failures.
+    """
+
+    def __init__(self, message, failed_pages=None, total_pages=None):
+        super().__init__(message)
+        self.failed_pages = failed_pages
+        self.total_pages = total_pages
 
 
 class ChapterWithSource(Chapter):
@@ -387,6 +397,9 @@ def download_chapter(
     naming_template: Optional[str] = None,
     cancel_event=None,
     max_retries: int = 3,
+    allow_partial: bool = False,
+    partial_threshold: float = 0.0,
+    on_partial=None,
 ) -> Optional[Path]:
     """
     Download a chapter and convert to PDF or EPUB.
@@ -402,11 +415,33 @@ def download_chapter(
             InterruptedError before/during page fetching to abort the download.
         max_retries: Number of times to retry failed page downloads
             (with exponential back-off). 0 to disable.
+        allow_partial: When True, a chapter that still has missing pages
+            after retries is kept as a *partial* download (only the pages
+            that succeeded, in order) instead of raising — provided the
+            failure rate is within ``partial_threshold``. Off by default,
+            so the historical "any failure aborts the chapter" behavior is
+            unchanged unless a caller opts in (issue #86).
+        partial_threshold: Maximum share of pages allowed to fail, as a
+            percentage (0-100). A partial is kept only when
+            ``failed_pages / total_pages * 100 <= partial_threshold`` and
+            at least one page downloaded. With the default 0, any failure
+            still aborts.
+        on_partial: Optional callable(failed_page_nums, total_pages) invoked
+            when a partial download is accepted, so callers can log/surface
+            it and record which pages are missing.
 
     Returns:
         Path to downloaded file, or None if failed
     """
     title = manga["title"]
+
+    # Defensive: keep the tolerance within [0, 100] even if a caller passes
+    # something out of range directly (issue #86). The CLI/config already
+    # clamp, but download_chapter is a public entry point.
+    try:
+        partial_threshold = max(0.0, min(100.0, float(partial_threshold)))
+    except (TypeError, ValueError):
+        partial_threshold = 0.0
 
     def _check_cancel():
         if cancel_event is not None and cancel_event.is_set():
@@ -517,10 +552,36 @@ def download_chapter(
         still_failed = [idx for idx, _, _ in download_tasks if idx not in results]
         if still_failed:
             failed_page_nums = [i + 1 for i in still_failed]
-            raise DownloaderError(
-                f"Incomplete download: {len(still_failed)}/{len(page_urls)} "
-                f"pages failed (pages {failed_page_nums})"
+            failed_pct = len(still_failed) / total_pages * 100
+
+            # Partial-chapter tolerance (issue #86): when enabled and the
+            # failure rate is within the configured threshold, keep the
+            # pages we did get instead of discarding the whole chapter.
+            # At least one page must have downloaded — a chapter with zero
+            # usable pages is a hard failure regardless of the threshold.
+            partial_ok = (
+                allow_partial
+                and results
+                and failed_pct <= partial_threshold
             )
+            if not partial_ok:
+                raise DownloaderError(
+                    f"Incomplete download: {len(still_failed)}/{len(page_urls)} "
+                    f"pages failed (pages {failed_page_nums})",
+                    failed_pages=failed_page_nums,
+                    total_pages=total_pages,
+                )
+
+            print(
+                f"  Partial chapter kept: {len(still_failed)}/{total_pages} "
+                f"page(s) missing ({failed_pct:.0f}% <= "
+                f"{partial_threshold:g}% tolerance), pages {failed_page_nums}"
+            )
+            if on_partial is not None:
+                try:
+                    on_partial(failed_page_nums, total_pages)
+                except Exception:
+                    pass
 
         # Preserve page order
         image_paths = [results[i] for i in sorted(results)]

--- a/memanga/gui/app.py
+++ b/memanga/gui/app.py
@@ -263,8 +263,18 @@ class MeMangaApp(QMainWindow):
         title = data.get("title", "")
         chapter = data.get("chapter", "")
         path = data.get("path", "")
+        partial = data.get("partial")
 
-        self.app_state.add_notification("download", f"Downloaded {title} Ch. {chapter}")
+        if partial:
+            miss = partial.get("failed_pages", [])
+            total = partial.get("total", 0)
+            self.app_state.add_notification(
+                "warn",
+                f"Downloaded {title} Ch. {chapter} as partial: "
+                f"{len(miss)}/{total} page(s) missing (pages {miss}).",
+            )
+        else:
+            self.app_state.add_notification("download", f"Downloaded {title} Ch. {chapter}")
         self.events.publish("notification_added", {})
 
         size_mb = 0

--- a/memanga/gui/pages/detail.py
+++ b/memanga/gui/pages/detail.py
@@ -1160,6 +1160,8 @@ class DetailPage(BasePage):
             output_format=self.app.config.output_format,
             state=self.app.app_state, kindle_cfg=kindle_cfg,
             naming_template=naming_template,
+            allow_partial=self.app.config.partial_enabled,
+            partial_threshold=self.app.config.partial_threshold,
         )
 
         # Visual feedback: disable the button and relabel until completion

--- a/memanga/gui/pages/downloads.py
+++ b/memanga/gui/pages/downloads.py
@@ -592,6 +592,8 @@ class DownloadsPage(BasePage):
                     output_format=self.app.config.output_format,
                     state=self.app.app_state, kindle_cfg=kindle_cfg,
                     naming_template=naming_template,
+                    allow_partial=self.app.config.partial_enabled,
+                    partial_threshold=self.app.config.partial_threshold,
                 )
         if skipped:
             Toast(self, f"Skipped {skipped} chapter(s) already on disk", kind="info")

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QFrame,
     QScrollArea, QWidget, QComboBox, QCheckBox, QRadioButton,
     QLineEdit, QFileDialog, QButtonGroup, QSizePolicy, QSpinBox,
+    QAbstractSpinBox,
 )
 from PySide6.QtCore import Qt
 from .base import BasePage
@@ -54,7 +55,8 @@ class SettingsPage(BasePage):
         reset_btn.setProperty("variant", "ghost")
         reset_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         reset_btn.setIcon(icon("refresh", T.tokens()["text.t_2"], 14))
-        reset_btn.setToolTip("Reset all settings to defaults (coming soon)")
+        reset_btn.setToolTip("Reset all settings to defaults")
+        reset_btn.clicked.connect(self._reset_to_defaults)
         top_row.addWidget(reset_btn)
         h_layout.addLayout(top_row)
 
@@ -484,40 +486,6 @@ class SettingsPage(BasePage):
     def _build_advanced(self):
         f = self._advanced_layout
 
-        # Partial-chapter tolerance (issue #86)
-        self._section(f, "Partial Chapters")
-        partial_hint = QLabel(
-            "Keep a chapter that is missing a few pages instead of discarding it."
-        )
-        partial_hint.setProperty("role", "hint")
-        partial_hint.setWordWrap(True)
-        f.addWidget(partial_hint)
-
-        self._partial_check = QCheckBox("Allow partial chapters")
-        self._partial_check.setChecked(self.app.config.partial_enabled)
-        f.addWidget(self._partial_check)
-
-        thresh_row = QHBoxLayout()
-        thresh_lbl = QLabel("Max pages allowed to fail:")
-        thresh_lbl.setStyleSheet(f"font-size: {T.FONT_SIZE_SM}pt;")
-        thresh_row.addWidget(thresh_lbl)
-
-        self._partial_threshold = QSpinBox()
-        self._partial_threshold.setMinimum(0)
-        self._partial_threshold.setMaximum(100)
-        self._partial_threshold.setSuffix(" %")
-        self._partial_threshold.setValue(int(round(self.app.config.partial_threshold)))
-        self._partial_threshold.setMinimumWidth(90)
-        thresh_row.addWidget(self._partial_threshold)
-        thresh_row.addStretch(1)
-        f.addLayout(thresh_row)
-
-        # Grey out the threshold when tolerance is off.
-        self._partial_threshold.setEnabled(self._partial_check.isChecked())
-        self._partial_check.toggled.connect(self._partial_threshold.setEnabled)
-
-        f.addSpacing(T.PAD_XL)
-
         # Scheduled checks
         self._section(f, "Scheduled Checks")
         cron_row = QHBoxLayout()
@@ -564,6 +532,43 @@ class SettingsPage(BasePage):
         self._cron_status_label = QLabel("")
         self._cron_status_label.setStyleSheet(f"font-size: {T.FONT_SIZE_XS}pt; color: {T.FG_MUTED};")
         f.addWidget(self._cron_status_label)
+
+        f.addSpacing(T.PAD_XL)
+
+        # Partial-chapter tolerance (issue #86)
+        self._section(f, "Partial Chapters")
+        partial_hint = QLabel(
+            "Keep a chapter that is missing a few pages instead of discarding it."
+        )
+        partial_hint.setProperty("role", "hint")
+        partial_hint.setWordWrap(True)
+        f.addWidget(partial_hint)
+
+        self._partial_check = QCheckBox("Allow partial chapters")
+        self._partial_check.setChecked(self.app.config.partial_enabled)
+        f.addWidget(self._partial_check)
+
+        thresh_row = QHBoxLayout()
+        thresh_lbl = QLabel("Max pages allowed to fail:")
+        thresh_lbl.setStyleSheet(f"font-size: {T.FONT_SIZE_SM}pt;")
+        thresh_row.addWidget(thresh_lbl)
+
+        self._partial_threshold = QSpinBox()
+        self._partial_threshold.setMinimum(0)
+        self._partial_threshold.setMaximum(100)
+        self._partial_threshold.setSuffix(" %")
+        self._partial_threshold.setButtonSymbols(QAbstractSpinBox.ButtonSymbols.NoButtons)
+        self._partial_threshold.setAlignment(Qt.AlignmentFlag.AlignRight)
+        self._partial_threshold.setValue(int(round(self.app.config.partial_threshold)))
+        self._partial_threshold.setMinimumWidth(56)
+        self._partial_threshold.setMaximumWidth(72)
+        thresh_row.addWidget(self._partial_threshold)
+        thresh_row.addStretch(1)
+        f.addLayout(thresh_row)
+
+        # Grey out the threshold when tolerance is off.
+        self._partial_threshold.setEnabled(self._partial_check.isChecked())
+        self._partial_check.toggled.connect(self._partial_threshold.setEnabled)
 
         f.addSpacing(T.PAD_XL)
 
@@ -816,6 +821,49 @@ class SettingsPage(BasePage):
 
         cfg.save()
         Toast(self, "Settings saved", kind="success")
+
+    def _reset_to_defaults(self):
+        cfg = self.app.config
+        defaults = cfg._default_config()
+        for section in ("delivery", "email", "cron", "gui", "partial_chapters"):
+            cfg.set(section, defaults[section])
+        cfg.save()
+        self._load_config_into_widgets()
+        Toast(self, "Settings reset to defaults", kind="success")
+
+    def _load_config_into_widgets(self):
+        cfg = self.app.config
+
+        if cfg.delivery_mode == "email":
+            self._radio_email.setChecked(True)
+        else:
+            self._radio_local.setChecked(True)
+
+        self._dir_entry.setText(str(cfg.download_dir))
+        self._format_combo.setCurrentText(cfg.output_format)
+        self._concurrent_slider.setValue(
+            max(1, min(8, int(cfg.get("gui.max_concurrent_downloads", 2))))
+        )
+        self._naming_entry.setText(
+            cfg.get("delivery.naming_template", "{title} - Chapter {chapter}")
+        )
+
+        self._entry_kindle_email.setText(cfg.get("email.kindle_email", ""))
+        self._entry_sender_email.setText(cfg.get("email.sender_email", ""))
+        self._entry_smtp_server.setText(cfg.get("email.smtp_server", "smtp.gmail.com"))
+        self._entry_smtp_port.setText(str(cfg.get("email.smtp_port", 587)))
+        self._password_entry.clear()
+        self._delete_after_check.setChecked(cfg.get("delivery.delete_after_send", False))
+
+        self._cron_check.setChecked(cfg.get("cron.enabled", False))
+        self._cron_time.setText(cfg.get("cron.time", "06:00"))
+
+        if hasattr(self, "_partial_check"):
+            self._partial_check.setChecked(cfg.partial_enabled)
+            self._partial_threshold.setValue(int(round(cfg.partial_threshold)))
+            self._partial_threshold.setEnabled(self._partial_check.isChecked())
+
+        self._refresh_filename_preview()
 
     def _test_email(self):
         self._test_label.setText("Testing...")

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from PySide6.QtWidgets import (
     QVBoxLayout, QHBoxLayout, QLabel, QPushButton, QFrame,
     QScrollArea, QWidget, QComboBox, QCheckBox, QRadioButton,
-    QLineEdit, QFileDialog, QButtonGroup, QSizePolicy,
+    QLineEdit, QFileDialog, QButtonGroup, QSizePolicy, QSpinBox,
 )
 from PySide6.QtCore import Qt
 from .base import BasePage
@@ -484,6 +484,40 @@ class SettingsPage(BasePage):
     def _build_advanced(self):
         f = self._advanced_layout
 
+        # Partial-chapter tolerance (issue #86)
+        self._section(f, "Partial Chapters")
+        partial_hint = QLabel(
+            "Keep a chapter that is missing a few pages instead of discarding it."
+        )
+        partial_hint.setProperty("role", "hint")
+        partial_hint.setWordWrap(True)
+        f.addWidget(partial_hint)
+
+        self._partial_check = QCheckBox("Allow partial chapters")
+        self._partial_check.setChecked(self.app.config.partial_enabled)
+        f.addWidget(self._partial_check)
+
+        thresh_row = QHBoxLayout()
+        thresh_lbl = QLabel("Max pages allowed to fail:")
+        thresh_lbl.setStyleSheet(f"font-size: {T.FONT_SIZE_SM}pt;")
+        thresh_row.addWidget(thresh_lbl)
+
+        self._partial_threshold = QSpinBox()
+        self._partial_threshold.setMinimum(0)
+        self._partial_threshold.setMaximum(100)
+        self._partial_threshold.setSuffix(" %")
+        self._partial_threshold.setValue(int(round(self.app.config.partial_threshold)))
+        self._partial_threshold.setMinimumWidth(90)
+        thresh_row.addWidget(self._partial_threshold)
+        thresh_row.addStretch(1)
+        f.addLayout(thresh_row)
+
+        # Grey out the threshold when tolerance is off.
+        self._partial_threshold.setEnabled(self._partial_check.isChecked())
+        self._partial_check.toggled.connect(self._partial_threshold.setEnabled)
+
+        f.addSpacing(T.PAD_XL)
+
         # Scheduled checks
         self._section(f, "Scheduled Checks")
         cron_row = QHBoxLayout()
@@ -774,6 +808,11 @@ class SettingsPage(BasePage):
             cron_time = "06:00"
         cfg.set("cron.enabled", self._cron_check.isChecked())
         cfg.set("cron.time", cron_time)
+
+        # Partial-chapter tolerance (issue #86)
+        if hasattr(self, "_partial_check"):
+            cfg.set("partial_chapters.enabled", self._partial_check.isChecked())
+            cfg.set("partial_chapters.threshold_percent", int(self._partial_threshold.value()))
 
         cfg.save()
         Toast(self, "Settings saved", kind="success")

--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -318,8 +318,15 @@ class BackgroundWorker:
     # ------------------------------------------------------------------
 
     def download_chapter(self, manga, chapter, output_dir, output_format, state,
-                         kindle_cfg=None, naming_template=None):
-        """Queue a chapter download."""
+                         kindle_cfg=None, naming_template=None,
+                         allow_partial=False, partial_threshold=0.0):
+        """Queue a chapter download.
+
+        ``allow_partial``/``partial_threshold`` carry the partial-chapter
+        tolerance settings (issue #86) from config through to the
+        downloader. Off by default so behavior is unchanged unless the
+        caller opts in.
+        """
         task_id = f"{manga['title']}:{chapter.number}"
         # Refuse to enqueue while offline — the request would just
         # block a worker slot until per-source retries time out.
@@ -347,6 +354,8 @@ class BackgroundWorker:
             "kindle_cfg": kindle_cfg,
             "naming_template": naming_template,
             "cancel": cancel,
+            "allow_partial": allow_partial,
+            "partial_threshold": partial_threshold,
         }
 
         with self._lock:
@@ -372,7 +381,12 @@ class BackgroundWorker:
         """Execute a single download task."""
         import traceback
         try:
-            from ..downloader import download_chapter
+            from ..downloader import (
+                download_chapter,
+                DownloaderError,
+                ChapterWithSource,
+                _get_sources_from_manga,
+            )
         except Exception as e:
             print(f"[Download] FATAL: Failed to import downloader: {e}", flush=True)
             traceback.print_exc()
@@ -409,18 +423,17 @@ class BackgroundWorker:
             except Exception:
                 pass
 
-        try:
-            path = download_chapter(
-                manga=manga,
-                chapter=chapter,
-                output_dir=item["output_dir"],
-                output_format=item["output_format"],
-                state=item["state"],
-                progress_callback=progress_cb,
-                naming_template=item.get("naming_template"),
-                cancel_event=item["cancel"],
-            )
+        # Captures partial-download detail (issue #86) so the completion
+        # event can surface which pages are missing without parsing logs.
+        partial_info = {}
 
+        def on_partial(failed_pages, total):
+            partial_info["failed_pages"] = failed_pages
+            partial_info["total"] = total
+
+        def _finish(path, from_backup):
+            """Deliver to Kindle (if configured) and publish
+            download_complete, carrying any accepted partial detail."""
             # Kindle delivery
             if item["kindle_cfg"] and path:
                 try:
@@ -438,14 +451,73 @@ class BackgroundWorker:
                 except Exception as e:
                     self._events.publish("kindle_error", {"task_id": task_id, "error": str(e)})
 
-            self._events.publish("download_complete", {
+            complete_payload = {
                 "task_id": task_id,
                 "path": str(path) if path else None,
                 "title": manga["title"],
                 "chapter": chapter.number,
-            })
+                "from_backup": from_backup,
+            }
+            if partial_info:
+                complete_payload["partial"] = dict(partial_info)
+                print(
+                    f"[Download] Partial kept{' from backup' if from_backup else ''}: "
+                    f"{manga['title']} Ch.{chapter.number} "
+                    f"— {len(partial_info['failed_pages'])}/{partial_info['total']} "
+                    f"page(s) missing {partial_info['failed_pages']}",
+                    flush=True,
+                )
+            elif from_backup:
+                print(
+                    f"[Download] Completed from backup: "
+                    f"{manga['title']} Ch.{chapter.number}",
+                    flush=True,
+                )
+            self._events.publish("download_complete", complete_payload)
+
+        allow_partial = item.get("allow_partial", False)
+        partial_threshold = item.get("partial_threshold", 0.0)
+
+        # Backup-first parity with the CLI (issue #86): when the chapter is
+        # from the primary source and the manga has a backup configured,
+        # prefer a *complete* backup download over keeping a primary
+        # partial. Only accept a primary partial straight away when there
+        # is no backup to try first.
+        is_from_backup = isinstance(chapter, ChapterWithSource) and chapter.is_backup
+        has_backup = (not is_from_backup) and len(_get_sources_from_manga(manga)) > 1
+        primary_allow_partial = allow_partial and not has_backup
+
+        try:
+            partial_info.clear()
+            path = download_chapter(
+                manga=manga,
+                chapter=chapter,
+                output_dir=item["output_dir"],
+                output_format=item["output_format"],
+                state=item["state"],
+                progress_callback=progress_cb,
+                naming_template=item.get("naming_template"),
+                cancel_event=item["cancel"],
+                allow_partial=primary_allow_partial,
+                partial_threshold=partial_threshold,
+                on_partial=on_partial,
+            )
+            _finish(path, from_backup=False)
         except InterruptedError:
             self._events.publish("download_cancelled", {"task_id": task_id})
+        except DownloaderError as e:
+            # Primary source couldn't deliver a complete chapter. Try the
+            # backup first (complete), then salvage the best partial within
+            # threshold (backup, then primary) if tolerance is enabled.
+            try:
+                self._recover_via_backup(
+                    item, chapter, manga, e, on_partial, partial_info,
+                    _finish, allow_partial, partial_threshold,
+                    primary_allow_partial, is_from_backup,
+                    progress_callback=progress_cb,
+                )
+            except InterruptedError:
+                self._events.publish("download_cancelled", {"task_id": task_id})
         except Exception as e:
             print(f"[Download] ERROR: {manga['title']} Ch.{chapter.number}: {e}", flush=True)
             traceback.print_exc()
@@ -456,6 +528,103 @@ class BackgroundWorker:
         finally:
             self._cancel_flags.pop(task_id, None)
             self._start_next_download()
+
+    def _recover_via_backup(self, item, chapter, manga, primary_err,
+                            on_partial, partial_info, finish,
+                            allow_partial, partial_threshold,
+                            primary_allow_partial, is_from_backup,
+                            progress_callback=None):
+        """Backup-first recovery after a primary DownloaderError.
+
+        Mirrors the CLI (issue #86): 1) try a *complete* download from the
+        backup source; 2) if that also fails and partial tolerance is on,
+        keep the best partial within threshold, preferring the backup
+        partial over the primary partial; 3) otherwise publish
+        download_error. ``InterruptedError`` (cancellation) is allowed to
+        propagate so the caller can report a cancelled download.
+
+        ``progress_callback`` mirrors the primary attempt so backup and
+        salvage downloads still emit ``download_progress`` events (and,
+        because the same callback raises ``InterruptedError`` on a set
+        cancel flag, keep honouring cancellation).
+        """
+        from ..downloader import (
+            download_chapter,
+            DownloaderError,
+            _find_chapter_on_backup,
+        )
+
+        task_id = item["task_id"]
+
+        backup_ch = None
+        if not is_from_backup:
+            backup_ch = _find_chapter_on_backup(manga, chapter.number)
+
+        def _dl(cand, allow_partial_flag):
+            return download_chapter(
+                manga=manga,
+                chapter=cand,
+                output_dir=item["output_dir"],
+                output_format=item["output_format"],
+                state=item["state"],
+                progress_callback=progress_callback,
+                naming_template=item.get("naming_template"),
+                cancel_event=item["cancel"],
+                allow_partial=allow_partial_flag,
+                partial_threshold=partial_threshold,
+                on_partial=on_partial,
+            )
+
+        backup_err = None
+
+        # 1) Complete download from the backup source.
+        if backup_ch:
+            print(
+                f"[Download] Primary failed ({primary_err}), trying backup "
+                f"({backup_ch.source}) for {manga['title']} Ch.{chapter.number}",
+                flush=True,
+            )
+            partial_info.clear()
+            try:
+                path = _dl(backup_ch, False)
+                finish(path, from_backup=True)
+                return
+            except DownloaderError as be:
+                backup_err = be
+                print(f"[Download] Backup also failed: {be}", flush=True)
+
+        # 2) Salvage the best partial within threshold (backup first, then
+        #    primary), only if partial tolerance is enabled.
+        if allow_partial:
+            salvage = []
+            if backup_ch:
+                salvage.append((backup_ch, True))
+            # Skip the primary here if it was already attempted with partial
+            # enabled above (the no-backup case).
+            if not primary_allow_partial:
+                salvage.append((chapter, False))
+            for cand, from_backup in salvage:
+                partial_info.clear()
+                try:
+                    path = _dl(cand, True)
+                except DownloaderError:
+                    continue
+                finish(path, from_backup=from_backup)
+                return
+
+        # 3) Nothing worked — surface the failure.
+        if backup_ch and backup_err is not None:
+            error_msg = f"Primary: {primary_err}; Backup: {backup_err}"
+        else:
+            error_msg = str(primary_err)
+        print(
+            f"[Download] ERROR: {manga['title']} Ch.{chapter.number}: {error_msg}",
+            flush=True,
+        )
+        self._events.publish("download_error", {
+            "task_id": task_id, "error": error_msg,
+            "title": manga["title"], "chapter": chapter.number,
+        })
 
     def _start_next_download(self):
         """Release the finished download's slot, then refill from the queue.

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -275,7 +275,8 @@ def test_issue_40_pause_resume_keeps_queue(app_window, qapp, monkeypatch):
 
     def fake_download_chapter(manga, chapter, output_dir, output_format,
                                state, progress_callback=None,
-                               naming_template=None, cancel_event=None):
+                               naming_template=None, cancel_event=None,
+                               **kwargs):
         gates[f"{manga['title']}:{chapter.number}"].wait(timeout=10)
         return None
 

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import pytest
 import sys
+import types
 from unittest.mock import patch, MagicMock
 
 
@@ -196,6 +197,28 @@ class TestCheckCommand:
         rc = run_cli("check")
         assert rc == 0  # nothing to do — should exit cleanly
 
+    def test_partial_flags_are_accepted(self, run_cli, config):
+        # Issue #86: the partial-tolerance override flags must parse.
+        # With no manga, check exits cleanly regardless.
+        rc = run_cli("check", "--allow-partial", "--partial-threshold", "10")
+        assert rc == 0
+
+    def test_check_out_of_range_threshold_rejected(self, run_cli, config):
+        # Issue #86: out-of-range threshold is rejected consistently with
+        # `config` (argparse type error).
+        rc = run_cli("check", "--partial-threshold", "150")
+        assert rc != 0
+
+    def test_allow_and_no_partial_are_mutually_exclusive(self, run_cli, config):
+        rc = run_cli("check", "--allow-partial", "--no-partial")
+        assert rc != 0  # argparse rejects the conflicting pair
+
+    def test_partial_flags_listed_in_help(self, run_cli, capsys):
+        run_cli("check", "--help")
+        out = capsys.readouterr().out.lower()
+        assert "--allow-partial" in out
+        assert "--partial-threshold" in out
+
     def test_check_with_one_manga(self, run_cli, config, patch_get_scraper,
                                     monkeypatch):
         config.set("manga", [{
@@ -208,6 +231,172 @@ class TestCheckCommand:
         rc = run_cli("check")
         # Either returns 0 (success) or a small int — should not crash.
         assert rc in (0, 1)
+
+    def test_backup_success_in_email_mode_sends_before_marking_downloaded(
+            self, run_cli, config, monkeypatch, tmp_path):
+        """Issue #86 regression: backup recovery must still run Kindle
+        delivery before the chapter is marked downloaded."""
+        from memanga import cli
+        from memanga.downloader import DownloaderError
+        from memanga.state import State
+
+        config.set("delivery.mode", "email")
+        config.set("email.kindle_email", "reader@example.com")
+        config.set("email.sender_email", "sender@example.com")
+        config.set("manga", [{
+            "title": "Vinland Saga",
+            "status": "reading",
+            "sources": [
+                {"source": "primary.test", "url": "https://primary.test/vs"},
+                {"source": "backup.test", "url": "https://backup.test/vs"},
+            ],
+        }])
+        config.save()
+
+        cli.state = State()
+        primary_ch = types.SimpleNamespace(
+            number="71", title="", url="https://primary.test/c/71",
+            source="primary.test", is_backup=False)
+        backup_ch = types.SimpleNamespace(
+            number="71", title="", url="https://backup.test/c/71",
+            source="backup.test", is_backup=True)
+        backup_path = tmp_path / "backup.pdf"
+        sent = []
+
+        monkeypatch.setattr(cli, "check_for_updates",
+                            lambda *a, **k: [primary_ch])
+        monkeypatch.setattr(cli, "_find_chapter_on_backup",
+                            lambda *a, **k: backup_ch)
+
+        def fake_download(manga, chapter, *args, **kwargs):
+            if getattr(chapter, "is_backup", False):
+                return backup_path
+            raise DownloaderError("primary incomplete",
+                                  failed_pages=[13], total_pages=40)
+
+        def fake_send_to_kindle(**kwargs):
+            sent.append(kwargs["pdf_path"])
+            assert not cli.state.is_chapter_downloaded("Vinland Saga", "71")
+
+        monkeypatch.setattr(cli, "download_chapter", fake_download)
+        monkeypatch.setattr(cli, "send_to_kindle", fake_send_to_kindle)
+        monkeypatch.setattr(cli, "get_app_password", lambda cfg: "pw")
+
+        rc = run_cli("check", "--auto", "--quiet")
+
+        assert rc == 0
+        assert sent == [backup_path]
+        assert cli.state.is_chapter_downloaded("Vinland Saga", "71")
+
+    def test_backup_partial_in_email_mode_sends_and_warns(
+            self, run_cli, config, monkeypatch, tmp_path):
+        """When both sources fail complete downloads, an accepted backup
+        partial must be delivered and logged before state is advanced."""
+        from memanga import cli
+        from memanga.downloader import DownloaderError
+        from memanga.state import State
+
+        config.set("delivery.mode", "email")
+        config.set("email.kindle_email", "reader@example.com")
+        config.set("email.sender_email", "sender@example.com")
+        config.set("partial_chapters.enabled", True)
+        config.set("partial_chapters.threshold_percent", 10)
+        config.set("manga", [{
+            "title": "Vinland Saga",
+            "status": "reading",
+            "sources": [
+                {"source": "primary.test", "url": "https://primary.test/vs"},
+                {"source": "backup.test", "url": "https://backup.test/vs"},
+            ],
+        }])
+        config.save()
+
+        cli.state = State()
+        primary_ch = types.SimpleNamespace(
+            number="71", title="", url="https://primary.test/c/71",
+            source="primary.test", is_backup=False)
+        backup_ch = types.SimpleNamespace(
+            number="71", title="", url="https://backup.test/c/71",
+            source="backup.test", is_backup=True)
+        partial_path = tmp_path / "backup-partial.pdf"
+        sent = []
+
+        monkeypatch.setattr(cli, "check_for_updates",
+                            lambda *a, **k: [primary_ch])
+        monkeypatch.setattr(cli, "_find_chapter_on_backup",
+                            lambda *a, **k: backup_ch)
+
+        def fake_download(manga, chapter, *args, **kwargs):
+            if not getattr(chapter, "is_backup", False):
+                raise DownloaderError("primary incomplete",
+                                      failed_pages=[13], total_pages=40)
+            if not kwargs.get("allow_partial", False):
+                raise DownloaderError("backup incomplete",
+                                      failed_pages=[7], total_pages=40)
+            kwargs["on_partial"]([7], 40)
+            return partial_path
+
+        def fake_send_to_kindle(**kwargs):
+            sent.append(kwargs["pdf_path"])
+            assert not cli.state.is_chapter_downloaded("Vinland Saga", "71")
+
+        monkeypatch.setattr(cli, "download_chapter", fake_download)
+        monkeypatch.setattr(cli, "send_to_kindle", fake_send_to_kindle)
+        monkeypatch.setattr(cli, "get_app_password", lambda cfg: "pw")
+
+        rc = run_cli("check", "--auto", "--quiet")
+
+        assert rc == 0
+        assert sent == [partial_path]
+        assert cli.state.is_chapter_downloaded("Vinland Saga", "71")
+        notifications = cli.state.get("notifications", [])
+        assert any("saved as partial" in n["message"] for n in notifications)
+
+    def test_over_threshold_backup_failure_records_failure_not_downloaded(
+            self, run_cli, config, monkeypatch):
+        """If neither complete nor partial recovery is acceptable, the
+        chapter stays failed and is not marked downloaded."""
+        from memanga import cli
+        from memanga.downloader import DownloaderError
+        from memanga.state import State
+
+        config.set("partial_chapters.enabled", True)
+        config.set("partial_chapters.threshold_percent", 1)
+        config.set("manga", [{
+            "title": "Vinland Saga",
+            "status": "reading",
+            "sources": [
+                {"source": "primary.test", "url": "https://primary.test/vs"},
+                {"source": "backup.test", "url": "https://backup.test/vs"},
+            ],
+        }])
+        config.save()
+
+        cli.state = State()
+        primary_ch = types.SimpleNamespace(
+            number="71", title="", url="https://primary.test/c/71",
+            source="primary.test", is_backup=False)
+        backup_ch = types.SimpleNamespace(
+            number="71", title="", url="https://backup.test/c/71",
+            source="backup.test", is_backup=True)
+
+        monkeypatch.setattr(cli, "check_for_updates",
+                            lambda *a, **k: [primary_ch])
+        monkeypatch.setattr(cli, "_find_chapter_on_backup",
+                            lambda *a, **k: backup_ch)
+        monkeypatch.setattr(
+            cli, "download_chapter",
+            lambda *a, **k: (_ for _ in ()).throw(
+                DownloaderError("incomplete", failed_pages=[1], total_pages=10)
+            ),
+        )
+
+        rc = run_cli("check", "--auto", "--quiet")
+
+        assert rc == 0
+        assert not cli.state.is_chapter_downloaded("Vinland Saga", "71")
+        failed = cli.state.get_failed_chapters("Vinland Saga")
+        assert "71" in failed
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -241,6 +430,46 @@ class TestConfigCommand:
             # Reload config from disk
             from memanga.config import Config
             assert Config().get("delivery.output_format") == "epub"
+
+    # ── Non-interactive partial-chapter tolerance (issue #86) ──
+
+    def test_config_partial_on_persists(self, run_cli, config):
+        rc = run_cli("config", "--partial", "on", "--partial-threshold", "5")
+        assert rc == 0
+        assert config.get("partial_chapters.enabled") is True
+        assert float(config.get("partial_chapters.threshold_percent")) == 5.0
+
+    def test_config_partial_off_persists(self, run_cli, config):
+        run_cli("config", "--partial", "on")
+        rc = run_cli("config", "--partial", "off")
+        assert rc == 0
+        assert config.get("partial_chapters.enabled") is False
+
+    def test_config_threshold_only_keeps_enabled_state(self, run_cli, config):
+        # Turn tolerance on, then change only the threshold — enabled
+        # state must be preserved.
+        run_cli("config", "--partial", "on", "--partial-threshold", "5")
+        rc = run_cli("config", "--partial-threshold", "10")
+        assert rc == 0
+        assert config.get("partial_chapters.enabled") is True
+        assert float(config.get("partial_chapters.threshold_percent")) == 10.0
+
+    def test_config_out_of_range_threshold_rejected(self, run_cli, config):
+        rc = run_cli("config", "--partial-threshold", "150")
+        assert rc != 0  # argparse rejects it, nothing persisted
+        assert config.get("partial_chapters.threshold_percent") != 150
+
+    def test_config_non_numeric_threshold_rejected(self, run_cli, config):
+        rc = run_cli("config", "--partial-threshold", "lots")
+        assert rc != 0
+
+    def test_config_show_does_not_prompt(self, run_cli, config, monkeypatch):
+        # --show must return without touching stdin.
+        def _boom(*a, **k):
+            raise AssertionError("config --show should not prompt")
+        monkeypatch.setattr("builtins.input", _boom)
+        rc = run_cli("config", "--show")
+        assert rc == 0
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -228,6 +228,22 @@ class TestSettingsPage:
         # No exception = passes. Config got at least one write.
         assert app_window.config.get("delivery.output_format") is not None
 
+    def test_partial_toggle_saves_to_config(self, app_window, qapp):
+        # Partial-chapter tolerance (issue #86): the Advanced-tab toggle +
+        # threshold spin should persist to config on save.
+        page = app_window._pages["settings"]
+        page._partial_check.setChecked(True)
+        page._partial_threshold.setValue(12)
+        page._save()
+        assert app_window.config.partial_enabled is True
+        assert app_window.config.partial_threshold == 12.0
+
+    def test_partial_threshold_disabled_when_toggle_off(self, app_window, qapp):
+        page = app_window._pages["settings"]
+        page._partial_check.setChecked(False)
+        qapp.processEvents()
+        assert not page._partial_threshold.isEnabled()
+
     def test_template_preview_substitutes(self, app_window, qapp):
         page = app_window._pages["settings"]
         page._naming_entry.setText("X-{chapter}")

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -244,6 +244,34 @@ class TestSettingsPage:
         qapp.processEvents()
         assert not page._partial_threshold.isEnabled()
 
+    def test_partial_threshold_uses_keyboard_only_input(self, app_window, qapp):
+        from PySide6.QtWidgets import QAbstractSpinBox
+
+        page = app_window._pages["settings"]
+        assert (
+            page._partial_threshold.buttonSymbols()
+            == QAbstractSpinBox.ButtonSymbols.NoButtons
+        )
+        assert page._partial_threshold.maximumWidth() == 72
+
+    def test_reset_defaults_updates_partial_controls(self, app_window, qapp):
+        page = app_window._pages["settings"]
+        app_window.config.set("manga", [{"title": "KeepMe"}])
+        app_window.config.set("partial_chapters.enabled", True)
+        app_window.config.set("partial_chapters.threshold_percent", 12)
+        page._partial_check.setChecked(True)
+        page._partial_threshold.setValue(12)
+
+        page._reset_to_defaults()
+        qapp.processEvents()
+
+        assert app_window.config.partial_enabled is False
+        assert app_window.config.partial_threshold == 5.0
+        assert not page._partial_check.isChecked()
+        assert page._partial_threshold.value() == 5
+        assert not page._partial_threshold.isEnabled()
+        assert app_window.config.get("manga") == [{"title": "KeepMe"}]
+
     def test_template_preview_substitutes(self, app_window, qapp):
         page = app_window._pages["settings"]
         page._naming_entry.setText("X-{chapter}")

--- a/tests/unit/gui/test_workers.py
+++ b/tests/unit/gui/test_workers.py
@@ -80,7 +80,8 @@ class TestPauseResumeQueue:
 
         def fake_download_chapter(manga, chapter, output_dir, output_format,
                                    state, progress_callback=None,
-                                   naming_template=None, cancel_event=None):
+                                   naming_template=None, cancel_event=None,
+                                   **kwargs):
             tid = f"{manga['title']}:{chapter.number}"
             with h._lock:
                 h.running.add(tid)
@@ -169,6 +170,220 @@ class TestPauseResumeQueue:
         event_bus.poll()
         assert sorted(completed) == [f"M:{i}" for i in range(1, 6)]
         assert gated_downloads.max_running == 2
+
+
+class TestPartialDownload:
+    """Partial-chapter tolerance (issue #86): the worker forwards the
+    config-derived settings to the downloader and surfaces the accepted
+    partial in the download_complete event."""
+
+    def test_partial_info_forwarded_and_surfaced(
+            self, worker, event_bus, monkeypatch, tmp_path):
+        import types
+        import time
+        import memanga.downloader as dl
+
+        seen_kwargs = {}
+
+        def fake_download_chapter(manga, chapter, output_dir, output_format,
+                                   state, progress_callback=None,
+                                   naming_template=None, cancel_event=None,
+                                   allow_partial=False, partial_threshold=0.0,
+                                   on_partial=None, **kwargs):
+            seen_kwargs["allow_partial"] = allow_partial
+            seen_kwargs["partial_threshold"] = partial_threshold
+            # Simulate an accepted partial download.
+            if on_partial is not None:
+                on_partial([6], 40)
+            return tmp_path / "out.pdf"
+
+        monkeypatch.setattr(dl, "download_chapter", fake_download_chapter)
+
+        completed = []
+        event_bus.subscribe("download_complete", lambda d: completed.append(d))
+
+        worker.download_chapter(
+            {"title": "Vinland Saga"}, types.SimpleNamespace(number="71"),
+            str(tmp_path), "pdf", None,
+            allow_partial=True, partial_threshold=5,
+        )
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and not completed:
+            event_bus.poll()
+            time.sleep(0.02)
+
+        assert seen_kwargs == {"allow_partial": True, "partial_threshold": 5}
+        assert completed and completed[0].get("partial") == {
+            "failed_pages": [6], "total": 40}
+
+
+class TestBackupFirst:
+    """Backup-first parity with the CLI (issue #86): when a primary
+    download fails and the manga has a backup source, the worker prefers
+    a *complete* backup download over keeping a primary partial. Only if
+    the backup also fails does partial tolerance salvage the best partial
+    (backup first, then primary) within threshold."""
+
+    # Manga with a real backup source configured (sources array, len 2).
+    _MANGA = {
+        "title": "Vinland Saga",
+        "sources": [
+            {"url": "https://primary.test/vs", "source": "primary.test"},
+            {"url": "https://backup.test/vs", "source": "backup.test"},
+        ],
+    }
+
+    def _run(self, worker, event_bus, monkeypatch, fake_dl,
+             allow_partial, partial_threshold, tmp_path):
+        """Drive a single download through the worker with a faked
+        downloader + backup lookup; return (completes, errors, cancels)."""
+        import types
+        import time
+        import memanga.downloader as dl
+
+        # Backup lookup returns a chapter tagged as backup so the fake
+        # downloader can tell primary and backup attempts apart.
+        backup_ch = types.SimpleNamespace(
+            number="71", url="https://backup.test/vs/71",
+            source="backup.test", is_backup=True)
+        monkeypatch.setattr(
+            dl, "_find_chapter_on_backup", lambda manga, num: backup_ch)
+        monkeypatch.setattr(dl, "download_chapter", fake_dl)
+
+        completes, errors, cancels = [], [], []
+        event_bus.subscribe("download_complete", lambda d: completes.append(d))
+        event_bus.subscribe("download_error", lambda d: errors.append(d))
+        event_bus.subscribe("download_cancelled", lambda d: cancels.append(d))
+
+        chapter = types.SimpleNamespace(number="71", url="https://primary.test/vs/71")
+        worker.download_chapter(
+            self._MANGA, chapter, str(tmp_path), "pdf", None,
+            allow_partial=allow_partial, partial_threshold=partial_threshold)
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and not (completes or errors or cancels):
+            event_bus.poll()
+            time.sleep(0.02)
+        event_bus.poll()
+        return completes, errors, cancels
+
+    def test_primary_error_backup_complete_no_partial(
+            self, worker, event_bus, monkeypatch, tmp_path):
+        # Primary raises; backup delivers a complete chapter → completes
+        # from backup with no partial warning.
+        from memanga.downloader import DownloaderError
+
+        def fake_dl(manga, chapter, output_dir, output_format, state=None,
+                    on_partial=None, **kw):
+            if not getattr(chapter, "is_backup", False):
+                raise DownloaderError("primary boom",
+                                      failed_pages=[3], total_pages=10)
+            return tmp_path / "backup.pdf"  # complete, no on_partial
+
+        completes, errors, cancels = self._run(
+            worker, event_bus, monkeypatch, fake_dl,
+            allow_partial=True, partial_threshold=5, tmp_path=tmp_path)
+
+        assert not errors and not cancels
+        assert len(completes) == 1
+        assert completes[0].get("from_backup") is True
+        assert "partial" not in completes[0]
+
+    def test_primary_partial_still_prefers_complete_backup(
+            self, worker, event_bus, monkeypatch, tmp_path):
+        # Even when the primary *could* have been kept as a partial within
+        # threshold, the presence of a backup means the primary is tried
+        # with partial disabled first, so it errors and the complete
+        # backup wins.
+        from memanga.downloader import DownloaderError
+
+        seen = {"primary_allow_partial": None}
+
+        def fake_dl(manga, chapter, output_dir, output_format, state=None,
+                    allow_partial=False, on_partial=None, **kw):
+            if not getattr(chapter, "is_backup", False):
+                seen["primary_allow_partial"] = allow_partial
+                raise DownloaderError("primary incomplete")
+            return tmp_path / "backup.pdf"
+
+        completes, errors, cancels = self._run(
+            worker, event_bus, monkeypatch, fake_dl,
+            allow_partial=True, partial_threshold=90, tmp_path=tmp_path)
+
+        # Primary was attempted with partial disabled (backup exists).
+        assert seen["primary_allow_partial"] is False
+        assert not errors and len(completes) == 1
+        assert completes[0].get("from_backup") is True
+        assert "partial" not in completes[0]
+
+    def test_backup_partial_under_threshold_kept_from_backup(
+            self, worker, event_bus, monkeypatch, tmp_path):
+        # Primary fails, backup can't complete either, but the backup
+        # partial is within threshold → keep the backup partial.
+        from memanga.downloader import DownloaderError
+
+        def fake_dl(manga, chapter, output_dir, output_format, state=None,
+                    allow_partial=False, on_partial=None, **kw):
+            if not getattr(chapter, "is_backup", False):
+                raise DownloaderError("primary boom")
+            if not allow_partial:
+                raise DownloaderError("backup incomplete")  # complete attempt
+            if on_partial is not None:
+                on_partial([4], 20)  # 5% missing, within threshold
+            return tmp_path / "backup_partial.pdf"
+
+        completes, errors, cancels = self._run(
+            worker, event_bus, monkeypatch, fake_dl,
+            allow_partial=True, partial_threshold=10, tmp_path=tmp_path)
+
+        assert not errors and len(completes) == 1
+        assert completes[0].get("from_backup") is True
+        assert completes[0].get("partial") == {"failed_pages": [4], "total": 20}
+
+    def test_all_fail_over_threshold_errors(
+            self, worker, event_bus, monkeypatch, tmp_path):
+        # Primary fails, backup complete fails, and neither backup nor
+        # primary partial is within threshold → download_error, and the
+        # message names both sources.
+        from memanga.downloader import DownloaderError
+
+        def fake_dl(manga, chapter, output_dir, output_format, state=None,
+                    allow_partial=False, on_partial=None, **kw):
+            # Over-threshold partials raise from the real downloader; the
+            # fake mimics that by always raising.
+            raise DownloaderError("incomplete")
+
+        completes, errors, cancels = self._run(
+            worker, event_bus, monkeypatch, fake_dl,
+            allow_partial=True, partial_threshold=1, tmp_path=tmp_path)
+
+        assert not completes and not cancels
+        assert len(errors) == 1
+        assert "Primary" in errors[0]["error"] and "Backup" in errors[0]["error"]
+
+    def test_partial_disabled_backup_complete_still_used(
+            self, worker, event_bus, monkeypatch, tmp_path):
+        # With partial tolerance off, a failing primary still falls back to
+        # a *complete* backup (parity with the CLI multi-source backup),
+        # but no partial is ever kept.
+        from memanga.downloader import DownloaderError
+
+        def fake_dl(manga, chapter, output_dir, output_format, state=None,
+                    allow_partial=False, on_partial=None, **kw):
+            if not getattr(chapter, "is_backup", False):
+                raise DownloaderError("primary boom")
+            if not allow_partial:
+                return tmp_path / "backup.pdf"
+            raise AssertionError("partial salvage must not run when disabled")
+
+        completes, errors, cancels = self._run(
+            worker, event_bus, monkeypatch, fake_dl,
+            allow_partial=False, partial_threshold=0, tmp_path=tmp_path)
+
+        assert not errors and len(completes) == 1
+        assert completes[0].get("from_backup") is True
+        assert "partial" not in completes[0]
 
 
 class TestCancelFlags:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,6 +22,33 @@ class TestConfigBasics:
         assert a == {"b": {"c": 42}}
 
 
+class TestPartialChapterConfig:
+    """Partial-chapter tolerance settings (issue #86)."""
+
+    def test_disabled_by_default(self, config):
+        assert config.partial_enabled is False
+        # Default threshold is exposed as a float for the downloader.
+        assert config.partial_threshold == 5.0
+
+    def test_enable_and_set_threshold(self, config):
+        config.set("partial_chapters.enabled", True)
+        config.set("partial_chapters.threshold_percent", 10)
+        assert config.partial_enabled is True
+        assert config.partial_threshold == 10.0
+
+    def test_threshold_falls_back_on_garbage(self, config):
+        config.set("partial_chapters.threshold_percent", "not-a-number")
+        assert config.partial_threshold == 5.0
+
+    def test_threshold_clamps_above_100(self, config):
+        config.set("partial_chapters.threshold_percent", 150)
+        assert config.partial_threshold == 100.0
+
+    def test_threshold_clamps_below_0(self, config):
+        config.set("partial_chapters.threshold_percent", -20)
+        assert config.partial_threshold == 0.0
+
+
 class TestConfigPersistence:
     def test_save_then_reload(self, isolated_home):
         from memanga.config import Config

--- a/tests/unit/test_downloader_pipeline.py
+++ b/tests/unit/test_downloader_pipeline.py
@@ -385,6 +385,111 @@ class TestDownloadChapterErrors:
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# Partial-chapter tolerance (issue #86) — opt-in; a few missing pages are
+# kept instead of discarding the whole chapter when within threshold.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _PartialScraper:
+    """Fake scraper whose download_image fails a chosen set of page
+    indexes (0-based) and writes a valid JPEG for the rest."""
+
+    def __init__(self, num_pages, fail_indexes):
+        self._num_pages = num_pages
+        self._fail = set(fail_indexes)
+
+    def get_pages(self, url):
+        return [f"https://cdn.test/p{i}.jpg" for i in range(self._num_pages)]
+
+    def download_image(self, url, path):
+        # Index encoded in the filename we asked for: page_%03d.ext
+        idx = int(Path(url).stem[1:])
+        if idx in self._fail:
+            return False
+        Image.new("RGB", (200, 300), (10, 20, 30)).save(path, "JPEG")
+        return True
+
+    def get_cover_url(self, url):
+        return None
+
+
+def _partial_chapter():
+    return types.SimpleNamespace(
+        number="71", title="", url="https://cdn.test/c/71",
+        source="cdn.test", source_url="https://cdn.test/c/71",
+        is_backup=False)
+
+
+class TestPartialChapterTolerance:
+    def _patch(self, monkeypatch, num_pages, fail_indexes):
+        import memanga.downloader as dl
+        monkeypatch.setattr(
+            dl, "get_scraper",
+            lambda d: _PartialScraper(num_pages, fail_indexes))
+
+    def test_disabled_by_default_raises_with_structured_detail(
+            self, tmp_path, fake_state, monkeypatch):
+        """Default behavior unchanged: one missing page discards the
+        chapter, and the error carries structured failure detail."""
+        from memanga.downloader import download_chapter, DownloaderError
+        self._patch(monkeypatch, num_pages=40, fail_indexes={5})
+        manga = {"title": "Vinland Saga", "url": "https://cdn.test/x",
+                 "source": "cdn.test"}
+        with pytest.raises(DownloaderError) as exc:
+            download_chapter(manga, _partial_chapter(), tmp_path, "pdf",
+                             fake_state, max_retries=0)
+        assert exc.value.failed_pages == [6]  # 1-indexed
+        assert exc.value.total_pages == 40
+
+    def test_enabled_under_threshold_keeps_partial(
+            self, tmp_path, fake_state, monkeypatch):
+        """1/40 pages missing (2.5%) is within a 5% threshold — the
+        chapter is kept and on_partial is notified."""
+        from memanga.downloader import download_chapter
+        self._patch(monkeypatch, num_pages=40, fail_indexes={5})
+        manga = {"title": "Vinland Saga", "url": "https://cdn.test/x",
+                 "source": "cdn.test"}
+        seen = {}
+
+        def on_partial(failed, total):
+            seen["failed"] = failed
+            seen["total"] = total
+
+        out = download_chapter(
+            manga, _partial_chapter(), tmp_path, "pdf", fake_state,
+            max_retries=0, allow_partial=True, partial_threshold=5,
+            on_partial=on_partial)
+        assert out is not None and out.exists()
+        assert seen == {"failed": [6], "total": 40}
+
+    def test_enabled_over_threshold_still_raises(
+            self, tmp_path, fake_state, monkeypatch):
+        """5/40 pages missing (12.5%) exceeds a 5% threshold — still a
+        hard failure even with tolerance on."""
+        from memanga.downloader import download_chapter, DownloaderError
+        self._patch(monkeypatch, num_pages=40, fail_indexes={1, 2, 3, 4, 5})
+        manga = {"title": "Vinland Saga", "url": "https://cdn.test/x",
+                 "source": "cdn.test"}
+        with pytest.raises(DownloaderError) as exc:
+            download_chapter(
+                manga, _partial_chapter(), tmp_path, "pdf", fake_state,
+                max_retries=0, allow_partial=True, partial_threshold=5)
+        assert len(exc.value.failed_pages) == 5
+
+    def test_zero_usable_pages_is_hard_failure(
+            self, tmp_path, fake_state, monkeypatch):
+        """Even at 100% threshold, a chapter with no usable pages must
+        not be kept as an empty partial."""
+        from memanga.downloader import download_chapter, DownloaderError
+        self._patch(monkeypatch, num_pages=3, fail_indexes={0, 1, 2})
+        manga = {"title": "X", "url": "https://cdn.test/x", "source": "cdn.test"}
+        with pytest.raises(DownloaderError):
+            download_chapter(
+                manga, _partial_chapter(), tmp_path, "pdf", fake_state,
+                max_retries=0, allow_partial=True, partial_threshold=100)
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # Restart browsers — Playwright pool reset, used by GUI memory-pressure
 # ─────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Add opt-in partial chapter tolerance with a configurable failure threshold.
- Prefer complete backup downloads before keeping an acceptable partial chapter.
- Add CLI and GUI settings plus downloader, CLI, and worker coverage for partial and backup recovery paths.

## Tests
- `venv/bin/python -m pytest tests/unit/test_config.py tests/unit/cli/test_cli_commands.py tests/unit/test_downloader_pipeline.py::TestPartialChapterTolerance tests/unit/gui/test_workers.py -q`
- `venv/bin/python -m pytest tests/unit/gui/pages/test_pages.py::TestSettingsPage::test_partial_toggle_saves_to_config tests/unit/gui/pages/test_pages.py::TestSettingsPage::test_partial_threshold_disabled_when_toggle_off tests/integration/test_issue_regressions.py::test_issue_40_pause_resume_keeps_queue -q`
- `git diff --check`
- `venv/bin/python -m py_compile memanga/downloader.py memanga/cli.py memanga/config.py memanga/gui/workers.py memanga/gui/pages/settings.py memanga/gui/pages/detail.py memanga/gui/pages/downloads.py memanga/gui/app.py tests/unit/test_downloader_pipeline.py tests/unit/test_config.py tests/unit/cli/test_cli_commands.py tests/unit/gui/test_workers.py tests/unit/gui/pages/test_pages.py tests/integration/test_issue_regressions.py`

Closes #86
