### PR TITLE
feat(reader): resume chapter position

### DIFF
--- a/memanga/gui/app.py
+++ b/memanga/gui/app.py
@@ -617,6 +617,12 @@ class MeMangaApp(QMainWindow):
                 self.worker.check_updates(manga_list, self.app_state, self.config)
 
     def closeEvent(self, event):
+        # Issue #106: closing the app doesn't route through show_page, so
+        # the reader never gets its on_hide save point — ask the current
+        # page to persist its reading position before the final flush.
+        page = self._pages.get(self._current_page)
+        if page is not None and hasattr(page, "save_reading_position"):
+            page.save_reading_position()
         self.app_state.flush()
         self.worker.shutdown()
         if hasattr(self, "network"):

--- a/memanga/gui/pages/reader.py
+++ b/memanga/gui/pages/reader.py
@@ -179,6 +179,10 @@ class ReaderPage(BasePage):
         self.setFocus()
 
     def on_hide(self):
+        # Issue #106: any navigation away from the reader (Back button,
+        # Escape, sidebar — everything routed through show_page) is a
+        # save point for the in-chapter resume position.
+        self.save_reading_position()
         self._images.clear()
         self._page_labels.clear()
 
@@ -596,6 +600,9 @@ class ReaderPage(BasePage):
             return
         self._read_marked = True
         self.app.app_state.mark_chapter_read(title, str(self._chapter))
+        # Issue #106: a finished chapter should reopen from its first
+        # page, not keep resuming at the saved end-of-chapter position.
+        self.app.app_state.clear_reader_position(title, str(self._chapter))
         # Tell other pages (Library, Detail) to repaint without
         # waiting for the next navigation.
         self.app.events.publish("chapter_read", {
@@ -619,6 +626,119 @@ class ReaderPage(BasePage):
             return
         if content.sizeHint().height() <= viewport_h:
             self._mark_current_read()
+
+    # ── In-chapter resume position (issue #106) ───────────────────────
+    # Separate from the chapter cursor (`reading_progress.last_chapter`)
+    # and the read set (issue #45): remembers *where inside* a chapter
+    # the user stopped, so reopening that chapter picks up there. Saved
+    # on every way out of the reader — Back/Escape/sidebar via on_hide,
+    # Prev/Next via _navigate_chapter, app close via MeMangaApp.closeEvent
+    # — and cleared once the chapter is finished, so completed chapters
+    # reopen from the start instead of forever near the end.
+
+    def save_reading_position(self):
+        """Persist (or clear) the resume position for the open chapter.
+        Positions at the very start or at/over the completion threshold
+        aren't worth resuming — the start is the default and the end
+        means the chapter was finished — so those clear instead."""
+        if not self._manga or not self._chapter or not self._images:
+            return
+        title = self._manga.get("title", "")
+        if not title:
+            return
+        state = self.app.app_state
+        chapter = str(self._chapter)
+
+        if self._view_mode in self.PAGED_MODES:
+            last = self._current_page + (1 if self._view_mode == "double"
+                                         else 0)
+            if self._current_page <= 0 or last >= len(self._images) - 1:
+                state.clear_reader_position(title, chapter)
+                return
+            state.set_reader_position(title, chapter, mode=self._view_mode,
+                                      page_index=self._current_page)
+            return
+
+        if self._scroll is None:
+            return
+        try:
+            sb = self._scroll.verticalScrollBar()
+            maximum, value = sb.maximum(), sb.value()
+        except RuntimeError:
+            return  # scroll area already torn down
+        if maximum <= 0:
+            # Chapter fits the viewport whole — nothing to resume.
+            state.clear_reader_position(title, chapter)
+            return
+        ratio = value / maximum
+        if ratio <= 0.0 or ratio >= self.READ_THRESHOLD:
+            state.clear_reader_position(title, chapter)
+            return
+        state.set_reader_position(title, chapter, mode="continuous",
+                                  scroll_ratio=ratio)
+
+    def _restore_reader_position(self):
+        """Re-apply a previously saved in-chapter position. Paged modes
+        jump straight to the saved page/spread before the first render;
+        continuous mode defers the scroll one event-loop turn so the
+        freshly-built layout has a scrollbar range to scroll within.
+        Everything is clamped, cross-converted between page index and
+        scroll ratio when the layout changed since the save, and ignored
+        at/over the completion threshold — a restore must never flip the
+        chapter to read by itself, and stale data (page count changed,
+        chapter re-downloaded) must stay harmless."""
+        title = (self._manga or {}).get("title", "")
+        if not title or not self._images:
+            return
+        pos = self.app.app_state.get_reader_position(title, str(self._chapter))
+        if not pos:
+            return
+        total = len(self._images)
+        page_index = pos.get("page_index")
+        scroll_ratio = pos.get("scroll_ratio")
+
+        if self._view_mode in self.PAGED_MODES:
+            if page_index is None:
+                # Saved from continuous mode: estimate the page from the
+                # scroll ratio, same mapping _set_view_mode uses.
+                if scroll_ratio is None:
+                    return
+                page_index = int(float(scroll_ratio) * total)
+            index = max(0, min(total - 1, int(page_index)))
+            if self._view_mode == "double":
+                index -= index % 2  # spreads stay aligned to fixed pairs
+            last = index + (1 if self._view_mode == "double" else 0)
+            if index <= 0 or last >= total - 1:
+                return
+            self._current_page = index
+            return
+
+        if scroll_ratio is None:
+            # Saved from a paged mode: page N of M lands at ratio N/M.
+            if page_index is None:
+                return
+            scroll_ratio = int(page_index) / total
+        ratio = min(1.0, max(0.0, float(scroll_ratio)))
+        if ratio <= 0.0 or ratio >= self.READ_THRESHOLD:
+            return
+        # The scrollbar range is still 0 while _load_chapter builds the
+        # layout — defer one turn, same trick as _mark_read_if_unscrollable.
+        chapter = str(self._chapter)
+        QTimer.singleShot(
+            0, lambda: self._apply_saved_scroll_ratio(chapter, ratio))
+
+    def _apply_saved_scroll_ratio(self, chapter: str, ratio: float):
+        """Deferred half of the continuous-mode restore."""
+        # The user may have navigated on before the timer fired; only
+        # apply to the chapter the ratio was saved against.
+        if str(self._chapter) != chapter or self._scroll is None:
+            return
+        try:
+            sb = self._scroll.verticalScrollBar()
+            if sb.maximum() > 0:
+                sb.setValue(int(ratio * sb.maximum()))
+        except RuntimeError:
+            pass  # scroll area torn down before the timer fired
 
     def _render_images(self):
         # Total width the spread is allowed to occupy.
@@ -716,7 +836,9 @@ class ReaderPage(BasePage):
         # when navigating Prev/Next within the reader.
         self._read_marked = False
         # Issue #32: every chapter opens on its first page, in whatever
-        # layout this manga last used (or the global/legacy fallback).
+        # layout this manga last used (or the global/legacy fallback) —
+        # unless a resume position was saved for it (issue #106), which
+        # _restore_reader_position re-applies once the images are in.
         self._current_page = 0
         self._view_mode = self._resolve_view_mode()
 
@@ -848,6 +970,11 @@ class ReaderPage(BasePage):
             empty.setWordWrap(True)
             content_layout.addWidget(empty, 1)
             return
+
+        # Issue #106: land back where the user left this chapter. Sits
+        # after the empty-images bail-out above, so a chapter whose file
+        # was cleaned up never touches (or trips over) its stale position.
+        self._restore_reader_position()
 
         self._page_indicator.setText(
             f"{int(self._zoom_level * 100)}%  |  {len(self._images)} pages"
@@ -994,6 +1121,9 @@ class ReaderPage(BasePage):
         return []
 
     def _navigate_chapter(self, chapter):
+        # Issue #106: keep the outgoing chapter's resume point before the
+        # cursor moves on — Prev/Next never goes through on_hide.
+        self.save_reading_position()
         self._chapter = chapter
         if self._manga:
             title = self._manga.get("title", "")

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -367,6 +367,45 @@ class State:
                     best = {"title": title, **progress}
         return best
 
+    # ── Reader resume position (issue #106) ────────────────────────────
+    # Separate from `reading_progress.last_chapter` (the cursor) and
+    # `read_chapters` (the read set): this stores *where inside a chapter*
+    # the reader left off, so reopening a chapter can restore the exact
+    # page (paged mode) or scroll offset (webtoon/strip mode).
+
+    def set_reader_position(self, manga_title: str, chapter, mode: str,
+                            page_index: Optional[int] = None,
+                            scroll_ratio: Optional[float] = None):
+        """Save the in-chapter resume position for a manga/chapter."""
+        if chapter is None or str(chapter).strip() == "":
+            return
+        self._ensure_manga_entry(manga_title)
+        entry = self._data["manga"][manga_title]
+        positions = entry.setdefault("reader_positions", {})
+        pos: Dict[str, Any] = {
+            "mode": mode,
+            "updated_at": datetime.now().isoformat(),
+        }
+        if page_index is not None:
+            pos["page_index"] = max(0, int(page_index))
+        if scroll_ratio is not None:
+            pos["scroll_ratio"] = min(1.0, max(0.0, float(scroll_ratio)))
+        positions[str(chapter)] = pos
+        self._mark_dirty()
+
+    def get_reader_position(self, manga_title: str, chapter) -> Optional[Dict[str, Any]]:
+        """Get the saved resume position, or None if never saved."""
+        positions = self.get_manga_state(manga_title).get("reader_positions", {})
+        return positions.get(str(chapter))
+
+    def clear_reader_position(self, manga_title: str, chapter):
+        """Drop the saved resume position (e.g. chapter finished)."""
+        positions = self._data.get("manga", {}).get(manga_title, {}).get("reader_positions", {})
+        ch = str(chapter)
+        if ch in positions:
+            del positions[ch]
+            self._mark_dirty()
+
     # ── Per-chapter read tracking (issue #18) ──────────────────────────
     # `reading_progress.last_chapter` only tracks the cursor (the most-
     # recently-opened chapter). The set below tracks every individual

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -530,6 +530,182 @@ class TestReaderPage:
         reader._zoom_in()
         assert reader._zoom_level > z0
 
+    # ── In-chapter resume position (issue #106) ──────────────────────
+
+    @staticmethod
+    def _stage_chapter(app_window, manga, make_cbz, pages=6, chapter="1"):
+        """Drop a downloadable CBZ where the reader looks for it."""
+        from pathlib import Path
+        app_window.config.set("manga", [manga])
+        title = manga["title"]
+        dl = Path(app_window.config.download_dir) / title
+        dl.mkdir(parents=True, exist_ok=True)
+        cbz = make_cbz(pages=pages, name=f"ch{chapter}.cbz")
+        (dl / f"{title} - Chapter {chapter}.cbz").write_bytes(cbz.read_bytes())
+        app_window.app_state.add_downloaded_chapter(title, chapter)
+        return title
+
+    def test_single_mode_position_saved_and_restored(self, app_window, qapp,
+                                                     sample_manga, make_cbz):
+        title = self._stage_chapter(app_window, sample_manga, make_cbz)
+        app_window.config.set("gui.reader_view_mode", "single")
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        reader = app_window._pages["reader"]
+        reader._go_to_page(2)
+
+        # Back to detail → on_hide is the save point.
+        app_window.show_page("detail", manga=sample_manga)
+        qapp.processEvents()
+        pos = app_window.app_state.get_reader_position(title, "1")
+        assert pos["page_index"] == 2
+        assert pos["mode"] == "single"
+
+        # Reopening the same chapter resumes on the saved page.
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        assert reader._current_page == 2
+
+    def test_double_mode_saves_spread_first_page(self, app_window, qapp,
+                                                 sample_manga, make_cbz):
+        title = self._stage_chapter(app_window, sample_manga, make_cbz,
+                                    pages=8)
+        app_window.config.set("gui.reader_view_mode", "double")
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        reader = app_window._pages["reader"]
+        reader._go_to_page(3)  # double aligns spreads to even indices
+        assert reader._current_page == 2
+
+        app_window.show_page("detail", manga=sample_manga)
+        qapp.processEvents()
+        pos = app_window.app_state.get_reader_position(title, "1")
+        assert pos["page_index"] == 2
+
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        assert reader._current_page == 2
+
+    def test_finished_chapter_clears_position_and_reopens_at_start(
+            self, app_window, qapp, sample_manga, make_cbz):
+        title = self._stage_chapter(app_window, sample_manga, make_cbz)
+        app_window.config.set("gui.reader_view_mode", "single")
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        reader = app_window._pages["reader"]
+
+        reader._go_to_page(5)  # final page → read flip (issue #45)
+        assert app_window.app_state.is_chapter_read(title, "1")
+        assert app_window.app_state.get_reader_position(title, "1") is None
+
+        # Leaving from the end must not re-save an end-of-chapter position.
+        app_window.show_page("detail", manga=sample_manga)
+        qapp.processEvents()
+        assert app_window.app_state.get_reader_position(title, "1") is None
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        assert reader._current_page == 0
+
+    def test_stale_position_beyond_page_count_is_ignored(
+            self, app_window, qapp, sample_manga, make_cbz):
+        title = self._stage_chapter(app_window, sample_manga, make_cbz)
+        app_window.config.set("gui.reader_view_mode", "single")
+        # e.g. saved against a bigger re-release, then re-downloaded small.
+        app_window.app_state.set_reader_position(title, "1", mode="single",
+                                                 page_index=50)
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        reader = app_window._pages["reader"]
+        # Clamping would land on the last page and instantly flip the
+        # chapter to read — the restore must bail out instead.
+        assert reader._current_page == 0
+        assert not app_window.app_state.is_chapter_read(title, "1")
+
+    def test_continuous_ratio_restores_as_page_in_single_mode(
+            self, app_window, qapp, sample_manga, make_cbz):
+        title = self._stage_chapter(app_window, sample_manga, make_cbz)
+        # Saved while reading continuous, reopened after switching layouts.
+        app_window.app_state.set_reader_position(title, "1",
+                                                 mode="continuous",
+                                                 scroll_ratio=0.5)
+        app_window.config.set("gui.reader_view_mode", "single")
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        assert app_window._pages["reader"]._current_page == 3  # 0.5 * 6
+
+    def test_continuous_scroll_position_saved_and_restored(
+            self, app_window, qapp, sample_manga, make_cbz):
+        title = self._stage_chapter(app_window, sample_manga, make_cbz,
+                                    pages=8)
+        app_window.show()
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        reader = app_window._pages["reader"]
+        assert reader._view_mode == "continuous"
+        sb = reader._scroll.verticalScrollBar()
+        assert sb.maximum() > 0  # 8 tall pages overflow the viewport
+        sb.setValue(sb.maximum() // 2)
+
+        app_window.show_page("detail", manga=sample_manga)
+        qapp.processEvents()
+        pos = app_window.app_state.get_reader_position(title, "1")
+        assert pos["scroll_ratio"] == pytest.approx(0.5, abs=0.05)
+
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()  # restore is deferred one event-loop turn
+        qapp.processEvents()
+        sb = reader._scroll.verticalScrollBar()
+        assert sb.value() == pytest.approx(sb.maximum() * 0.5, abs=sb.maximum() * 0.05)
+        assert not app_window.app_state.is_chapter_read(title, "1")
+
+    def test_prev_next_navigation_saves_outgoing_position(
+            self, app_window, qapp, sample_manga, make_cbz):
+        title = self._stage_chapter(app_window, sample_manga, make_cbz,
+                                    chapter="1")
+        self._stage_chapter(app_window, sample_manga, make_cbz, chapter="2")
+        app_window.config.set("gui.reader_view_mode", "single")
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        reader = app_window._pages["reader"]
+        reader._go_to_page(2)
+
+        reader._go_next_chapter()
+        qapp.processEvents()
+        assert reader._chapter == "2"
+        assert app_window.app_state.get_reader_position(title, "1")[
+            "page_index"] == 2
+
+    def test_close_event_saves_position(self, app_window, qapp, sample_manga,
+                                        make_cbz):
+        title = self._stage_chapter(app_window, sample_manga, make_cbz)
+        app_window.config.set("gui.reader_view_mode", "single")
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        app_window._pages["reader"]._go_to_page(2)
+
+        app_window.close()  # closeEvent — never routes through show_page
+        assert app_window.app_state.get_reader_position(title, "1")[
+            "page_index"] == 2
+
+    def test_stale_position_with_missing_file_is_harmless(
+            self, app_window, qapp, sample_manga, make_cbz):
+        from pathlib import Path
+        title = self._stage_chapter(app_window, sample_manga, make_cbz)
+        app_window.app_state.set_reader_position(title, "1", mode="single",
+                                                 page_index=3)
+        # Cleanup (e.g. remove-after-read) deleted the artifact.
+        dl = Path(app_window.config.download_dir) / title
+        (dl / f"{title} - Chapter 1.cbz").unlink()
+
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        reader = app_window._pages["reader"]
+        assert reader._images == []  # error placeholder, no crash
+
+        # Leaving again must not corrupt or crash either.
+        app_window.show_page("detail", manga=sample_manga)
+        qapp.processEvents()
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Add Manga modal

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -167,6 +167,81 @@ class TestReadingProgress:
         assert state.get_continue_reading() is None
 
 
+class TestReaderPosition:
+    """Issue #106 — per-chapter in-reader resume position."""
+
+    def test_set_and_get_paged_position(self, state):
+        state.set_reader_position("X", "7", mode="paged", page_index=12)
+        pos = state.get_reader_position("X", "7")
+        assert pos["mode"] == "paged"
+        assert pos["page_index"] == 12
+        assert "scroll_ratio" not in pos
+        assert pos["updated_at"]  # ISO timestamp string
+
+    def test_set_and_get_scroll_position(self, state):
+        state.set_reader_position("X", "7", mode="webtoon", scroll_ratio=0.42)
+        pos = state.get_reader_position("X", "7")
+        assert pos["mode"] == "webtoon"
+        assert pos["scroll_ratio"] == pytest.approx(0.42)
+        assert "page_index" not in pos
+
+    def test_positions_are_per_chapter(self, state):
+        state.set_reader_position("X", "1", mode="paged", page_index=3)
+        state.set_reader_position("X", "2", mode="paged", page_index=9)
+        assert state.get_reader_position("X", "1")["page_index"] == 3
+        assert state.get_reader_position("X", "2")["page_index"] == 9
+
+    def test_set_overwrites_previous(self, state):
+        state.set_reader_position("X", "1", mode="paged", page_index=3)
+        state.set_reader_position("X", "1", mode="webtoon", scroll_ratio=0.5)
+        pos = state.get_reader_position("X", "1")
+        assert pos["mode"] == "webtoon"
+        assert "page_index" not in pos
+
+    def test_page_index_clamped_nonnegative(self, state):
+        state.set_reader_position("X", "1", mode="paged", page_index=-5)
+        assert state.get_reader_position("X", "1")["page_index"] == 0
+
+    def test_scroll_ratio_clamped_to_unit_range(self, state):
+        state.set_reader_position("X", "1", mode="webtoon", scroll_ratio=1.7)
+        assert state.get_reader_position("X", "1")["scroll_ratio"] == 1.0
+        state.set_reader_position("X", "2", mode="webtoon", scroll_ratio=-0.3)
+        assert state.get_reader_position("X", "2")["scroll_ratio"] == 0.0
+
+    def test_chapter_keys_are_stringified(self, state):
+        state.set_reader_position("X", 7, mode="paged", page_index=1)
+        assert state.get_reader_position("X", "7")["page_index"] == 1
+
+    def test_get_unknown_manga_or_chapter_returns_none(self, state):
+        assert state.get_reader_position("never-added", "1") is None
+        state.set_reader_position("X", "1", mode="paged", page_index=0)
+        assert state.get_reader_position("X", "99") is None
+
+    def test_clear_reader_position(self, state):
+        state.set_reader_position("X", "1", mode="paged", page_index=4)
+        state.clear_reader_position("X", "1")
+        assert state.get_reader_position("X", "1") is None
+
+    def test_clear_unknown_is_noop(self, state):
+        state.clear_reader_position("never-added", "1")  # must not raise
+        state.set_reader_position("X", "1", mode="paged", page_index=0)
+        state.clear_reader_position("X", "99")  # must not raise
+
+    def test_blank_chapter_id_ignored(self, state):
+        state.set_reader_position("X", "", mode="paged", page_index=1)
+        state.set_reader_position("X", None, mode="paged", page_index=1)
+        assert state.get_manga_state("X").get("reader_positions", {}) == {}
+
+    def test_old_state_file_without_reader_positions(self, state):
+        # Entry created before the feature existed lacks the key entirely.
+        state._ensure_manga_entry("Legacy")
+        state._data["manga"]["Legacy"].pop("reader_positions", None)
+        assert state.get_reader_position("Legacy", "1") is None
+        state.clear_reader_position("Legacy", "1")  # must not raise
+        state.set_reader_position("Legacy", "1", mode="paged", page_index=2)
+        assert state.get_reader_position("Legacy", "1")["page_index"] == 2
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Notifications + filter API (issue #18)
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds per-chapter in-reader resume positions so reopening a downloaded chapter returns to the last saved page, spread, or continuous scroll position.

Closes #106

## Changes

- Store reader positions separately from chapter cursor progress and read-state.
- Save positions when leaving the reader, switching chapters, or closing the app.
- Restore positions in single-page, double-page, and continuous reader modes, with safeguards for completed chapters and missing artifacts.
- Add regression coverage for state storage, save/restore paths, stale data, and cleanup-safe behavior.

## Testing

- `venv/bin/python -m pytest tests/unit/test_state.py -q`
- `venv/bin/python -m pytest tests/unit/gui/pages/test_pages.py::TestReaderPage -q`
- `venv/bin/python -m compileall -q memanga tests/unit/test_state.py tests/unit/gui/pages/test_pages.py`
- `git diff --check`
- Public hygiene scan clean
- Review court approved with non-blocking coverage note
