### PR TITLE
fix(cron): quote Unix scheduled-check paths

### DIFF
--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -21,6 +21,7 @@ from rich import box
 
 from .backup import EXPORT_VERSION, BackupVersionError, validate_backup
 from .config import Config, get_app_password, set_app_password
+from .cron import build_cron_line
 from .state import State
 from .downloader import check_for_updates, download_chapter, get_supported_sources, DownloaderError, ChapterWithSource, restart_browsers, _find_chapter_on_backup, _get_sources_from_manga
 from .scrapers import get_scraper
@@ -983,8 +984,7 @@ def _cmd_cron_unix(args):
             console.print("[red]Invalid time format. Use HH:MM[/red]")
             return 1
 
-        cron_cmd = f"cd {project_dir} && {python_path} -m memanga check --auto --quiet"
-        cron_line = f"{minute} {hour} * * * {cron_cmd} >> {project_dir}/memanga.log 2>&1"
+        cron_line = build_cron_line(minute, hour, project_dir, python_path)
 
         result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
         existing = result.stdout if result.returncode == 0 else ""

--- a/memanga/cron.py
+++ b/memanga/cron.py
@@ -1,0 +1,28 @@
+"""
+Crontab helpers for shell-safe construction of the Unix cron entry shared
+by the CLI (`memanga cron install`) and the GUI Settings page.
+"""
+
+import shlex
+from pathlib import Path
+
+
+def quote_cron_path(path) -> str:
+    """Quote a filesystem path for use inside a crontab command.
+
+    ``shlex.quote()`` guards against spaces and shell metacharacters;
+    crontab(5) additionally turns an unescaped ``%`` into a newline, so
+    those are backslash-escaped on top of the shell quoting.
+    """
+    return shlex.quote(str(path)).replace("%", r"\%")
+
+
+def build_cron_line(minute, hour, project_dir, python_path) -> str:
+    """Build the daily auto-check crontab entry with shell-safe paths."""
+    project_dir = Path(project_dir)
+    command = (
+        f"cd {quote_cron_path(project_dir)} && "
+        f"{quote_cron_path(python_path)} -m memanga check --auto --quiet"
+    )
+    log_path = quote_cron_path(project_dir / "memanga.log")
+    return f"{minute} {hour} * * * {command} >> {log_path} 2>&1"

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -20,6 +20,7 @@ from .base import BasePage
 from .. import theme as T
 from ..components.toast import Toast
 from ...backup import EXPORT_VERSION, BackupVersionError, validate_backup
+from ...cron import build_cron_line
 
 
 class SettingsPage(BasePage):
@@ -1006,10 +1007,7 @@ class SettingsPage(BasePage):
         venv_python = project_dir / "venv" / "bin" / "python3"
         if venv_python.exists():
             python_path = str(venv_python)
-        cron_cmd = (
-            f'{minute} {hour} * * * cd {project_dir} && {python_path} '
-            f'-m memanga check --auto --quiet >> {project_dir}/memanga.log 2>&1'
-        )
+        cron_cmd = build_cron_line(minute, hour, project_dir, python_path)
         try:
             result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
             existing = result.stdout if result.returncode == 0 else ""

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -755,6 +755,44 @@ class TestCronCommand:
         rc = run_cli("cron", "status")
         assert rc in (0, 1, 2)
 
+    def test_cron_install_submits_quoted_line(self, run_cli, monkeypatch):
+        """#109: `cron install` must submit the shell-safe crontab line
+        from build_cron_line() so paths with spaces survive."""
+        from pathlib import Path
+
+        from memanga import cli
+        from memanga.cron import build_cron_line
+
+        monkeypatch.setattr(cli.platform, "system", lambda: "Linux")
+
+        submitted = {}
+
+        class _FakePopen:
+            returncode = 0
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def communicate(self, input=None):
+                submitted["crontab"] = input
+                return ("", "")
+
+        monkeypatch.setattr(
+            cli.subprocess, "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1, stdout="",
+                                                  stderr=""))
+        monkeypatch.setattr(cli.subprocess, "Popen", _FakePopen)
+
+        rc = run_cli("cron", "install", "--time", "06:00")
+        assert rc == 0
+
+        project_dir = Path(cli.__file__).resolve().parent.parent
+        python_path = project_dir / "venv" / "bin" / "python3"
+        if not python_path.exists():
+            python_path = Path(sys.executable)
+        expected = build_cron_line(0, 6, project_dir, python_path)
+        assert expected in submitted["crontab"].splitlines()
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # `tui` — interactive mode — we don't drive it; just import-check

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -353,6 +353,36 @@ class TestSettingsPage:
                   for m in app_window.config.get("manga", []) or []]
         assert "FromBackup" in titles
 
+    def test_install_cron_unix_quotes_paths(self, app_window, qapp,
+                                            monkeypatch, tmp_path):
+        """#109: cron paths with spaces must be shell-quoted so the
+        generated crontab entry survives spaced install dirs."""
+        import subprocess
+        import sys
+
+        from memanga.cron import build_cron_line
+        from memanga.gui.pages import settings as settings_mod
+
+        page = app_window._pages["settings"]
+        project_dir = tmp_path / "My Manga"
+        project_dir.mkdir()
+
+        submitted = {}
+
+        def _fake_run(cmd, input=None, **kwargs):
+            if cmd == ["crontab", "-"]:
+                submitted["crontab"] = input
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            return subprocess.CompletedProcess(cmd, 1, "", "")
+
+        monkeypatch.setattr(settings_mod.subprocess, "run", _fake_run)
+
+        page._install_cron_unix(project_dir, "06", "30")
+
+        expected = build_cron_line("30", "06", project_dir, sys.executable)
+        assert expected in submitted["crontab"].splitlines()
+        assert f"'{project_dir}'" in submitted["crontab"]
+
     def test_import_rejects_versionless_backup(self, app_window, qapp,
                                                monkeypatch, tmp_path):
         # Regression for #42: import never read the export's `version`

--- a/tests/unit/test_cron.py
+++ b/tests/unit/test_cron.py
@@ -1,0 +1,47 @@
+"""Tests for memanga.cron shell-safe crontab line construction (#109)."""
+
+import shlex
+
+from memanga.cron import build_cron_line, quote_cron_path
+
+
+class TestQuoteCronPath:
+    def test_plain_path_unchanged(self):
+        assert quote_cron_path("/opt/memanga") == "/opt/memanga"
+
+    def test_path_with_spaces_is_quoted(self):
+        assert quote_cron_path("/opt/My Manga") == "'/opt/My Manga'"
+
+    def test_shell_metacharacters_neutralized(self):
+        evil = "/tmp/$(touch pwned); echo"
+        assert shlex.split(quote_cron_path(evil)) == [evil]
+
+    def test_percent_escaped_for_cron(self):
+        # crontab(5) turns an unescaped % into a newline.
+        assert quote_cron_path("/opt/100%manga") == r"/opt/100\%manga"
+
+
+class TestBuildCronLine:
+    def test_plain_paths(self):
+        line = build_cron_line(0, 6, "/opt/memanga", "/usr/bin/python3")
+        assert line == (
+            "0 6 * * * cd /opt/memanga && /usr/bin/python3 "
+            "-m memanga check --auto --quiet >> /opt/memanga/memanga.log 2>&1"
+        )
+
+    def test_paths_with_spaces(self):
+        line = build_cron_line(30, 7, "/opt/My Manga",
+                               "/opt/My Manga/venv/bin/python3")
+        assert line == (
+            "30 7 * * * cd '/opt/My Manga' && "
+            "'/opt/My Manga/venv/bin/python3' "
+            "-m memanga check --auto --quiet "
+            ">> '/opt/My Manga/memanga.log' 2>&1"
+        )
+
+    def test_metacharacter_paths_stay_single_words(self):
+        evil = "/tmp/x; touch pwned"
+        line = build_cron_line(0, 6, evil, "/usr/bin/python3")
+        command = line.split("* * * ", 1)[1]
+        # The shell must see the whole path as one word, not extra commands.
+        assert evil in shlex.split(command)


### PR DESCRIPTION
## Summary

Closes #109.

## Changes

- Add a shared Unix cron line builder that shell-quotes project, Python, and log paths.
- Use the shared builder from both CLI and GUI scheduled-check installation.
- Cover plain paths, spaced paths, shell metacharacters, cron percent escaping, and CLI/GUI crontab submission.

## Testing

- `timeout 180 venv/bin/python -m pytest tests/unit/test_cron.py tests/unit/cli/test_cli_commands.py::TestCronCommand tests/unit/gui/pages/test_pages.py::TestSettingsPage::test_install_cron_unix_quotes_paths -q`
- `timeout 240 venv/bin/python -m pytest tests/unit/cli/test_cli_commands.py -q`
- `timeout 240 venv/bin/python -m pytest tests/unit/gui/pages/test_pages.py::TestSettingsPage -q`
- `timeout 120 venv/bin/python -m compileall -q memanga tests/unit/test_cron.py tests/unit/cli/test_cli_commands.py tests/unit/gui/pages/test_pages.py`
- `git diff --check`
- Public hygiene scan clean
- No-side-effect cron-line inspection with a spaced and shell-metacharacter path