### PR TITLE
fix(downloader): track trusted chapter catalogue baseline

### DIFF
--- a/memanga/downloader.py
+++ b/memanga/downloader.py
@@ -138,6 +138,31 @@ def _get_sources_from_manga(manga: Dict[str, Any]) -> List[Dict[str, str]]:
     }]
 
 
+def _max_cached_chapter(cached: List[Dict[str, Any]]) -> float:
+    """Highest numeric chapter number in a cached available-chapters list.
+
+    Used to bootstrap the catalogue baseline for manga that predate the
+    stored ``catalogue_baseline`` field (#102). Entries are the dicts the
+    GUI persists via ``set_available_chapters`` (``{"number": ...}``).
+    Returns 0.0 when nothing usable is present.
+    """
+    best = 0.0
+    for entry in cached or []:
+        if not isinstance(entry, dict):
+            continue
+        num = entry.get("number")
+        if num is None:
+            continue
+        try:
+            best = max(best, float(num))
+        except (TypeError, ValueError):
+            # Fall back to the leading number in strings like "12 Part 1".
+            match = re.search(r"\d+\.?\d*", str(num))
+            if match:
+                best = max(best, float(match.group()))
+    return best
+
+
 def check_for_updates(
     manga: Dict[str, Any],
     state: State,
@@ -276,55 +301,124 @@ def check_for_updates(
             f"All sources failed for '{title}': " + "; ".join(source_errors)
         )
 
-    # Suspicious-batch guard. Only meaningful when we have a baseline (a
-    # previously tracked chapter) and the user isn't explicitly
-    # bulk-downloading with from_chapter.
-    if from_chapter is None and last_num > 0 and primary_checked:
-        from .suspicion import evaluate_new_chapters
+    # Suspicious-batch guard.
+    #
+    # The batch is scored against the source's *catalogue baseline* — the
+    # highest chapter the source has legitimately exposed before — not the
+    # last downloaded chapter. Scoring against the last download makes a
+    # manual-mode backlog (only an early chapter grabbed from an
+    # already-large catalogue) look like a giant source jump on every check
+    # (#102). Only chapters that appear beyond the known catalogue are
+    # candidates for suspicion; anything at or below it is an existing,
+    # still-undownloaded backlog and stays freely downloadable.
+    if primary_checked:
+        primary_high = max((ch.numeric for ch in primary_all), default=0.0)
 
-        suspicion = evaluate_new_chapters(
-            state, title,
-            [ch.numeric for ch in primary_chapters.values()],
-            last_num,
+        get_suspicious_batch = getattr(state, "get_suspicious_batch", None)
+        active_suspicious = (
+            get_suspicious_batch(title)
+            if callable(get_suspicious_batch)
+            else None
         )
-        if suspicion.suspicious and not force_suspicious:
-            suspect = sorted(primary_chapters.values())
-            suspect_numbers = [round(ch.numeric, 3) for ch in suspect]
+        get_catalogue_baseline = getattr(state, "get_catalogue_baseline", None)
+        baseline = (
+            get_catalogue_baseline(title)
+            if callable(get_catalogue_baseline)
+            else None
+        )
+        if baseline is None and not active_suspicious:
+            # No trusted snapshot yet (manga predates this field, or was
+            # never checked). Bootstrap from the last cached catalogue so an
+            # existing large backlog isn't mistaken for a jump.
+            get_available_chapters = getattr(state, "get_available_chapters", None)
+            cached = (
+                get_available_chapters(title)
+                if callable(get_available_chapters)
+                else []
+            )
+            baseline = _max_cached_chapter(cached)
+        if baseline is None:
+            baseline = 0.0
+        bootstrapped_manual_baseline = False
+        if baseline <= 0 and manga.get("mode") == "manual" and from_chapter is None:
+            # First manual-mode check after adding/importing a manga. Manual
+            # mode only surfaces Download buttons, so this snapshot is not an
+            # auto-delivery risk; use it as the initial catalogue baseline
+            # instead of scoring the whole undownloaded backlog against the
+            # user's last downloaded/read chapter (#102).
+            baseline = primary_high
+            bootstrapped_manual_baseline = True
 
-            # Verify against backup sources before withholding anything.
-            confirmed = sum(1 for n in suspect_numbers if n in backup_all_numbers)
-            if backup_sources_checked and confirmed / len(suspect_numbers) >= 0.5:
-                # Backup largely agrees with the primary, so accept the batch.
-                state.clear_suspicious_batch(title)
-            else:
-                if backup_sources_checked:
-                    backup_status = (
-                        f"backup confirmed only {confirmed}/{len(suspect_numbers)} chapters"
-                    )
-                else:
-                    backup_status = "no backup source available to verify"
-                state.set_suspicious_batch(title, {
-                    "detected_at": datetime.now().isoformat(),
-                    "chapters": [ch.number for ch in suspect],
-                    "count": len(suspect),
-                    "last_chapter": last_num,
-                    "highest": max(suspect_numbers),
-                    "score": suspicion.score,
-                    "reasons": suspicion.reasons,
-                    "backup_status": backup_status,
-                })
-                state.add_notification(
-                    "warn",
-                    f"Suspicious chapter batch for '{title}': "
-                    f"{len(suspect)} chapter(s) up to {max(suspect_numbers):g} "
-                    f"({backup_status}). Skipped auto-delivery.",
+        catalogue_trusted = True
+        # Only score when we have a download baseline and the user isn't
+        # explicitly bulk-downloading with from_chapter.
+        if from_chapter is None and last_num > 0:
+            from .suspicion import evaluate_new_chapters
+
+            guard_from = max(last_num, baseline)
+            scored = {
+                num: ch for num, ch in primary_chapters.items()
+                if ch.numeric > guard_from
+            }
+            suspicion = (
+                evaluate_new_chapters(
+                    state, title,
+                    [ch.numeric for ch in scored.values()],
+                    guard_from,
                 )
-                # Withhold the whole primary batch from download/delivery.
-                primary_chapters = {}
-        else:
-            # Batch is normal, forced, or backup-confirmed. Drop any
-            # stale suspicious record so warnings don't linger.
-            state.clear_suspicious_batch(title)
+                if scored else None
+            )
+            if suspicion is not None and suspicion.suspicious and not force_suspicious:
+                suspect = sorted(scored.values())
+                suspect_numbers = [round(ch.numeric, 3) for ch in suspect]
+
+                # Verify against backup sources before withholding anything.
+                confirmed = sum(1 for n in suspect_numbers if n in backup_all_numbers)
+                if backup_sources_checked and confirmed / len(suspect_numbers) >= 0.5:
+                    # Backup largely agrees with the primary, so accept the batch.
+                    state.clear_suspicious_batch(title)
+                else:
+                    if backup_sources_checked:
+                        backup_status = (
+                            f"backup confirmed only {confirmed}/{len(suspect_numbers)} chapters"
+                        )
+                    else:
+                        backup_status = "no backup source available to verify"
+                    state.set_suspicious_batch(title, {
+                        "detected_at": datetime.now().isoformat(),
+                        "chapters": [ch.number for ch in suspect],
+                        "count": len(suspect),
+                        "last_chapter": guard_from,
+                        "highest": max(suspect_numbers),
+                        "score": suspicion.score,
+                        "reasons": suspicion.reasons,
+                        "backup_status": backup_status,
+                    })
+                    state.add_notification(
+                        "warn",
+                        f"Suspicious chapter batch for '{title}': "
+                        f"{len(suspect)} chapter(s) up to {max(suspect_numbers):g} "
+                        f"({backup_status}). Skipped auto-delivery.",
+                    )
+                    # Withhold only the suspicious newly-appeared chapters;
+                    # the known backlog stays downloadable. Don't advance the
+                    # trusted baseline past an unverified jump.
+                    for num in scored:
+                        primary_chapters.pop(num, None)
+                    catalogue_trusted = False
+            else:
+                # Batch is normal, forced, or backup-confirmed. Drop any
+                # stale suspicious record so warnings don't linger.
+                state.clear_suspicious_batch(title)
+
+        # Advance the trusted catalogue high-water mark unless we just held
+        # back an unverified jump. Recording it even when the guard didn't
+        # run (fresh manga, explicit from_chapter) gives later checks a
+        # baseline so a big existing backlog is never re-scored as a jump.
+        if catalogue_trusted and (primary_high > baseline or bootstrapped_manual_baseline):
+            set_catalogue_baseline = getattr(state, "set_catalogue_baseline", None)
+            if callable(set_catalogue_baseline):
+                set_catalogue_baseline(title, primary_high)
 
     # Process primary chapters first (always download these)
     for ch_num, ch in primary_chapters.items():

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -452,6 +452,36 @@ class State:
         """Get the cached chapter list for a manga (empty list if never checked)."""
         return self.get_manga_state(manga_title).get("available_chapters", [])
 
+    def get_catalogue_baseline(self, manga_title: str) -> Optional[float]:
+        """Highest chapter number the source has legitimately exposed so far.
+
+        This "last seen available chapter" high-water mark lets the
+        suspicious-batch guard tell an existing-but-undownloaded backlog
+        apart from a genuine source jump (#102). Returns ``None`` when no
+        trusted snapshot has been recorded yet.
+        """
+        value = self.get_manga_state(manga_title).get("catalogue_baseline")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def set_catalogue_baseline(self, manga_title: str, highest: float):
+        """Record the trusted catalogue high-water mark for a manga (#102).
+
+        Only ever called with a value the source has actually shown and that
+        the guard did not hold back, so it never advances past an unverified
+        suspicious jump.
+        """
+        self._ensure_manga_entry(manga_title)
+        try:
+            self._data["manga"][manga_title]["catalogue_baseline"] = float(highest)
+        except (TypeError, ValueError):
+            return
+        self._mark_dirty()
+
     # ========================================================================
     # External Chapters (already read outside the app)
     # ========================================================================

--- a/tests/unit/test_suspicion.py
+++ b/tests/unit/test_suspicion.py
@@ -308,6 +308,184 @@ class TestCheckForUpdatesGuard:
 
 
 # -------------------------------------------------------------------------
+# #102: existing catalogue backlog must not read as a suspicious jump
+# -------------------------------------------------------------------------
+
+
+# Blue Lock scenario: a large existing catalogue with only chapter 1 grabbed.
+BLUE_LOCK_MANGA = {
+    "title": "Blue Lock",
+    "mode": "manual",
+    "source": "primary.test",
+    "url": "https://primary.test/m",
+}
+
+
+def _cache_catalogue(state, title, numbers):
+    """Mimic the GUI persisting the primary chapter list after a check."""
+    state.set_available_chapters(title, [
+        {"number": f"{n:g}", "title": "", "source": "primary.test",
+         "source_url": "https://primary.test/m", "is_backup": False,
+         "url": f"u/{n:g}"}
+        for n in numbers
+    ])
+
+
+class TestManualBacklogNotSuspicious:
+    def test_first_manual_check_bootstraps_catalogue_baseline(self, state, monkeypatch):
+        # Exact #102 shape: no cached catalogue yet, only chapter 1 is
+        # downloaded, and the source reports a large existing catalogue.
+        # Manual mode should snapshot that catalogue instead of treating the
+        # old backlog as an auto-delivery anomaly.
+        from memanga.downloader import check_for_updates
+
+        state.add_downloaded_chapter("Blue Lock", "1")
+        assert state.get_available_chapters("Blue Lock") == []
+        assert state.get_catalogue_baseline("Blue Lock") is None
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 354)]),
+        })
+
+        new = check_for_updates(BLUE_LOCK_MANGA, state)
+
+        assert [c.number for c in new] == [str(n) for n in range(2, 354)]
+        assert state.get_suspicious_batch("Blue Lock") is None
+        assert state.get_catalogue_baseline("Blue Lock") == 353.0
+        assert not any(n["type"] == "warn" for n in state.get_notifications())
+
+    def test_undownloaded_backlog_is_not_flagged(self, state, monkeypatch):
+        # Manual manga: chapter 1 downloaded out of an existing 1..344
+        # catalogue that has since grown to 353. The backlog must stay
+        # visible/downloadable without a suspicious record (#102).
+        from memanga.downloader import check_for_updates
+
+        state.add_downloaded_chapter("Blue Lock", "1")
+        state.set_catalogue_baseline("Blue Lock", 344.0)
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 354)]),
+        })
+
+        new = check_for_updates(BLUE_LOCK_MANGA, state)
+
+        # The whole undownloaded backlog (2..353) is offered, none withheld.
+        assert [c.number for c in new] == [str(n) for n in range(2, 354)]
+        assert state.get_suspicious_batch("Blue Lock") is None
+        assert not any(n["type"] == "warn" for n in state.get_notifications())
+
+    def test_baseline_bootstrapped_from_cached_catalogue(self, state, monkeypatch):
+        # No explicit baseline yet (pre-existing manga), but the GUI has
+        # cached the catalogue up to 344 from an earlier check. That cache
+        # bootstraps the baseline so the backlog isn't flagged.
+        from memanga.downloader import check_for_updates
+
+        state.add_downloaded_chapter("Blue Lock", "1")
+        _cache_catalogue(state, "Blue Lock", range(1, 345))
+        assert state.get_catalogue_baseline("Blue Lock") is None
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 354)]),
+        })
+
+        new = check_for_updates(BLUE_LOCK_MANGA, state)
+
+        assert state.get_suspicious_batch("Blue Lock") is None
+        assert [c.number for c in new] == [str(n) for n in range(2, 354)]
+        # The baseline is now persisted at the current catalogue high.
+        assert state.get_catalogue_baseline("Blue Lock") == 353.0
+
+    def test_growth_beyond_baseline_is_still_scored(self, state, monkeypatch):
+        # A genuine bogus jump beyond the known catalogue is still caught,
+        # even when an old backlog sits below the baseline.
+        from memanga.downloader import check_for_updates
+
+        state.add_downloaded_chapter("Blue Lock", "1")
+        state.set_catalogue_baseline("Blue Lock", 344.0)
+        # Source suddenly re-numbers far past the catalogue high.
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning(
+                [float(n) for n in range(1, 345)] + [900.0, 950.0, 999.0]
+            ),
+        })
+
+        new = check_for_updates(BLUE_LOCK_MANGA, state)
+
+        record = state.get_suspicious_batch("Blue Lock")
+        assert record is not None
+        # Only the newly-appeared chapters beyond 344 are held back; the
+        # existing backlog (2..344) is still offered.
+        assert record["chapters"] == ["900", "950", "999"]
+        assert [c.number for c in new] == [str(n) for n in range(2, 345)]
+        # Baseline stays at the trusted 344 — not advanced past the jump.
+        assert state.get_catalogue_baseline("Blue Lock") == 344.0
+
+    def test_baseline_advances_on_normal_growth(self, state, monkeypatch):
+        # A first check with no download baseline snapshots the catalogue;
+        # later growth is measured from that snapshot.
+        from memanga.downloader import check_for_updates
+
+        # Fresh manual manga, nothing downloaded yet: guard doesn't run but
+        # the catalogue is snapshotted as trusted.
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 345)]),
+        })
+        check_for_updates(BLUE_LOCK_MANGA, state)
+        assert state.get_catalogue_baseline("Blue Lock") == 344.0
+
+        # Now one chapter is downloaded and the source grows modestly.
+        state.add_downloaded_chapter("Blue Lock", "1")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 354)]),
+        })
+        check_for_updates(BLUE_LOCK_MANGA, state)
+        assert state.get_suspicious_batch("Blue Lock") is None
+        assert state.get_catalogue_baseline("Blue Lock") == 353.0
+
+    def test_mangafire_jump_still_flagged_with_cached_catalogue(self, state, monkeypatch):
+        # #35 must be preserved: a manga tracked at 52.3 whose cached
+        # catalogue is also ~52 still flags the bogus jump to 148.
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _cache_catalogue(state, "Tomodachi", [50, 51, 52, 52.3])
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3] + MANGAFIRE_BOGUS_BATCH),
+        })
+
+        new = check_for_updates(SINGLE_SOURCE_MANGA, state)
+
+        assert new == []
+        assert state.get_suspicious_batch("Tomodachi") is not None
+
+    def test_withheld_batch_not_trusted_from_gui_cache_on_next_check(self, state, monkeypatch):
+        # GUI checks cache `all_chapters`, including chapters that were
+        # withheld as suspicious. That cache must not become a trusted
+        # catalogue baseline while the suspicious record is active.
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3] + MANGAFIRE_BOGUS_BATCH),
+        })
+
+        first_new, first_all = check_for_updates(SINGLE_SOURCE_MANGA, state, return_all=True)
+        assert first_new == []
+        first_record = state.get_suspicious_batch("Tomodachi")
+        assert first_record is not None
+
+        state.set_available_chapters("Tomodachi", [
+            {"number": c.number, "title": c.title, "source": c.source,
+             "source_url": c.source_url, "is_backup": c.is_backup, "url": c.url}
+            for c in first_all
+        ])
+
+        second_new, _ = check_for_updates(SINGLE_SOURCE_MANGA, state, return_all=True)
+
+        assert second_new == []
+        second_record = state.get_suspicious_batch("Tomodachi")
+        assert second_record is not None
+        assert second_record["chapters"] == first_record["chapters"]
+
+
+# -------------------------------------------------------------------------
 # State persistence of the suspicious record
 # -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add a trusted catalogue high-water mark so update checks distinguish existing undownloaded backlog from newly exposed source jumps
- Bootstrap first manual-mode checks from the current source catalogue instead of scoring the whole backlog against the last downloaded chapter
- Keep active suspicious batches from trusting GUI-cached `all_chapters`, preserving the #35 protection on repeated checks

Closes #102.

## Changes
- Store an optional per-manga `catalogue_baseline` in state
- Score suspicious batches only for chapters beyond the trusted catalogue baseline
- Leave known backlog downloadable while withholding only suspicious newly appeared chapters
- Add regression coverage for no-cache manual backlog, cached catalogue bootstrap, baseline growth, suspicious overflow, and repeated GUI-cache checks after a withheld batch

## Testing
- `venv/bin/python -m pytest tests/unit/test_suspicion.py tests/unit/test_downloader.py tests/unit/test_downloader_pipeline.py tests/unit/gui/test_workers.py -q`
- Local #102 probe: manual manga with only chapter 1 downloaded and source chapters 1..353 returns chapters 2..353 with no suspicious record
- Local #35 probe: repeated GUI-style checks keep a bogus MangaFire-style batch withheld after `all_chapters` is cached
- `git diff --check`
- Public hygiene scan clean
