### PR TITLE
fix(reader): find normalized downloads

### DIFF
--- a/memanga/gui/pages/reader.py
+++ b/memanga/gui/pages/reader.py
@@ -836,8 +836,12 @@ class ReaderPage(BasePage):
         self._page_labels.clear()
 
         if not self._images:
+            from ...downloader import _sanitize_filename
             download_dir = self.app.config.download_dir
-            manga_dir = Path(download_dir) / self._manga.get("title", "")
+            # Issue #111: report the sanitized folder — the one the
+            # downloader actually writes to — not the raw title.
+            manga_dir = Path(download_dir) / _sanitize_filename(
+                self._manga.get("title", ""))
             empty = QLabel(
                 f"Could not load chapter {self._chapter} images.\n\n"
                 f"Looked in: {manga_dir}\n"
@@ -955,41 +959,51 @@ class ReaderPage(BasePage):
         QTimer.singleShot(0, self._mark_read_if_unscrollable)
 
     def _find_and_load_chapter(self) -> List[QImage]:
+        # Issue #111: the downloader saves under the *sanitized* title
+        # folder and formats chapter labels for sorting ("2 Part 1" ->
+        # "2.01"), so the lookup must mirror those exact conventions.
+        # Raw title/label locations are kept as fallbacks for downloads
+        # that predate this fix.
+        from ...downloader import _format_chapter_number, _sanitize_filename
+
         title = self._manga.get("title", "")
-        ch = self._chapter
-        download_dir = self.app.config.download_dir
-        manga_dir = Path(download_dir) / title
+        ch = str(self._chapter)
+        download_dir = Path(self.app.config.download_dir)
 
-        if not manga_dir.exists():
-            return []
+        labels = []
+        for label in (_format_chapter_number(ch), ch, f"{ch}.0"):
+            if label not in labels:
+                labels.append(label)
 
-        def sanitize(name):
-            for c in '<>:"/\\|?*':
-                name = name.replace(c, '')
-            return name.strip()[:100]
+        manga_dirs = []
+        for d in (download_dir / _sanitize_filename(title), download_dir / title):
+            if d.is_dir() and d not in manga_dirs:
+                manga_dirs.append(d)
 
-        patterns = [
-            f"{sanitize(title)} - Chapter {ch}",
-            f"{sanitize(title)} - Chapter {ch}.0",
-        ]
+        for manga_dir in manga_dirs:
+            for label in labels:
+                # Sanitize the full base name, not just the title — the
+                # downloader builds "{title} - Chapter {chapter}" first
+                # and sanitizes the result (incl. the length cap).
+                base = _sanitize_filename(f"{title} - Chapter {label}")
+                for ext in [".pdf", ".epub", ".cbz", ".zip"]:
+                    filepath = manga_dir / f"{base}{ext}"
+                    if filepath.exists():
+                        return _extract_images_from_file(filepath)
 
-        for pattern in patterns:
-            for ext in [".pdf", ".epub", ".cbz", ".zip"]:
-                filepath = manga_dir / f"{pattern}{ext}"
-                if filepath.exists():
-                    return _extract_images_from_file(filepath)
+                folder = manga_dir / f"Chapter {label}"
+                if folder.is_dir():
+                    return _extract_images_from_folder(folder)
 
-            folder = manga_dir / f"Chapter {ch}"
-            if folder.is_dir():
-                return _extract_images_from_folder(folder)
-
-        # Fallback: scan directory
-        ch_str = str(ch)
-        for f in manga_dir.iterdir():
-            if f.is_file() and f"chapter {ch_str}" in f.stem.lower():
-                return _extract_images_from_file(f)
-            if f.is_dir() and ch_str in f.name:
-                return _extract_images_from_folder(f)
+        # Fallback: scan directories for anything chapter-shaped
+        for manga_dir in manga_dirs:
+            for f in manga_dir.iterdir():
+                if f.is_file() and any(
+                    f"chapter {label.lower()}" in f.stem.lower() for label in labels
+                ):
+                    return _extract_images_from_file(f)
+                if f.is_dir() and any(label in f.name for label in labels):
+                    return _extract_images_from_folder(f)
 
         return []
 

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -18,6 +18,7 @@ If any of these go red, a previously-fixed bug has come back.
 | #45 | Chapter marked read before reaching the end |
 | #49 | "Next chapter" button label invisible |
 | #55 | Detail page blank when Email to Kindle delivery selected |
+| #111 | Reader missed downloads saved under sanitized/formatted names |
 """
 
 from __future__ import annotations
@@ -661,3 +662,73 @@ def test_issue_55_email_enabled_is_bool(config):
 
     config.set("delivery.mode", "local")
     assert config.email_enabled is False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# #111 — Reader finds downloads under sanitized title / formatted label
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_issue_111_sanitized_title_folder(app_window, qapp, make_cbz):
+    """The downloader strips filesystem-unsafe characters before building
+    the manga folder and file name; the reader used to start from the raw
+    title folder and never found the download."""
+    from pathlib import Path
+    manga = {"title": 'Kaguya: "Love" is <War>?',
+             "url": "https://mangadex.org/title/x", "source": "mangadex.org",
+             "status": "reading", "mode": "manual"}
+    app_window.config.set("manga", [manga])
+    # Exactly what the downloader writes: sanitized folder + sanitized
+    # "{title} - Chapter {chapter}" base name.
+    dl = Path(app_window.config.download_dir) / "Kaguya Love is War"
+    dl.mkdir(parents=True, exist_ok=True)
+    (dl / "Kaguya Love is War - Chapter 1.cbz").write_bytes(
+        make_cbz(pages=2).read_bytes())
+    app_window.app_state.add_downloaded_chapter(manga["title"], "1")
+
+    app_window.show_page("reader", manga=manga, chapter="1")
+    qapp.processEvents()
+    reader = app_window._pages["reader"]
+    assert reader._images, (
+        "#111 regression: chapter under sanitized title folder unreachable")
+
+
+def test_issue_111_part_style_chapter_label(app_window, qapp, sample_manga,
+                                            make_cbz):
+    """Part-style labels are formatted for archive sorting on disk
+    ("2 Part 1" -> "2.01"); the reader used to search for the raw label
+    only."""
+    from pathlib import Path
+    app_window.config.set("manga", [sample_manga])
+    dl = Path(app_window.config.download_dir) / sample_manga["title"]
+    dl.mkdir(parents=True, exist_ok=True)
+    (dl / f"{sample_manga['title']} - Chapter 2.01.cbz").write_bytes(
+        make_cbz(pages=2).read_bytes())
+    app_window.app_state.add_downloaded_chapter(sample_manga["title"],
+                                                "2 Part 1")
+
+    app_window.show_page("reader", manga=sample_manga, chapter="2 Part 1")
+    qapp.processEvents()
+    reader = app_window._pages["reader"]
+    assert reader._images, (
+        "#111 regression: downloader-formatted part chapter unreachable")
+
+
+def test_issue_111_raw_locations_still_load(app_window, qapp, make_cbz):
+    """Backward compatibility: downloads that ended up under the raw
+    title folder with a raw chapter label must stay reachable."""
+    from pathlib import Path
+    manga = {"title": "Dr. Who?", "url": "https://mangadex.org/title/y",
+             "source": "mangadex.org", "status": "reading", "mode": "manual"}
+    app_window.config.set("manga", [manga])
+    dl = Path(app_window.config.download_dir) / "Dr. Who?"
+    dl.mkdir(parents=True, exist_ok=True)
+    (dl / "Dr. Who? - Chapter 2 Part 1.cbz").write_bytes(
+        make_cbz(pages=2).read_bytes())
+    app_window.app_state.add_downloaded_chapter(manga["title"], "2 Part 1")
+
+    app_window.show_page("reader", manga=manga, chapter="2 Part 1")
+    qapp.processEvents()
+    reader = app_window._pages["reader"]
+    assert reader._images, (
+        "#111 regression: pre-fix raw-title/raw-label download unreachable")


### PR DESCRIPTION
## Summary

Fixes the reader lookup for downloads saved with the downloader's normalized filesystem names. The reader now searches sanitized title folders first, tries downloader-formatted chapter labels before raw labels, and keeps raw-title/raw-label fallbacks for existing downloads.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [ ] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #111

## Tests

- `venv/bin/python -m pytest tests/integration/test_issue_regressions.py -q -k issue_111`
- `python -m compileall memanga`
- `git diff --cached --check`
