### PR TITLE
feat(reader): remove chapters after reading

### DIFF
--- a/memanga/config.py
+++ b/memanga/config.py
@@ -88,6 +88,13 @@ class Config:
                 # the immediate next available chapter in the background.
                 "reader_prefetch_next": False,
             },
+            # Built-in reader behaviour (issue #104). Kept separate from
+            # delivery.delete_after_send, which is tied to email delivery —
+            # this is reader-driven local cleanup. Off by default: a chapter
+            # stays on disk after it is read unless the user opts in.
+            "reader": {
+                "remove_after_read": False,
+            },
             # Partial-chapter tolerance (issue #86). Off by default: any
             # missing page still aborts the chapter and discards output.
             # When enabled, a chapter whose failure rate is within

--- a/memanga/gui/pages/reader.py
+++ b/memanga/gui/pages/reader.py
@@ -5,6 +5,7 @@ Three layouts: continuous vertical scroll, single page, two-up spreads.
 
 import io
 import re
+import shutil
 import zipfile
 from pathlib import Path
 from typing import List, Optional
@@ -143,6 +144,10 @@ class ReaderPage(BasePage):
         super().__init__(parent, app)
         self._manga = None
         self._chapter = None
+        # Issue #104: concrete file/folder the current chapter was loaded
+        # from, recorded in _find_and_load_chapter so the "remove after
+        # reading" cleanup deletes exactly what the reader opened.
+        self._artifact_path: Optional[Path] = None
         self._images: List[QImage] = []
         self._page_labels: list = []
         self._zoom_level = 1.0
@@ -171,6 +176,11 @@ class ReaderPage(BasePage):
         self._next_btn = None
         self._next_footer = None
         self._next_footer_btn = None
+        # Issue #104/#107: navigation needs a stable anchor while the
+        # current chapter remains visible after remove-after-read drops it
+        # from downloaded-state. New downloads are merged into this list so
+        # dynamic Next controls still reveal prefetched successors.
+        self._navigation_chapters: List[str] = []
         self._prefetch_fallback_key = None
         self._prefetch_fallback_attempted_key = None
         self.app.events.subscribe("download_complete",
@@ -640,11 +650,47 @@ class ReaderPage(BasePage):
         # Issue #106: a finished chapter should reopen from its first
         # page, not keep resuming at the saved end-of-chapter position.
         self.app.app_state.clear_reader_position(title, str(self._chapter))
+        # Issue #104: optionally discard the local file now that the
+        # chapter is finished. Runs after the read set is updated so read
+        # progress survives even if the deletion fails.
+        self._remove_after_read(title, str(self._chapter))
         # Tell other pages (Library, Detail) to repaint without
         # waiting for the next navigation.
         self.app.events.publish("chapter_read", {
             "title": title, "chapter": str(self._chapter),
         })
+
+    def _remove_after_read(self, title: str, chapter: str):
+        """Delete the just-read chapter's local artifact and drop it from
+        downloaded-state when the "remove chapters after reading" setting
+        is on (issue #104).
+
+        Read-state is intentionally left intact — only the downloaded
+        record and the on-disk file/folder go away, so the Detail row
+        returns to the Download state. Deletion failures are non-fatal:
+        the chapter stays marked downloaded and a notification is logged
+        instead of desyncing state from disk or crashing the reader.
+        """
+        if not self.app.config.get("reader.remove_after_read", False):
+            return
+        path = self._artifact_path
+        if path is None:
+            return
+        try:
+            if path.is_dir():
+                shutil.rmtree(path)
+            elif path.exists():
+                path.unlink()
+            # If the file is already gone, treat that as success and let
+            # the downloaded-state removal below reconcile with disk.
+        except OSError as exc:
+            self.app.app_state.add_notification(
+                "error",
+                f"Couldn't remove {title} Chapter {chapter} after reading: {exc}",
+            )
+            return
+        self._artifact_path = None
+        self.app.app_state.remove_downloaded_chapter(title, chapter)
 
     def _mark_read_if_unscrollable(self):
         """A chapter that fits entirely in the viewport never scrolls, so
@@ -929,14 +975,10 @@ class ReaderPage(BasePage):
         top_layout.addStretch()
 
         # Chapter navigation
-        downloaded = self.app.app_state.get_downloaded_chapters(title)
-        try:
-            idx = downloaded.index(str(self._chapter))
-        except ValueError:
-            idx = -1
+        prev_ch = self._navigation_neighbor(-1, title)
+        next_ch = self._navigation_neighbor(+1, title)
 
-        if idx > 0:
-            prev_ch = downloaded[idx - 1]
+        if prev_ch is not None:
             prev_btn = QPushButton("‹ Prev")
             prev_btn.setCursor(Qt.CursorShape.PointingHandCursor)
             prev_btn.clicked.connect(lambda checked=False, c=prev_ch: self._navigate_chapter(c))
@@ -950,7 +992,7 @@ class ReaderPage(BasePage):
         self._next_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         self._next_btn.clicked.connect(
             lambda checked=False: self._go_next_chapter())
-        self._next_btn.setVisible(0 <= idx < len(downloaded) - 1)
+        self._next_btn.setVisible(next_ch is not None)
         top_layout.addWidget(self._next_btn)
 
         # ── Layout toggle (issues #24, #32) ─────────────────────────────
@@ -1075,13 +1117,12 @@ class ReaderPage(BasePage):
         # Issue #107: built even without a successor (hidden) so a
         # prefetch completion can flip it visible without a reload.
         if self._view_mode == "continuous":
-            has_next = 0 <= idx < len(downloaded) - 1
             next_frame = QWidget()
             next_frame_layout = QHBoxLayout(next_frame)
             next_frame_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
             next_chapter_btn = QPushButton(
-                self._next_footer_label(downloaded, idx))
+                self._next_footer_label(next_ch))
             next_chapter_btn.setProperty("class", "accent")
             next_chapter_btn.setFixedHeight(40)
             next_chapter_btn.setFixedWidth(250)
@@ -1092,7 +1133,7 @@ class ReaderPage(BasePage):
             next_frame_layout.addWidget(next_chapter_btn)
             self._image_layout.addSpacing(T.PAD_XL)
             self._image_layout.addWidget(next_frame)
-            next_frame.setVisible(has_next)
+            next_frame.setVisible(next_ch is not None)
             self._next_footer = next_frame
             self._next_footer_btn = next_chapter_btn
 
@@ -1151,6 +1192,9 @@ class ReaderPage(BasePage):
         # that predate this fix.
         from ...downloader import _format_chapter_number, _sanitize_filename
 
+        # Reset before resolving so a failed load can't leave a stale path
+        # pointing at the previous chapter (issue #104).
+        self._artifact_path = None
         title = self._manga.get("title", "")
         ch = str(self._chapter)
         download_dir = Path(self.app.config.download_dir)
@@ -1174,10 +1218,12 @@ class ReaderPage(BasePage):
                 for ext in [".pdf", ".epub", ".cbz", ".zip"]:
                     filepath = manga_dir / f"{base}{ext}"
                     if filepath.exists():
+                        self._artifact_path = filepath
                         return _extract_images_from_file(filepath)
 
                 folder = manga_dir / f"Chapter {label}"
                 if folder.is_dir():
+                    self._artifact_path = folder
                     return _extract_images_from_folder(folder)
 
         # Fallback: scan directories for anything chapter-shaped
@@ -1186,8 +1232,10 @@ class ReaderPage(BasePage):
                 if f.is_file() and any(
                     f"chapter {label.lower()}" in f.stem.lower() for label in labels
                 ):
+                    self._artifact_path = f
                     return _extract_images_from_file(f)
                 if f.is_dir() and any(label in f.name for label in labels):
+                    self._artifact_path = f
                     return _extract_images_from_folder(f)
 
         return []
@@ -1208,25 +1256,88 @@ class ReaderPage(BasePage):
         if not self._manga:
             return
         title = self._manga.get("title", "")
-        downloaded = self.app.app_state.get_downloaded_chapters(title)
-        try:
-            idx = downloaded.index(str(self._chapter))
-            if idx < len(downloaded) - 1:
-                self._navigate_chapter(downloaded[idx + 1])
-        except ValueError:
-            pass
+        next_ch = self._navigation_neighbor(+1, title)
+        if next_ch is not None:
+            self._navigate_chapter(next_ch)
 
     def _go_prev_chapter(self):
         if not self._manga:
             return
         title = self._manga.get("title", "")
-        downloaded = self.app.app_state.get_downloaded_chapters(title)
+        prev_ch = self._navigation_neighbor(-1, title)
+        if prev_ch is not None:
+            self._navigate_chapter(prev_ch)
+
+    def _sync_navigation_chapters(self, title: str) -> List[str]:
+        """Return the reader-local chapter order for Prev/Next.
+
+        When the current chapter is still in downloaded-state, the live
+        downloaded list is authoritative. If remove-after-read has already
+        dropped the visible chapter, keep the previous reader-local order as
+        the anchor and merge in any newly downloaded/prefetched chapters.
+        """
+        downloaded = [
+            str(ch) for ch in self.app.app_state.get_downloaded_chapters(title)
+        ]
+        current = str(self._chapter)
+        if current in downloaded:
+            self._navigation_chapters = downloaded
+            return self._navigation_chapters
+
+        merged = []
+        for chapter in self._navigation_chapters:
+            chapter = str(chapter)
+            if chapter not in merged:
+                merged.append(chapter)
+        if current not in merged:
+            self._insert_navigation_chapter(merged, current)
+        for chapter in downloaded:
+            chapter = str(chapter)
+            if chapter not in merged:
+                self._insert_navigation_chapter(merged, chapter)
+        self._navigation_chapters = merged
+        return self._navigation_chapters
+
+    def _insert_navigation_chapter(self, sequence: List[str], chapter: str):
+        """Insert a newly discovered chapter into reader-local order."""
+        key = _chapter_sort_key(chapter)
+        if key is None:
+            sequence.append(chapter)
+            return
+
+        for idx, existing in enumerate(sequence):
+            existing_key = _chapter_sort_key(existing)
+            if existing_key is not None and existing_key > key:
+                sequence.insert(idx, chapter)
+                return
+        sequence.append(chapter)
+
+    def _navigation_neighbor(self, direction: int,
+                             title: Optional[str] = None) -> Optional[str]:
+        """Find the nearest downloaded neighbor in the local navigation
+        sequence. Removed stale entries are skipped, but the current chapter
+        itself may remain as the anchor after remove-after-read."""
+        if not self._manga or self._chapter is None:
+            return None
+        title = title if title is not None else self._manga.get("title", "")
+        sequence = self._sync_navigation_chapters(title)
+        current = str(self._chapter)
         try:
-            idx = downloaded.index(str(self._chapter))
-            if idx > 0:
-                self._navigate_chapter(downloaded[idx - 1])
+            idx = sequence.index(current)
         except ValueError:
-            pass
+            return None
+
+        downloaded = set(
+            str(ch) for ch in self.app.app_state.get_downloaded_chapters(title)
+        )
+        step = 1 if direction > 0 else -1
+        i = idx + step
+        while 0 <= i < len(sequence):
+            chapter = sequence[i]
+            if chapter in downloaded:
+                return chapter
+            i += step
+        return None
 
     # -- Reader prefetch (issue #107) ------------------------------------
     def _maybe_prefetch_next(self):
@@ -1396,13 +1507,13 @@ class ReaderPage(BasePage):
             return
         self._refresh_next_controls()
 
-    def _next_footer_label(self, downloaded, idx):
+    def _next_footer_label(self, next_chapter):
         """Caption for the continuous-mode footer button, resolved from
-        the downloaded list at build/refresh time -- never captured -- so
+        reader navigation at build/refresh time -- never captured -- so
         a chapter prefetched mid-read shows its real number once
         _refresh_next_controls reveals the button (issue #107)."""
-        if 0 <= idx < len(downloaded) - 1:
-            return f"Next: Chapter {downloaded[idx + 1]} >>"
+        if next_chapter is not None:
+            return f"Next: Chapter {next_chapter} >>"
         return "Next Chapter >>"
 
     def _refresh_next_controls(self):
@@ -1413,16 +1524,12 @@ class ReaderPage(BasePage):
         if not self._manga or self._chapter is None:
             return
         title = self._manga.get("title", "")
-        downloaded = self.app.app_state.get_downloaded_chapters(title)
-        try:
-            idx = downloaded.index(str(self._chapter))
-        except ValueError:
-            idx = -1
-        has_next = 0 <= idx < len(downloaded) - 1
+        next_ch = self._navigation_neighbor(+1, title)
+        has_next = next_ch is not None
         if self._next_footer_btn is not None:
             try:
                 self._next_footer_btn.setText(
-                    self._next_footer_label(downloaded, idx))
+                    self._next_footer_label(next_ch))
             except RuntimeError:
                 pass
         for widget in (self._next_btn, self._next_footer):

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -647,6 +647,27 @@ class SettingsPage(BasePage):
 
         f.addSpacing(T.PAD_XL)
 
+        # Remove chapters after reading (issue #104)
+        self._section(f, "Reader Cleanup")
+        remove_read_hint = QLabel(
+            "Delete a chapter's local download once you finish it in the "
+            "built-in reader. Read progress is kept, so the chapter simply "
+            "returns to the Download state on the Detail page."
+        )
+        remove_read_hint.setProperty("role", "hint")
+        remove_read_hint.setWordWrap(True)
+        f.addWidget(remove_read_hint)
+
+        self._remove_after_read_check = QCheckBox(
+            "Remove chapters after reading"
+        )
+        self._remove_after_read_check.setChecked(
+            self.app.config.get("reader.remove_after_read", False)
+        )
+        f.addWidget(self._remove_after_read_check)
+
+        f.addSpacing(T.PAD_XL)
+
         # Import/Export
         self._section(f, "Import / Export")
         ie_row = QHBoxLayout()
@@ -915,13 +936,21 @@ class SettingsPage(BasePage):
         if hasattr(self, "_prefetch_check"):
             cfg.set("gui.reader_prefetch_next", self._prefetch_check.isChecked())
 
+        # Remove chapters after reading (issue #104)
+        if hasattr(self, "_remove_after_read_check"):
+            cfg.set(
+                "reader.remove_after_read",
+                self._remove_after_read_check.isChecked(),
+            )
+
         cfg.save()
         Toast(self, "Settings saved", kind="success")
 
     def _reset_to_defaults(self):
         cfg = self.app.config
         defaults = cfg._default_config()
-        for section in ("delivery", "email", "cron", "gui", "partial_chapters"):
+        for section in ("delivery", "email", "cron", "gui", "partial_chapters",
+                        "reader"):
             cfg.set(section, defaults[section])
         cfg.save()
         self._load_config_into_widgets()
@@ -972,6 +1001,11 @@ class SettingsPage(BasePage):
 
         if hasattr(self, "_prefetch_check"):
             self._prefetch_check.setChecked(cfg.reader_prefetch_enabled)
+
+        if hasattr(self, "_remove_after_read_check"):
+            self._remove_after_read_check.setChecked(
+                cfg.get("reader.remove_after_read", False)
+            )
 
         self._refresh_filename_preview()
 

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -263,6 +263,27 @@ class State:
         """Check if a chapter has been downloaded."""
         return str(chapter) in self.get_downloaded_chapters(manga_title)
 
+    def remove_downloaded_chapter(self, manga_title: str, chapter: str) -> bool:
+        """Drop a single chapter from the downloaded list (issue #104).
+
+        Deliberately narrow: it touches only ``downloaded`` and leaves
+        ``read_chapters`` alone, so removing a chapter's local file after
+        it is read returns the Detail row to the Download state without
+        losing read progress. Returns True if the chapter was present.
+        No-op for unknown manga or chapters not marked downloaded.
+        """
+        with self._locked() as data:
+            manga_state = data.get("manga", {}).get(manga_title)
+            if not manga_state:
+                return False
+            downloaded = manga_state.get("downloaded", [])
+            chapter_str = str(chapter)
+            if chapter_str not in downloaded:
+                return False
+            downloaded.remove(chapter_str)
+            self._mark_dirty()
+            return True
+
     # ========================================================================
     # Backup Source Tracking
     # ========================================================================

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -431,6 +431,152 @@ def test_issue_45_reader_marks_read_at_end(app_window, qapp, sample_manga,
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# #104 — Remove chapters after reading
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_issue_104_removes_chapter_after_read(app_window, qapp, sample_manga,
+                                              make_cbz):
+    from pathlib import Path
+    app_window.config.set("reader.remove_after_read", True)
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=8)
+    title = sample_manga["title"]
+    artifact = Path(app_window.config.download_dir) / title / \
+        f"{title} - Chapter 1.cbz"
+    assert artifact.exists()
+
+    bar = reader._scroll.verticalScrollBar()
+    assert bar.maximum() > 0, "test needs scrollable reader content"
+    bar.setValue(bar.maximum())
+    qapp.processEvents()
+
+    # File gone, dropped from downloaded, but read progress kept.
+    assert not artifact.exists()
+    assert not app_window.app_state.is_chapter_downloaded(title, "1")
+    assert app_window.app_state.is_chapter_read(title, "1")
+
+
+def test_issue_104_next_survives_current_download_cleanup(
+        app_window, qapp, sample_manga, make_cbz):
+    from pathlib import Path
+    app_window.config.set("reader.remove_after_read", True)
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz,
+                          chapters=("1", "2"), pages=8)
+    title = sample_manga["title"]
+    chapter_1 = Path(app_window.config.download_dir) / title / \
+        f"{title} - Chapter 1.cbz"
+    chapter_2 = Path(app_window.config.download_dir) / title / \
+        f"{title} - Chapter 2.cbz"
+    assert chapter_1.exists()
+    assert chapter_2.exists()
+
+    bar = reader._scroll.verticalScrollBar()
+    assert bar.maximum() > 0, "test needs scrollable reader content"
+    bar.setValue(bar.maximum())
+    qapp.processEvents()
+
+    assert not chapter_1.exists()
+    assert not app_window.app_state.is_chapter_downloaded(title, "1")
+    assert app_window.app_state.is_chapter_downloaded(title, "2")
+    assert app_window.app_state.is_chapter_read(title, "1")
+
+    reader._go_next_chapter()
+    qapp.processEvents()
+
+    assert str(reader._chapter) == "2"
+    assert reader._artifact_path == chapter_2
+    assert reader._images
+
+
+def test_issue_104_107_prefetch_keeps_immediate_next_after_cleanup(
+        app_window, qapp, sample_manga, make_cbz):
+    from pathlib import Path
+    app_window.config.set("reader.remove_after_read", True)
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz,
+                          chapters=("1", "3"), pages=8)
+    title = sample_manga["title"]
+    dl = Path(app_window.config.download_dir) / title
+    chapter_1 = dl / f"{title} - Chapter 1.cbz"
+    chapter_2 = dl / f"{title} - Chapter 2.cbz"
+
+    assert reader._navigation_neighbor(+1, title) == "3"
+
+    bar = reader._scroll.verticalScrollBar()
+    assert bar.maximum() > 0, "test needs scrollable reader content"
+    bar.setValue(bar.maximum())
+    qapp.processEvents()
+
+    assert not chapter_1.exists()
+    assert app_window.app_state.get_downloaded_chapters(title) == ["3"]
+
+    # A prefetch/download completion lands chapter 2 after the current
+    # chapter has already been removed from downloaded state.
+    chapter_2.write_bytes(
+        make_cbz(pages=8, name="ch2.cbz").read_bytes())
+    app_window.app_state.add_downloaded_chapter(title, "2")
+    assert app_window.app_state.get_downloaded_chapters(title) == ["2", "3"]
+
+    reader._on_download_complete({"title": title, "chapter": "2"})
+    qapp.processEvents()
+
+    assert reader._navigation_neighbor(+1, title) == "2"
+    assert not reader._next_btn.isHidden()
+    assert reader._next_footer_btn.text() == "Next: Chapter 2 >>"
+
+    reader._go_next_chapter()
+    qapp.processEvents()
+
+    assert str(reader._chapter) == "2"
+    assert reader._artifact_path == chapter_2
+    assert reader._images
+
+
+def test_issue_104_disabled_keeps_chapter(app_window, qapp, sample_manga,
+                                          make_cbz):
+    from pathlib import Path
+    app_window.config.set("reader.remove_after_read", False)
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=8)
+    title = sample_manga["title"]
+    artifact = Path(app_window.config.download_dir) / title / \
+        f"{title} - Chapter 1.cbz"
+
+    bar = reader._scroll.verticalScrollBar()
+    bar.setValue(bar.maximum())
+    qapp.processEvents()
+
+    # Default behaviour: read but nothing deleted.
+    assert artifact.exists()
+    assert app_window.app_state.is_chapter_downloaded(title, "1")
+    assert app_window.app_state.is_chapter_read(title, "1")
+
+
+def test_issue_104_deletion_failure_keeps_downloaded(app_window, qapp,
+                                                     sample_manga, make_cbz):
+    # If the artifact can't be deleted, the chapter must stay downloaded
+    # (state must not desync from disk) and the reader must not crash.
+    from pathlib import Path
+    app_window.config.set("reader.remove_after_read", True)
+    reader = _open_reader(app_window, qapp, sample_manga, make_cbz, pages=8)
+    title = sample_manga["title"]
+    artifact = Path(app_window.config.download_dir) / title / \
+        f"{title} - Chapter 1.cbz"
+
+    # Force the (file) deletion to fail, as a locked/permission-denied
+    # artifact would in the wild.
+    import unittest.mock as mock
+    with mock.patch.object(type(artifact), "unlink",
+                           side_effect=OSError("boom")):
+        bar = reader._scroll.verticalScrollBar()
+        bar.setValue(bar.maximum())
+        qapp.processEvents()
+
+    # Non-fatal: file untouched, chapter stays downloaded and read.
+    assert artifact.exists()
+    assert app_window.app_state.is_chapter_downloaded(title, "1")
+    assert app_window.app_state.is_chapter_read(title, "1")
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # #32 — Page-by-page reading modes (single / two-up) with arrow keys
 # ─────────────────────────────────────────────────────────────────────────
 

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -327,6 +327,26 @@ class TestSettingsPage:
         assert not page._partial_threshold.isEnabled()
         assert app_window.config.get("manga") == [{"title": "KeepMe"}]
 
+    def test_remove_after_read_saves_to_config(self, app_window, qapp):
+        # Issue #104: the Advanced-tab "remove chapters after reading"
+        # toggle should persist to config on save. Off by default.
+        page = app_window._pages["settings"]
+        assert not page._remove_after_read_check.isChecked()
+        page._remove_after_read_check.setChecked(True)
+        page._save()
+        assert app_window.config.get("reader.remove_after_read") is True
+
+    def test_reset_defaults_clears_remove_after_read(self, app_window, qapp):
+        page = app_window._pages["settings"]
+        app_window.config.set("reader.remove_after_read", True)
+        page._remove_after_read_check.setChecked(True)
+
+        page._reset_to_defaults()
+        qapp.processEvents()
+
+        assert app_window.config.get("reader.remove_after_read") is False
+        assert not page._remove_after_read_check.isChecked()
+
     def test_template_preview_substitutes(self, app_window, qapp):
         page = app_window._pages["settings"]
         page._naming_entry.setText("X-{chapter}")

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -86,6 +86,29 @@ class TestChapterTracking:
             "Extra", "2 Part 1", "3", "3.5 Part 1", "10 Part 1"
         ]
 
+    def test_remove_downloaded_chapter(self, state):
+        # Issue #104: narrow removal drops only the downloaded record.
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "2")
+        assert state.remove_downloaded_chapter("X", "1") is True
+        assert state.get_downloaded_chapters("X") == ["2"]
+        assert not state.is_chapter_downloaded("X", "1")
+
+    def test_remove_downloaded_chapter_keeps_read_state(self, state):
+        # Read progress must survive the local file being removed.
+        state.add_downloaded_chapter("X", "1")
+        state.mark_chapter_read("X", "1")
+        state.remove_downloaded_chapter("X", "1")
+        assert not state.is_chapter_downloaded("X", "1")
+        assert state.is_chapter_read("X", "1")
+
+    def test_remove_downloaded_chapter_noop(self, state):
+        # Unknown manga / chapter must not raise and return False.
+        assert state.remove_downloaded_chapter("never", "1") is False
+        state.add_downloaded_chapter("X", "1")
+        assert state.remove_downloaded_chapter("X", "2") is False
+        assert state.get_downloaded_chapters("X") == ["1"]
+
     def test_set_last_chapter(self, state):
         state.set_last_chapter("X", "10")
         assert state.get_last_chapter("X") == "10"


### PR DESCRIPTION
## Summary

Adds an opt-in Advanced setting that removes a chapter's local download after the built-in reader marks it read.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Testing

- `venv/bin/python -m pytest tests/integration/test_issue_regressions.py -k 'issue_104 or issue_107 or issue_43 or issue_32'` - 17 passed, 23 deselected
- `venv/bin/python -m pytest tests/unit/gui/pages/test_reader_prefetch.py -q` - 28 passed
- `venv/bin/python -m pytest tests/unit/test_state.py tests/unit/gui/pages/test_pages.py -k 'remove_after_read or remove_downloaded_chapter or SettingsPage'` - 26 passed, 128 deselected
- `venv/bin/python -m compileall -q memanga tests` - passed
- `git diff --check` - passed
- Isolated offscreen reader probe verified chapter cleanup keeps read progress, removes only chapter 1's download, leaves chapter 2 downloaded, and opens chapter 2 through Next.

## Related issues

Closes #104
