### PR TITLE
fix(state): tolerate nonnumeric reset labels

### DIFF
--- a/memanga/state.py
+++ b/memanga/state.py
@@ -5,12 +5,24 @@ State management for MeManga - tracks downloaded chapters and check history
 import copy
 import json
 import os
+import re
 import tempfile
 import threading
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
 from typing import List, Optional, Dict, Any
+
+
+_LEADING_CHAPTER_RE = re.compile(r"\s*(\d+(?:\.\d+)?)")
+
+
+def _leading_chapter_number(label: Any) -> Optional[float]:
+    """Return the leading numeric chapter value, if the label starts with one."""
+    match = _LEADING_CHAPTER_RE.match(str(label))
+    if not match:
+        return None
+    return float(match.group(1))
 
 
 class State:
@@ -235,10 +247,8 @@ class State:
             if chapter_str not in entry["downloaded"]:
                 entry["downloaded"].append(chapter_str)
                 def _sort_key(x):
-                    try:
-                        return float(x)
-                    except (ValueError, TypeError):
-                        return 0.0
+                    num = _leading_chapter_number(x)
+                    return num if num is not None else 0.0
                 entry["downloaded"].sort(key=_sort_key)
 
             entry["last_chapter"] = chapter_str
@@ -588,10 +598,8 @@ class State:
                 entry["external_chapters"].append(ch_str)
 
                 def _sort_key(x):
-                    try:
-                        return float(x)
-                    except (ValueError, TypeError):
-                        return 0.0
+                    num = _leading_chapter_number(x)
+                    return num if num is not None else 0.0
 
                 entry["external_chapters"].sort(key=_sort_key)
                 self._mark_dirty()
@@ -782,10 +790,17 @@ class State:
                 entry["last_chapter"] = None
                 entry["downloaded"] = []
             else:
-                # Keep only chapters before from_chapter, remove the rest
+                # Keep only chapters before from_chapter, remove the rest.
+                # Part-style labels (e.g. "3 Part 1") compare by their leading
+                # chapter number. Labels with no leading number are preserved
+                # because they cannot be ordered safely against the threshold.
+                def _keep_downloaded(ch):
+                    num = _leading_chapter_number(ch)
+                    return num is None or num < from_chapter
+
                 entry["downloaded"] = [
                     ch for ch in entry.get("downloaded", [])
-                    if float(ch) < from_chapter
+                    if _keep_downloaded(ch)
                 ]
                 entry["last_chapter"] = None
             entry["last_updated"] = datetime.now().isoformat()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -78,6 +78,14 @@ class TestChapterTracking:
         assert not state.is_chapter_downloaded("X", "2")
         assert not state.is_chapter_downloaded("Y", "1")
 
+    def test_downloaded_part_labels_sort_by_leading_chapter(self, state):
+        for chapter in ["10 Part 1", "Extra", "2 Part 1", "3.5 Part 1", "3"]:
+            state.add_downloaded_chapter("X", chapter)
+
+        assert state.get_downloaded_chapters("X") == [
+            "Extra", "2 Part 1", "3", "3.5 Part 1", "10 Part 1"
+        ]
+
     def test_set_last_chapter(self, state):
         state.set_last_chapter("X", "10")
         assert state.get_last_chapter("X") == "10"
@@ -107,6 +115,14 @@ class TestExternalChapters:
         state.mark_external_chapter("X", "2")
         ext = state.get_external_chapters("X")
         assert "1" in ext and "2" in ext
+
+    def test_external_part_labels_sort_by_leading_chapter(self, state):
+        for chapter in ["10 Part 1", "Extra", "2 Part 1", "3.5 Part 1", "3"]:
+            state.mark_external_chapter("X", chapter)
+
+        assert state.get_external_chapters("X") == [
+            "Extra", "2 Part 1", "3", "3.5 Part 1", "10 Part 1"
+        ]
 
     def test_available_chapters_set_and_get(self, state):
         chapters = [{"number": "1", "title": "first"},
@@ -303,6 +319,39 @@ class TestResetManga:
         # Only chapters strictly < 3 survive
         assert "1" in kept and "2" in kept
         assert "3" not in kept and "4" not in kept and "5" not in kept
+
+    def test_reset_with_threshold_tolerates_nonnumeric_labels(self, state):
+        # Issue #112: part-style labels like "2 Part 1" must not raise
+        # during a partial reset, and their leading chapter number should
+        # decide whether they are kept.
+        for c in ["1", "2 Part 1", "2 Part 2", "3", "4"]:
+            state.add_downloaded_chapter("X", c)
+        state.reset_manga_progress("X", from_chapter=3)
+        kept = state.get_downloaded_chapters("X")
+        assert "1" in kept
+        assert "2 Part 1" in kept and "2 Part 2" in kept
+        assert "3" not in kept and "4" not in kept
+        assert state.get_last_chapter("X") is None
+
+    def test_reset_with_threshold_removes_part_labels_at_or_above_threshold(self, state):
+        for c in ["Extra", "1", "2 Part 1", "3 Part 1", "3 Part 2", "10 Part 1"]:
+            state.add_downloaded_chapter("X", c)
+
+        state.reset_manga_progress("X", from_chapter=3)
+
+        kept = state.get_downloaded_chapters("X")
+        assert "Extra" in kept
+        assert "1" in kept and "2 Part 1" in kept
+        assert "3 Part 1" not in kept
+        assert "3 Part 2" not in kept
+        assert "10 Part 1" not in kept
+        assert state.get_last_chapter("X") is None
+
+    def test_reset_with_zero_clears_nonnumeric_labels(self, state):
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "2 Part 1")
+        state.reset_manga_progress("X", from_chapter=0)
+        assert state.get_downloaded_chapters("X") == []
 
     def test_remove_manga(self, state):
         state.add_downloaded_chapter("X", "1")


### PR DESCRIPTION
## Summary

Fix Download from chapter resets so downloaded history entries with part-style or other nonnumeric labels no longer raise during progress cleanup.

Closes #112

## Changes

- Apply the existing downloaded-list numeric fallback policy when filtering downloaded chapters during partial resets.
- Add state regression coverage for partial and full resets with nonnumeric chapter labels.

## Testing

- `venv/bin/python -m pytest tests/unit/test_state.py -q`
- `venv/bin/python -m pytest tests/unit/gui/pages/test_pages.py::TestDetailPage::test_download_from_with_value_zero_resets_last_chapter tests/unit/gui/pages/test_pages.py::TestDetailPage::test_download_from_n_sets_threshold tests/integration/test_issue_regressions.py::test_issue_20_from_chapter_threshold -q`
- Direct State runtime check with part-style labels and `reset_manga_progress(from_chapter=3)`