### PR TITLE
feat(reader): prefetch next manual chapter

### DIFF
--- a/memanga/config.py
+++ b/memanga/config.py
@@ -83,6 +83,10 @@ class Config:
                 "sort_by": "title",
                 "auto_check": True,
                 "auto_check_interval": 3600,
+                # Reader prefetch (issue #107). Off by default: while
+                # reading a manual-mode manga, the reader quietly queues
+                # the immediate next available chapter in the background.
+                "reader_prefetch_next": False,
             },
             # Partial-chapter tolerance (issue #86). Off by default: any
             # missing page still aborts the chapter and discards output.
@@ -210,6 +214,12 @@ class Config:
         except (TypeError, ValueError):
             return 5.0
         return max(0.0, min(100.0, value))
+
+    @property
+    def reader_prefetch_enabled(self):
+        """Whether the reader prefetches the next manual-mode chapter
+        while reading (issue #107)."""
+        return bool(self.get("gui.reader_prefetch_next", False))
 
 
 _KEYRING_SERVICE = "memanga"

--- a/memanga/gui/app.py
+++ b/memanga/gui/app.py
@@ -379,6 +379,11 @@ class MeMangaApp(QMainWindow):
         return "auto"
 
     def _on_check_error(self, data):
+        # Issue #107: a request_id marks a correlated background check
+        # (the reader's prefetch fallback). Its initiator handles the
+        # outcome, so no notification for a lookup the user never made.
+        if data.get("request_id") is not None:
+            return
         title = data.get("title", "")
         error = data.get("error", "Unknown")
         self.app_state.add_notification("error", f"Check failed: {title} - {error[:80]}")
@@ -393,6 +398,7 @@ class MeMangaApp(QMainWindow):
 
     def _on_check_complete(self, data):
         results = data.get("results", [])
+        correlated = data.get("request_id") is not None
         total_new = sum(len(r["chapters"]) for r in results)
         config_dirty = False
 
@@ -400,7 +406,7 @@ class MeMangaApp(QMainWindow):
             manga = r["manga"]
             title = manga.get("title", "")
             count = len(r["chapters"])
-            if count > 0:
+            if count > 0 and not correlated:
                 self.app_state.set_new_chapters(title, count)
 
             # Cache the full chapter list from the primary source so the
@@ -426,7 +432,7 @@ class MeMangaApp(QMainWindow):
             # caching available_chapters so we always have something to walk.
             # One-shot: pop the sentinel and re-save config.
             threshold_raw = manga.get("external_threshold")
-            if threshold_raw is not None:
+            if threshold_raw is not None and not correlated:
                 if all_chapters:
                     if self._resolve_external_threshold(manga, threshold_raw, all_chapters):
                         config_dirty = True
@@ -437,6 +443,9 @@ class MeMangaApp(QMainWindow):
                     # second failure to keep config clean.
                     if self._increment_threshold_attempts(manga.get("title", "")):
                         config_dirty = True
+
+        if correlated:
+            return
 
         if config_dirty:
             # Persist the popped sentinels and the freshly-set last_chapter.

--- a/memanga/gui/components/sidebar.py
+++ b/memanga/gui/components/sidebar.py
@@ -170,7 +170,10 @@ class Sidebar(QWidget):
 
         # Wire up all nav count badges (library / downloads / notifications / sources).
         self.app.events.subscribe("notification_added", lambda d: self._refresh_badges())
-        self.app.events.subscribe("check_complete", lambda d: self._refresh_badges())
+        self.app.events.subscribe(
+            "check_complete",
+            lambda d: None if (d or {}).get("request_id") is not None else self._refresh_badges(),
+        )
         self.app.events.subscribe("library_updated", lambda d: self._refresh_badges())
         self.app.events.subscribe("download_complete", lambda d: self._refresh_badges())
         # Initial paint.
@@ -305,14 +308,20 @@ class Sidebar(QWidget):
 
         # Wire to actual check events.
         self.app.events.subscribe("check_progress", self._on_check_progress)
-        self.app.events.subscribe("check_complete", lambda d: self._on_check_done())
+        self.app.events.subscribe(
+            "check_complete",
+            lambda d: None if (d or {}).get("request_id") is not None else self._on_check_done(),
+        )
 
         return w
 
     # ── events ──
 
     def _on_check_progress(self, data):
-        done = data.get("done", 0)
+        data = data or {}
+        if data.get("request_id") is not None:
+            return
+        done = data.get("done", data.get("current", 0))
         total = data.get("total", 1)
         pct = int(100 * done / max(total, 1))
         self._sync_progress.setValue(pct)

--- a/memanga/gui/pages/downloads.py
+++ b/memanga/gui/pages/downloads.py
@@ -512,11 +512,18 @@ class DownloadsPage(BasePage):
     # ── Check event handlers ──
 
     def _on_check_error(self, data):
+        # Issue #107: correlated background checks (request_id set, e.g.
+        # the reader prefetch fallback) fail silently -- only checks the
+        # user initiated toast here.
+        if data.get("request_id") is not None:
+            return
         title = data.get("title", "")
         error = data.get("error", "Unknown error")
         Toast(self, f"Error: {title}: {error[:50]}", kind="error")
 
     def _on_check_complete(self, data):
+        if data.get("request_id") is not None:
+            return
         results = data.get("results", [])
         # Set by an explicit "Download All" / "Download from chapter" action.
         # Such a request must queue the resolved chapters regardless of mode;

--- a/memanga/gui/pages/reader.py
+++ b/memanga/gui/pages/reader.py
@@ -4,6 +4,7 @@ Three layouts: continuous vertical scroll, single page, two-up spreads.
 """
 
 import io
+import re
 import zipfile
 from pathlib import Path
 from typing import List, Optional
@@ -83,6 +84,29 @@ def _extract_images_from_file(filepath: Path) -> List[QImage]:
     return images
 
 
+def _chapter_sort_key(number) -> Optional[float]:
+    """Numeric sort key for a chapter number, or None when it can't be
+    parsed. Used by the reader prefetch (issue #107) to find the
+    immediate next chapter without assuming the cache is pre-sorted.
+    Mirrors Chapter.numeric's extraction so labels like "Chapter 2" or
+    "2 Part 1" resolve too, but yields None instead of 0.0 when nothing
+    numeric is found -- an unparseable chapter must skip prefetch, not
+    sort as chapter zero."""
+    if number is None:
+        return None
+    try:
+        return float(str(number).strip())
+    except (ValueError, TypeError):
+        pass
+    match = re.search(r"(\d+\.?\d*)", str(number))
+    if match:
+        return float(match.group(1))
+    return None
+
+
+_PREFETCH_SKIP = object()
+
+
 def _extract_images_from_folder(folder: Path) -> List[QImage]:
     extensions = {".jpg", ".jpeg", ".png", ".webp", ".gif"}
     images = []
@@ -139,6 +163,19 @@ class ReaderPage(BasePage):
         # Issue #45: set once the current chapter has been marked read,
         # so the scroll handler only fires the state write + event once.
         self._read_marked = False
+        # Issue #107: reader prefetch of the next manual-mode chapter.
+        # Handles to the Next controls live here so a prefetched
+        # download finishing mid-read can reveal them without reloading
+        # the chapter; _prefetch_fallback_key marks a prefetch that is
+        # waiting on a forced source lookup (cache-miss fallback).
+        self._next_btn = None
+        self._next_footer = None
+        self._next_footer_btn = None
+        self._prefetch_fallback_key = None
+        self._prefetch_fallback_attempted_key = None
+        self.app.events.subscribe("download_complete",
+                                  self._on_download_complete)
+        self.app.events.subscribe("check_complete", self._on_check_complete)
 
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
@@ -835,6 +872,14 @@ class ReaderPage(BasePage):
         # Issue #45: each chapter load starts with an unread gate, even
         # when navigating Prev/Next within the reader.
         self._read_marked = False
+        # Issue #107: the previous chapter's Next controls die with
+        # self._content above — drop the handles so a stray refresh
+        # can't poke deleted widgets.
+        self._next_btn = None
+        self._next_footer = None
+        self._next_footer_btn = None
+        self._prefetch_fallback_key = None
+        self._prefetch_fallback_attempted_key = None
         # Issue #32: every chapter opens on its first page, in whatever
         # layout this manga last used (or the global/legacy fallback) —
         # unless a resume position was saved for it (issue #106), which
@@ -897,12 +942,16 @@ class ReaderPage(BasePage):
             prev_btn.clicked.connect(lambda checked=False, c=prev_ch: self._navigate_chapter(c))
             top_layout.addWidget(prev_btn)
 
-        if idx >= 0 and idx < len(downloaded) - 1:
-            next_ch = downloaded[idx + 1]
-            next_btn = QPushButton("Next ›")
-            next_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-            next_btn.clicked.connect(lambda checked=False, c=next_ch: self._navigate_chapter(c))
-            top_layout.addWidget(next_btn)
+        # Issue #107: the Next button always exists (hidden without a
+        # successor) so a prefetched chapter finishing mid-read can
+        # reveal it via _refresh_next_controls instead of a full reload.
+        # It resolves its target on click, so no chapter is captured.
+        self._next_btn = QPushButton("Next ›")
+        self._next_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._next_btn.clicked.connect(
+            lambda checked=False: self._go_next_chapter())
+        self._next_btn.setVisible(0 <= idx < len(downloaded) - 1)
+        top_layout.addWidget(self._next_btn)
 
         # ── Layout toggle (issues #24, #32) ─────────────────────────────
         # Three iconified buttons (same style as the zoom +/- chip):
@@ -1019,23 +1068,29 @@ class ReaderPage(BasePage):
         # "Next Chapter" button at bottom — continuous mode only: the
         # paged layouts re-render per page, so an in-flow footer would
         # show under every single page rather than after the last one.
-        if self._view_mode == "continuous" and 0 <= idx < len(downloaded) - 1:
-            next_ch = downloaded[idx + 1]
+        # Issue #107: built even without a successor (hidden) so a
+        # prefetch completion can flip it visible without a reload.
+        if self._view_mode == "continuous":
+            has_next = 0 <= idx < len(downloaded) - 1
             next_frame = QWidget()
             next_frame_layout = QHBoxLayout(next_frame)
             next_frame_layout.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
-            next_chapter_btn = QPushButton(f"Next: Chapter {next_ch} >>")
+            next_chapter_btn = QPushButton(
+                self._next_footer_label(downloaded, idx))
             next_chapter_btn.setProperty("class", "accent")
             next_chapter_btn.setFixedHeight(40)
             next_chapter_btn.setFixedWidth(250)
             next_chapter_btn.setCursor(Qt.CursorShape.PointingHandCursor)
             next_chapter_btn.clicked.connect(
-                lambda checked=False, c=next_ch: self._navigate_chapter(c)
+                lambda checked=False: self._go_next_chapter()
             )
             next_frame_layout.addWidget(next_chapter_btn)
             self._image_layout.addSpacing(T.PAD_XL)
             self._image_layout.addWidget(next_frame)
+            next_frame.setVisible(has_next)
+            self._next_footer = next_frame
+            self._next_footer_btn = next_chapter_btn
 
         content_layout.addWidget(self._scroll, 1)
 
@@ -1080,6 +1135,9 @@ class ReaderPage(BasePage):
         # fit the viewport whole is immediately fully visible — the
         # scroll threshold can never fire for it.
         QTimer.singleShot(0, self._mark_read_if_unscrollable)
+        # Issue #107: with the chapter on screen, quietly prepare the
+        # next one for manual-mode manga (setting-gated, cache-first).
+        self._maybe_prefetch_next()
 
     def _find_and_load_chapter(self) -> List[QImage]:
         title = self._manga.get("title", "")
@@ -1155,3 +1213,210 @@ class ReaderPage(BasePage):
                 self._navigate_chapter(downloaded[idx - 1])
         except ValueError:
             pass
+
+    # -- Reader prefetch (issue #107) ------------------------------------
+    def _maybe_prefetch_next(self):
+        """Quietly queue the immediate next available chapter for a
+        manual-mode manga so Next keeps working without leaving the
+        reader. Setting-gated and cache-first; every failure path is a
+        silent no-op so it can never block or disrupt reading."""
+        try:
+            if not self.app.config.reader_prefetch_enabled:
+                return
+            if not self._manga or self._chapter is None:
+                return
+            # Manual mode only. Auto-mode manga already queue ahead on
+            # their own schedule, so prefetch here would be redundant.
+            if (self._manga.get("mode") or "auto") != "manual":
+                return
+            title = self._manga.get("title", "")
+            if not title:
+                return
+            # Never fire background network requests while the app knows
+            # it is offline -- download_chapter would only surface a
+            # download_error the user did not ask for.
+            worker = self.app.worker
+            if getattr(worker, "_is_offline", None) and worker._is_offline():
+                return
+            entry = self._resolve_next_chapter_entry()
+            if entry is _PREFETCH_SKIP:
+                return
+            if entry is None:
+                # Missing cache: optionally force one bounded lookup.
+                self._maybe_prefetch_fallback(title)
+                return
+            self._queue_prefetch(entry)
+        except Exception:
+            # Best-effort: a prefetch failure must never interrupt reading.
+            pass
+
+    def _resolve_next_chapter_entry(self):
+        """Return the cached available-chapters entry for the immediate
+        next chapter after the current one, or None. Skips when that
+        chapter is already downloaded (Next already works)."""
+        title = self._manga.get("title", "")
+        available = self.app.app_state.get_available_chapters(title)
+        if not available:
+            return None
+        current = _chapter_sort_key(self._chapter)
+        if current is None:
+            return _PREFETCH_SKIP
+        downloaded = set(self.app.app_state.get_downloaded_chapters(title))
+        best_key = None
+        best_entry = None
+        for entry in available:
+            key = _chapter_sort_key(entry.get("number"))
+            if key is None or key <= current:
+                continue
+            if best_key is None or key < best_key:
+                best_key = key
+                best_entry = entry
+        if best_entry is None:
+            # A cached list that stops at/before the current chapter may be
+            # stale, so let the bounded fallback refresh it once.
+            return None
+        # The immediate next chapter is already on disk -- nothing to do.
+        if str(best_entry.get("number")) in downloaded:
+            return _PREFETCH_SKIP
+        return best_entry
+
+    def _queue_prefetch(self, entry):
+        """Route a cached chapter entry through the shared download queue,
+        mirroring the manual Detail-page flow so output format, Kindle
+        delivery, naming, post-processing and partial tolerance all match.
+        The worker dedups the task id, so a queued/active chapter is a
+        no-op there too."""
+        try:
+            from ...downloader import ChapterWithSource
+            from ...scrapers.base import Chapter
+        except Exception:
+            return
+        number = str(entry.get("number", ""))
+        if not number:
+            return
+        title = self._manga.get("title", "")
+        # Guard the double-check race: a completion could have landed
+        # between resolve and here.
+        if self.app.app_state.is_chapter_downloaded(title, number):
+            return
+        url = entry.get("url") or entry.get("source_url") or ""
+        if not url:
+            return
+        source = entry.get("source", "")
+        source_url = entry.get("source_url") or url
+        is_backup = bool(entry.get("is_backup", False))
+        ch_title = entry.get("title") or ""
+        base = Chapter(number=number, title=ch_title, url=url, date=None)
+        chapter = ChapterWithSource(base, source, source_url, is_backup=is_backup)
+
+        cfg = self.app.config
+        kindle_cfg = None
+        global_email_on = (cfg.delivery_mode == "email" and cfg.email_enabled)
+        if global_email_on and self._manga.get("send_to_kindle", True):
+            try:
+                from ...config import get_app_password
+                kindle_cfg = dict(
+                    kindle_email=cfg.get("email.kindle_email"),
+                    sender_email=cfg.get("email.sender_email"),
+                    app_password=get_app_password(cfg),
+                    smtp_server=cfg.get("email.smtp_server", "smtp.gmail.com"),
+                    smtp_port=cfg.get("email.smtp_port", 587),
+                )
+            except Exception:
+                kindle_cfg = None
+
+        self.app.worker.download_chapter(
+            manga=self._manga, chapter=chapter,
+            output_dir=cfg.download_dir,
+            output_format=cfg.output_format,
+            state=self.app.app_state, kindle_cfg=kindle_cfg,
+            naming_template=cfg.get("delivery.naming_template"),
+            post_processing=cfg.get("delivery.post_processing"),
+            allow_partial=cfg.partial_enabled,
+            partial_threshold=cfg.partial_threshold,
+        )
+
+    def _maybe_prefetch_fallback(self, title):
+        """Missing-cache fallback: kick off one forced check so the next
+        chapter metadata can be populated, then retry on the matching
+        completion. The per-chapter attempt key bounds source failures to
+        one lookup for each reader load."""
+        key = "%s:%s" % (title, self._chapter)
+        if (self._prefetch_fallback_key is not None
+                or self._prefetch_fallback_attempted_key == key):
+            return
+        worker = self.app.worker
+        if getattr(worker, "_is_offline", None) and worker._is_offline():
+            return
+        self._prefetch_fallback_key = key
+        self._prefetch_fallback_attempted_key = key
+        try:
+            worker.check_updates(
+                [self._manga], self.app.app_state, self.app.config, force=True,
+                request_id=key)
+        except Exception:
+            self._prefetch_fallback_key = None
+
+    def _on_check_complete(self, data):
+        """A fallback check we started finished -- its results are cached
+        now, so retry the prefetch and reveal Next if a successor
+        appeared. Ignores checks we did not initiate."""
+        if (self._prefetch_fallback_key is None
+                or data.get("request_id") != self._prefetch_fallback_key):
+            return
+        self._prefetch_fallback_key = None
+        if not self._manga:
+            return
+        self._refresh_next_controls()
+        entry = self._resolve_next_chapter_entry()
+        if entry is not None and entry is not _PREFETCH_SKIP:
+            self._queue_prefetch(entry)
+
+    def _on_download_complete(self, data):
+        """A background download finished. If it belongs to the manga we
+        are reading, refresh the Next controls so a chapter prefetched
+        mid-read becomes navigable without reloading the current one."""
+        if not self._manga:
+            return
+        if data.get("title") != self._manga.get("title", ""):
+            return
+        self._refresh_next_controls()
+
+    def _next_footer_label(self, downloaded, idx):
+        """Caption for the continuous-mode footer button, resolved from
+        the downloaded list at build/refresh time -- never captured -- so
+        a chapter prefetched mid-read shows its real number once
+        _refresh_next_controls reveals the button (issue #107)."""
+        if 0 <= idx < len(downloaded) - 1:
+            return f"Next: Chapter {downloaded[idx + 1]} >>"
+        return "Next Chapter >>"
+
+    def _refresh_next_controls(self):
+        """Re-evaluate whether a next downloaded chapter exists and
+        show/hide the Next controls accordingly. Safe to call after a
+        background download completes -- it never rebuilds the reader and
+        tolerates widgets already torn down by a reload."""
+        if not self._manga or self._chapter is None:
+            return
+        title = self._manga.get("title", "")
+        downloaded = self.app.app_state.get_downloaded_chapters(title)
+        try:
+            idx = downloaded.index(str(self._chapter))
+        except ValueError:
+            idx = -1
+        has_next = 0 <= idx < len(downloaded) - 1
+        if self._next_footer_btn is not None:
+            try:
+                self._next_footer_btn.setText(
+                    self._next_footer_label(downloaded, idx))
+            except RuntimeError:
+                pass
+        for widget in (self._next_btn, self._next_footer):
+            if widget is None:
+                continue
+            try:
+                widget.setVisible(has_next)
+            except RuntimeError:
+                # Widget was deleted by a chapter reload; the fresh build
+                # will re-evaluate visibility itself.
+                pass

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -579,6 +579,22 @@ class SettingsPage(BasePage):
 
         f.addSpacing(T.PAD_XL)
 
+        # Reader prefetch (issue #107)
+        self._section(f, "Reader")
+        prefetch_hint = QLabel(
+            "While reading a manual-mode manga, download the next chapter "
+            "in the background so Next continues without leaving the reader."
+        )
+        prefetch_hint.setProperty("role", "hint")
+        prefetch_hint.setWordWrap(True)
+        f.addWidget(prefetch_hint)
+
+        self._prefetch_check = QCheckBox("Prefetch the next chapter while reading")
+        self._prefetch_check.setChecked(self.app.config.reader_prefetch_enabled)
+        f.addWidget(self._prefetch_check)
+
+        f.addSpacing(T.PAD_XL)
+
         # Post-processing
         self._section(f, "Post-Processing")
 
@@ -895,6 +911,10 @@ class SettingsPage(BasePage):
             cfg.set("partial_chapters.enabled", self._partial_check.isChecked())
             cfg.set("partial_chapters.threshold_percent", int(self._partial_threshold.value()))
 
+        # Reader prefetch (issue #107)
+        if hasattr(self, "_prefetch_check"):
+            cfg.set("gui.reader_prefetch_next", self._prefetch_check.isChecked())
+
         cfg.save()
         Toast(self, "Settings saved", kind="success")
 
@@ -949,6 +969,9 @@ class SettingsPage(BasePage):
             self._partial_check.setChecked(cfg.partial_enabled)
             self._partial_threshold.setValue(int(round(cfg.partial_threshold)))
             self._partial_threshold.setEnabled(self._partial_check.isChecked())
+
+        if hasattr(self, "_prefetch_check"):
+            self._prefetch_check.setChecked(cfg.reader_prefetch_enabled)
 
         self._refresh_filename_preview()
 

--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -213,7 +213,8 @@ class BackgroundWorker:
     # ------------------------------------------------------------------
 
     def check_updates(self, manga_list: list, state, config,
-                      force: bool = False, queue_all: bool = False):
+                      force: bool = False, queue_all: bool = False,
+                      request_id=None):
         """Check for new chapters across a list of manga.
 
         The library-wide sweep only checks manga whose status is
@@ -230,15 +231,36 @@ class BackgroundWorker:
         are otherwise only surfaced, never auto-queued.
         """
         import sys as _sys
+
+        def _complete_payload(results, **extra):
+            payload = {"results": results, **extra}
+            if request_id is not None:
+                payload["request_id"] = request_id
+            return payload
+
+        def _error_payload(title, error):
+            # Issue #107: errors carry the caller's request_id too, so a
+            # correlated background check (the reader prefetch fallback)
+            # can be kept out of the user-facing error surfaces while
+            # ordinary checks keep their notifications/toasts.
+            payload = {"title": title, "error": error}
+            if request_id is not None:
+                payload["request_id"] = request_id
+            return payload
+
+        def _progress_payload(current, total, title):
+            payload = {"current": current, "total": total, "title": title}
+            if request_id is not None:
+                payload["request_id"] = request_id
+            return payload
+
         # Short-circuit when we know we're offline. Every per-manga
         # check_for_updates() would otherwise burn 30 s × 3 retries
         # against an unreachable host.
         if self._is_offline():
-            self._events.publish("check_error", {
-                "title": "Offline",
-                "error": "Can't check for updates while offline.",
-            })
-            self._events.publish("check_complete", {"results": []})
+            self._events.publish("check_error", _error_payload(
+                "Offline", "Can't check for updates while offline."))
+            self._events.publish("check_complete", _complete_payload([]))
             return
         print(f"[Check] check_updates called with {len(manga_list)} manga", flush=True)
         for m in manga_list:
@@ -253,8 +275,9 @@ class BackgroundWorker:
                 print(f"[Check] FATAL: Failed to import downloader: {e}", flush=True)
                 traceback.print_exc()
                 _sys.stdout.flush()
-                self._events.publish("check_error", {"title": "Import Error", "error": str(e)})
-                self._events.publish("check_complete", {"results": []})
+                self._events.publish(
+                    "check_error", _error_payload("Import Error", str(e)))
+                self._events.publish("check_complete", _complete_payload([]))
                 return
             results = []
             _sys.stdout.flush()
@@ -265,11 +288,10 @@ class BackgroundWorker:
                     continue
                 title = manga.get("title", "")
                 print(f"[Check] Checking '{title}' ({i+1}/{len(manga_list)})", flush=True)
-                self._events.publish("check_progress", {
-                    "current": i + 1,
-                    "total": len(manga_list),
-                    "title": title,
-                })
+                self._events.publish(
+                    "check_progress",
+                    _progress_payload(i + 1, len(manga_list), title),
+                )
 
                 # Determine source domain for health tracking
                 sources = manga.get("sources", [])
@@ -303,13 +325,13 @@ class BackgroundWorker:
                     # Mark source unhealthy
                     if domain:
                         state.update_source_health(domain, success=False, error_msg=str(e))
-                    self._events.publish("check_error", {
-                        "title": title, "error": str(e),
-                    })
+                    self._events.publish(
+                        "check_error", _error_payload(title, str(e)))
             print(f"[Check] Done. Total results: {len(results)} manga with new chapters", flush=True)
-            self._events.publish("check_complete", {
-                "results": results, "queue_all": queue_all,
-            })
+            self._events.publish(
+                "check_complete",
+                _complete_payload(results, queue_all=queue_all),
+            )
 
         self._safe_submit(_task)
 
@@ -329,6 +351,11 @@ class BackgroundWorker:
         caller opts in.
         """
         task_id = f"{manga['title']}:{chapter.number}"
+        # Issue #107: drop duplicate requests for a chapter that is
+        # already active or queued (its cancel flag stays registered
+        # until the job finishes). The reader prefetch, a Detail-page
+        # click and quick chapter changes could otherwise race the same
+        # title:chapter task id into the queue twice.
         # Refuse to enqueue while offline — the request would just
         # block a worker slot until per-source retries time out.
         # Surfacing `download_error` lets the Downloads page + Toast
@@ -342,25 +369,29 @@ class BackgroundWorker:
                 "offline": True,
             })
             return
-        cancel = threading.Event()
-        self._cancel_flags[task_id] = cancel
-
-        item = {
-            "task_id": task_id,
-            "manga": manga,
-            "chapter": chapter,
-            "output_dir": output_dir,
-            "output_format": output_format,
-            "state": state,
-            "kindle_cfg": kindle_cfg,
-            "naming_template": naming_template,
-            "post_processing": post_processing,
-            "cancel": cancel,
-            "allow_partial": allow_partial,
-            "partial_threshold": partial_threshold,
-        }
-
         with self._lock:
+            # Check and register under the same lock: reader windows and
+            # Detail-page actions can enqueue from separate GUI callbacks,
+            # and a check outside the lock leaves a duplicate race.
+            existing = self._cancel_flags.get(task_id)
+            if existing is not None and not existing.is_set():
+                return
+            cancel = threading.Event()
+            self._cancel_flags[task_id] = cancel
+            item = {
+                "task_id": task_id,
+                "manga": manga,
+                "chapter": chapter,
+                "output_dir": output_dir,
+                "output_format": output_format,
+                "state": state,
+                "kindle_cfg": kindle_cfg,
+                "naming_template": naming_template,
+                "post_processing": post_processing,
+                "cancel": cancel,
+                "allow_partial": allow_partial,
+                "partial_threshold": partial_threshold,
+            }
             paused = self._paused
             if (not paused) and self._active_downloads < self._max_concurrent_downloads:
                 self._active_downloads += 1

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -16,15 +16,29 @@ from typing import List, Optional, Dict, Any, Mapping
 from .backup import merge_backup_state
 
 
-_LEADING_CHAPTER_RE = re.compile(r"\s*(\d+(?:\.\d+)?)")
+_CHAPTER_NUMBER_RE = re.compile(r"(\d+(?:\.\d+)?)")
 
 
-def _leading_chapter_number(label: Any) -> Optional[float]:
-    """Return the leading numeric chapter value, if the label starts with one."""
-    match = _LEADING_CHAPTER_RE.match(str(label))
+def _chapter_number(label: Any) -> Optional[float]:
+    """Return the first numeric chapter value embedded in a label."""
+    match = _CHAPTER_NUMBER_RE.search(str(label))
     if not match:
         return None
     return float(match.group(1))
+
+
+def _chapter_sort_key(chapter) -> float:
+    """Numeric sort key for a chapter identifier.
+
+    Mirrors Chapter.numeric (scrapers/base.py): plain numbers sort by
+    value and labelled numbers like "2 Part 1" or "Chapter 10" by their
+    first embedded number, so labelled chapters land after their plain
+    predecessors and the reader's Next controls can reach a prefetched
+    "2 Part 1" from chapter "1" (issue #107). Fully non-numeric labels
+    keep the old float()-only fallback of 0.0.
+    """
+    num = _chapter_number(chapter)
+    return num if num is not None else 0.0
 
 
 class State:
@@ -163,13 +177,6 @@ class State:
             data[key] = self._snapshot(value)
             self.save()
 
-    @staticmethod
-    def _chapter_sort_key(chapter):
-        try:
-            return float(chapter)
-        except (TypeError, ValueError):
-            return 0.0
-
     def merge_missing_manga_state(
         self,
         imported_state: Dict[str, Any],
@@ -246,10 +253,7 @@ class State:
             chapter_str = str(chapter)
             if chapter_str not in entry["downloaded"]:
                 entry["downloaded"].append(chapter_str)
-                def _sort_key(x):
-                    num = _leading_chapter_number(x)
-                    return num if num is not None else 0.0
-                entry["downloaded"].sort(key=_sort_key)
+                entry["downloaded"].sort(key=_chapter_sort_key)
 
             entry["last_chapter"] = chapter_str
             entry["last_updated"] = datetime.now().isoformat()
@@ -635,12 +639,7 @@ class State:
             ch_str = str(chapter)
             if ch_str not in entry["external_chapters"]:
                 entry["external_chapters"].append(ch_str)
-
-                def _sort_key(x):
-                    num = _leading_chapter_number(x)
-                    return num if num is not None else 0.0
-
-                entry["external_chapters"].sort(key=_sort_key)
+                entry["external_chapters"].sort(key=_chapter_sort_key)
                 self._mark_dirty()
 
     def get_external_chapters(self, manga_title: str) -> List[str]:
@@ -830,11 +829,11 @@ class State:
                 entry["downloaded"] = []
             else:
                 # Keep only chapters before from_chapter, remove the rest.
-                # Part-style labels (e.g. "3 Part 1") compare by their leading
-                # chapter number. Labels with no leading number are preserved
+                # Labelled chapters (e.g. "Chapter 3" or "3 Part 1") compare
+                # by their embedded chapter number. Labels with no number are preserved
                 # because they cannot be ordered safely against the threshold.
                 def _keep_downloaded(ch):
-                    num = _leading_chapter_number(ch)
+                    num = _chapter_number(ch)
                     return num is None or num < from_chapter
 
                 entry["downloaded"] = [

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -722,6 +722,23 @@ class TestDownloadsQueueing:
         })
         assert queued == []
 
+    def test_correlated_check_complete_does_not_toast_manual_results(
+            self, app_window, qapp, sample_manga, mocker):
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+        toast = mocker.patch("memanga.gui.pages.downloads.Toast")
+
+        page._on_check_complete({
+            "results": [self._result(sample_manga, "1", "2")],
+            "request_id": f"{sample_manga['title']}:1",
+        })
+        toast.assert_not_called()
+
+        page._on_check_complete({
+            "results": [self._result(sample_manga, "1", "2")],
+        })
+        toast.assert_called_once()
+
     def test_explicit_download_skips_already_downloaded(self, app_window, qapp,
                                                         sample_manga):
         app_window.show_page("downloads"); qapp.processEvents()

--- a/tests/unit/gui/pages/test_reader_prefetch.py
+++ b/tests/unit/gui/pages/test_reader_prefetch.py
@@ -1,0 +1,488 @@
+"""
+Reader prefetch of the next manual-mode chapter (issue #107).
+
+Covers the setting gate, manual-mode-only behavior, the already-downloaded
+skip, worker-level duplicate prevention, reader Next-control refresh after a
+prefetch completes, and the cache-miss fallback lookup.
+"""
+
+def _setup_manga(app_window, *, mode="manual", available=None,
+                 downloaded=None, current="1"):
+    """Register a manga on the reader page + seed its cached chapter list
+    and downloaded set, returning the reader page ready to prefetch."""
+    title = "Prefetch Manga"
+    manga = {
+        "title": title,
+        "url": "https://mock.test/title/pf",
+        "source": "mock.test",
+        "status": "reading",
+        "mode": mode,
+        "send_to_kindle": False,
+    }
+    state = app_window.app_state
+    for num in (downloaded or []):
+        state.add_downloaded_chapter(title, num)
+    if available is not None:
+        state.set_available_chapters(title, available)
+    page = app_window._pages["reader"]
+    page._manga = manga
+    page._chapter = current
+    return page, title
+
+
+def _avail(*numbers):
+    """Build cached available-chapters entries the resolver understands."""
+    return [
+        {"number": str(n), "title": f"Ch {n}",
+         "url": f"https://mock.test/c/{n}",
+         "source": "mock.test",
+         "source_url": f"https://mock.test/c/{n}",
+         "is_backup": False}
+        for n in numbers
+    ]
+
+
+def _capture_downloads(page):
+    """Replace worker.download_chapter with a call recorder."""
+    calls = []
+    page.app.worker.download_chapter = lambda **kw: calls.append(kw)
+    return calls
+
+
+class TestPrefetchGating:
+    def test_disabled_by_default_no_prefetch(self, app_window):
+        page, _ = _setup_manga(
+            app_window, available=_avail(1, 2, 3), downloaded=["1"])
+        calls = _capture_downloads(page)
+        assert page.app.config.reader_prefetch_enabled is False
+        page._maybe_prefetch_next()
+        assert calls == []
+
+    def test_auto_mode_never_prefetches(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, _ = _setup_manga(
+            app_window, mode="auto", available=_avail(1, 2, 3),
+            downloaded=["1"])
+        calls = _capture_downloads(page)
+        page._maybe_prefetch_next()
+        assert calls == []
+
+    def test_manual_mode_prefetches_immediate_next(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, _ = _setup_manga(
+            app_window, available=_avail(1, 2, 3), downloaded=["1"])
+        calls = _capture_downloads(page)
+        page._maybe_prefetch_next()
+        assert len(calls) == 1
+        assert calls[0]["chapter"].number == "2"
+
+    def test_next_already_downloaded_is_skipped(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        # Immediate next after ch1 is ch2, which is already on disk.
+        page, _ = _setup_manga(
+            app_window, available=_avail(1, 2, 3), downloaded=["1", "2"])
+        calls = _capture_downloads(page)
+        page._maybe_prefetch_next()
+        assert calls == []
+
+    def test_stale_cache_forces_lookup_then_prefetches_successor(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, title = _setup_manga(
+            app_window, available=_avail(1), downloaded=["1"])
+        downloads = _capture_downloads(page)
+        checks = []
+        page.app.worker.check_updates = lambda *args, **kwargs: checks.append(kwargs)
+
+        page._maybe_prefetch_next()
+        page._maybe_prefetch_next()
+
+        assert downloads == []
+        assert len(checks) == 1
+        assert checks[0]["force"] is True
+        assert checks[0]["request_id"] == f"{title}:1"
+
+        page.app.app_state.set_available_chapters(title, _avail(1, 2))
+        page._on_check_complete({"results": [], "request_id": f"{title}:1"})
+
+        assert [call["chapter"].number for call in downloads] == ["2"]
+
+
+class TestDuplicatePrevention:
+    def test_worker_drops_duplicate_task_id(self, app_window):
+        from memanga.scrapers.base import Chapter
+        worker = app_window.worker
+        # Pause so submitted jobs sit in the queue where we can count them.
+        worker.pause_all()
+        manga = {"title": "Dup Manga"}
+        ch = Chapter(number="7", title="c7", url="https://mock.test/c/7")
+        common = dict(
+            manga=manga, chapter=ch, output_dir="/tmp",
+            output_format="cbz", state=app_window.app_state)
+        worker.download_chapter(**common)
+        worker.download_chapter(**common)
+        queued = [i for i in worker._download_queue
+                  if i["task_id"] == "Dup Manga:7"]
+        assert len(queued) == 1
+
+    def test_prefetch_twice_queues_once(self, app_window):
+        # End-to-end: two prefetch passes for the same successor must not
+        # double-queue (worker cancel-flag dedup backs the reader).
+        app_window.config.set("gui.reader_prefetch_next", True)
+        app_window.worker.pause_all()
+        page, title = _setup_manga(
+            app_window, available=_avail(1, 2, 3), downloaded=["1"])
+        page._maybe_prefetch_next()
+        page._maybe_prefetch_next()
+        queued = [i for i in app_window.worker._download_queue
+                  if i["task_id"] == f"{title}:2"]
+        assert len(queued) == 1
+
+
+class TestFallbackAndRefresh:
+    def test_missing_cache_forces_one_correlated_lookup(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, title = _setup_manga(app_window, downloaded=["1"])
+        calls = []
+        page.app.worker.check_updates = lambda *args, **kwargs: calls.append(kwargs)
+
+        page._maybe_prefetch_next()
+        page._maybe_prefetch_next()
+
+        assert len(calls) == 1
+        assert calls[0]["force"] is True
+        assert calls[0]["request_id"] == f"{title}:1"
+
+        # An unrelated library check must not consume the in-flight fallback.
+        page._on_check_complete({"results": [], "request_id": None})
+        assert page._prefetch_fallback_key == f"{title}:1"
+
+    def test_failed_fallback_is_not_retried_for_same_chapter(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, title = _setup_manga(app_window, downloaded=["1"])
+        checks = []
+        page.app.worker.check_updates = lambda *args, **kwargs: checks.append(kwargs)
+
+        page._maybe_prefetch_next()
+        page._on_check_complete({"results": [], "request_id": f"{title}:1"})
+        page._maybe_prefetch_next()
+
+        assert len(checks) == 1
+
+    def test_stale_cache_fallback_not_retried_after_empty_completion(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, title = _setup_manga(
+            app_window, available=_avail(1), downloaded=["1"])
+        checks = []
+        page.app.worker.check_updates = lambda *args, **kwargs: checks.append(kwargs)
+
+        page._maybe_prefetch_next()
+        page._on_check_complete({"results": [], "request_id": f"{title}:1"})
+        page._maybe_prefetch_next()
+
+        assert len(checks) == 1
+
+    def test_matching_fallback_queues_newly_cached_successor(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, title = _setup_manga(app_window, downloaded=["1"])
+        page.app.worker.check_updates = lambda *args, **kwargs: None
+        downloads = _capture_downloads(page)
+
+        page._maybe_prefetch_next()
+        page.app.app_state.set_available_chapters(title, _avail(1, 2))
+        page._on_check_complete({"results": [], "request_id": f"{title}:1"})
+
+        assert [call["chapter"].number for call in downloads] == ["2"]
+
+    def test_download_completion_refreshes_next_controls(self, app_window, mocker):
+        page, title = _setup_manga(app_window, downloaded=["1"], current="1")
+        refresh = mocker.patch.object(page, "_refresh_next_controls")
+
+        page._on_download_complete({"title": "Other", "chapter": "2"})
+        refresh.assert_not_called()
+        page._on_download_complete({"title": title, "chapter": "2"})
+        refresh.assert_called_once_with()
+
+
+class TestContinuousFooter:
+    """Regression: the continuous-mode footer once referenced next_ch,
+    which stopped being assigned when Next navigation went dynamic --
+    crashing every reader load in the default view mode."""
+
+    def _load_reader(self, app_window, qapp, sample_manga, make_cbz,
+                     chapters):
+        from pathlib import Path
+        title = sample_manga["title"]
+        app_window.config.set("manga", [sample_manga])
+        dl = Path(app_window.config.download_dir) / title
+        dl.mkdir(parents=True, exist_ok=True)
+        for n in chapters:
+            cbz = make_cbz(pages=2, name="c%s.cbz" % n)
+            dest = dl / ("%s - Chapter %s.cbz" % (title, n))
+            dest.write_bytes(cbz.read_bytes())
+            app_window.app_state.add_downloaded_chapter(title, str(n))
+        app_window.show_page("reader", manga=sample_manga, chapter="1")
+        qapp.processEvents()
+        return app_window._pages["reader"]
+
+    def test_footer_builds_without_successor(self, app_window, qapp,
+                                             sample_manga, make_cbz):
+        reader = self._load_reader(
+            app_window, qapp, sample_manga, make_cbz, ["1"])
+        assert len(reader._images) >= 1
+        assert reader._next_footer is not None
+        assert reader._next_footer.isHidden()
+
+    def test_footer_labels_downloaded_successor(self, app_window, qapp,
+                                                sample_manga, make_cbz):
+        reader = self._load_reader(
+            app_window, qapp, sample_manga, make_cbz, ["1", "2"])
+        assert not reader._next_footer.isHidden()
+        assert reader._next_footer_btn.text() == "Next: Chapter 2 >>"
+
+    def test_prefetch_completion_reveals_footer(self, app_window, qapp,
+                                                sample_manga, make_cbz):
+        reader = self._load_reader(
+            app_window, qapp, sample_manga, make_cbz, ["1"])
+        title = sample_manga["title"]
+        assert reader._next_footer.isHidden()
+        # A prefetched chapter 2 lands mid-read.
+        app_window.app_state.add_downloaded_chapter(title, "2")
+        reader._on_download_complete(dict(title=title, chapter="2"))
+        assert not reader._next_footer.isHidden()
+        assert not reader._next_btn.isHidden()
+        assert reader._next_footer_btn.text() == "Next: Chapter 2 >>"
+
+    def test_prefetch_completion_reveals_labelled_footer(self, app_window,
+                                                         qapp, sample_manga,
+                                                         make_cbz):
+        # A labelled successor like "2 Part 1" must sort after the
+        # current "1" in state, or the Next controls stay hidden even
+        # though the prefetch downloaded it (issue #107).
+        reader = self._load_reader(
+            app_window, qapp, sample_manga, make_cbz, ["1"])
+        title = sample_manga["title"]
+        assert reader._next_footer.isHidden()
+        app_window.app_state.add_downloaded_chapter(title, "2 Part 1")
+        reader._on_download_complete(dict(title=title, chapter="2 Part 1"))
+        assert not reader._next_footer.isHidden()
+        assert not reader._next_btn.isHidden()
+        assert reader._next_footer_btn.text() == "Next: Chapter 2 Part 1 >>"
+
+
+class TestOfflineSkip:
+    def test_offline_no_ops_prefetch(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, _ = _setup_manga(
+            app_window, available=_avail(1, 2, 3), downloaded=["1"])
+        calls = _capture_downloads(page)
+        checks = []
+        page.app.worker.check_updates = lambda *a, **kw: checks.append(kw)
+        page.app.worker._is_offline = lambda: True
+        page._maybe_prefetch_next()
+        assert calls == []
+        assert checks == []
+
+    def test_offline_no_ops_fallback_lookup(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        # No cached chapter list, so the fallback path would fire.
+        page, title = _setup_manga(app_window, downloaded=["1"])
+        checks = []
+        page.app.worker.check_updates = lambda *a, **kw: checks.append(kw)
+        page.app.worker._is_offline = lambda: True
+        page._maybe_prefetch_next()
+        page._maybe_prefetch_fallback(title)
+        assert checks == []
+        assert page._prefetch_fallback_key is None
+
+
+class TestSilentFallbackErrors:
+    def test_worker_tags_check_error_with_request_id(self, app_window):
+        worker = app_window.worker
+        worker._is_offline = lambda: True
+        seen = []
+        app_window.events.subscribe("check_error", lambda d: seen.append(d))
+        worker.check_updates(
+            [], app_window.app_state, app_window.config,
+            force=True, request_id="Prefetch Manga:1")
+        app_window.events.poll()
+        assert [d.get("request_id") for d in seen] == ["Prefetch Manga:1"]
+
+    def test_app_skips_notification_for_correlated_error(self, app_window):
+        before = len(app_window.app_state.get_notifications())
+        app_window._on_check_error(
+            dict(title="T", error="boom", request_id="T:1"))
+        assert len(app_window.app_state.get_notifications()) == before
+
+    def test_app_keeps_notification_for_normal_error(self, app_window):
+        before = len(app_window.app_state.get_notifications())
+        app_window._on_check_error(dict(title="T", error="boom"))
+        assert len(app_window.app_state.get_notifications()) == before + 1
+
+    def test_downloads_toast_skipped_for_correlated_error(self, app_window,
+                                                          mocker):
+        toast = mocker.patch("memanga.gui.pages.downloads.Toast")
+        page = app_window._pages["downloads"]
+        page._on_check_error(dict(title="T", error="boom", request_id="T:1"))
+        toast.assert_not_called()
+        page._on_check_error(dict(title="T", error="boom"))
+        toast.assert_called_once()
+
+
+class TestSilentFallbackCompletions:
+    def _result(self, manga, *available):
+        import types
+
+        all_chapters = [
+            types.SimpleNamespace(
+                number=str(n), title=f"Ch {n}", url=f"https://mock.test/c/{n}",
+                source=manga.get("source", "mock.test"),
+                source_url=f"https://mock.test/c/{n}",
+                is_backup=False,
+            )
+            for n in available
+        ]
+        return {
+            "manga": manga,
+            "chapters": all_chapters[-1:],
+            "all_chapters": all_chapters,
+        }
+
+    def test_app_caches_correlated_completion_without_global_side_effects(
+            self, app_window, mocker):
+        manga = {
+            "title": "Quiet Complete Manga",
+            "url": "https://mock.test/title/qc",
+            "source": "mock.test",
+            "mode": "manual",
+        }
+        notifications_before = len(app_window.app_state.get_notifications())
+        history_before = app_window.app_state.get_check_history()
+        added = []
+        silent = []
+        app_window.events.subscribe("notification_added",
+                                    lambda d: added.append(d))
+        app_window.events.subscribe("check_complete_silent",
+                                    lambda d: silent.append(d))
+        refresh = mocker.patch.object(app_window._sidebar, "_refresh_badges")
+        sync_done = mocker.patch.object(app_window._sidebar, "_on_check_done")
+
+        app_window.events.publish("check_complete", {
+            "results": [self._result(manga, 1, 2)],
+            "request_id": f"{manga['title']}:1",
+        })
+        app_window.events.poll()
+
+        cached = app_window.app_state.get_available_chapters(manga["title"])
+        assert [c["number"] for c in cached] == ["1", "2"]
+        assert app_window.app_state.get_new_chapters(manga["title"]) == 0
+        assert len(app_window.app_state.get_notifications()) == notifications_before
+        assert app_window.app_state.get_check_history() == history_before
+        assert added == []
+        assert silent == []
+        refresh.assert_not_called()
+        sync_done.assert_not_called()
+
+    def test_sidebar_ignores_correlated_progress_and_completion(
+            self, app_window, qapp):
+        sidebar = app_window._sidebar
+        initial = {
+            "status": sidebar._sync_status.text(),
+            "counter": sidebar._sync_counter.text(),
+            "progress": sidebar._sync_progress.value(),
+            "active": sidebar._sync_dot._active,
+        }
+
+        app_window.events.publish("check_progress", {
+            "current": 1,
+            "total": 1,
+            "title": "Quiet Complete Manga",
+            "request_id": "Quiet Complete Manga:1",
+        })
+        app_window.events.publish("check_complete", {
+            "results": [],
+            "request_id": "Quiet Complete Manga:1",
+        })
+        app_window.events.poll()
+        qapp.processEvents()
+
+        assert sidebar._sync_status.text() == initial["status"]
+        assert sidebar._sync_counter.text() == initial["counter"]
+        assert sidebar._sync_progress.value() == initial["progress"]
+        assert sidebar._sync_dot._active == initial["active"] is False
+
+        app_window.events.publish("check_progress", {
+            "current": 1,
+            "total": 2,
+            "title": "Visible Manga",
+        })
+        app_window.events.poll()
+
+        assert sidebar._sync_status.text() == "Checking…"
+        assert sidebar._sync_counter.text() == "1/2"
+        assert sidebar._sync_progress.value() == 50
+        assert sidebar._sync_dot._active is True
+
+        app_window.events.publish("check_complete", {"results": []})
+        app_window.events.poll()
+        qapp.processEvents()
+
+        assert sidebar._sync_status.text() == "All caught up"
+        assert sidebar._sync_progress.value() == 100
+        assert sidebar._sync_dot._active is False
+
+
+class TestLabelledChapterNumbers:
+    def test_prefetch_resolves_labelled_successor(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, _ = _setup_manga(
+            app_window, available=_avail("1", "2 Part 1", "Chapter 3"),
+            downloaded=["1"])
+        calls = _capture_downloads(page)
+        page._maybe_prefetch_next()
+        assert len(calls) == 1
+        assert calls[0]["chapter"].number == "2 Part 1"
+
+    def test_prefetch_resolves_labelled_current_chapter(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, _ = _setup_manga(
+            app_window, available=_avail("Chapter 1", "Chapter 2"),
+            downloaded=["Chapter 1"], current="Chapter 1")
+        calls = _capture_downloads(page)
+        page._maybe_prefetch_next()
+        assert len(calls) == 1
+        assert calls[0]["chapter"].number == "Chapter 2"
+
+    def test_unparseable_current_chapter_skips(self, app_window):
+        app_window.config.set("gui.reader_prefetch_next", True)
+        page, _ = _setup_manga(
+            app_window, available=_avail("1", "2"),
+            downloaded=["Extra"], current="Extra")
+        calls = _capture_downloads(page)
+        page._maybe_prefetch_next()
+        assert calls == []
+
+
+class TestDownloadKwargsPropagation:
+    def test_prefetch_uses_configured_delivery_settings(self, app_window):
+        cfg = app_window.config
+        cfg.set("gui.reader_prefetch_next", True)
+        cfg.set("delivery.output_format", "epub")
+        cfg.set("delivery.naming_template", "custom-template")
+        post = dict(enabled=True, command="echo done", fail_on_error=False)
+        cfg.set("delivery.post_processing", post)
+        cfg.set("partial_chapters.enabled", True)
+        cfg.set("partial_chapters.threshold_percent", 12)
+        page, _ = _setup_manga(
+            app_window, available=_avail(1, 2), downloaded=["1"])
+        calls = _capture_downloads(page)
+        page._maybe_prefetch_next()
+        assert len(calls) == 1
+        call = calls[0]
+        assert call["output_format"] == "epub"
+        assert call["output_dir"] == cfg.download_dir
+        assert call["naming_template"] == "custom-template"
+        assert call["post_processing"] == post
+        assert call["allow_partial"] is True
+        assert call["partial_threshold"] == 12
+        assert call["kindle_cfg"] is None
+        assert call["state"] is page.app.app_state

--- a/tests/unit/gui/test_workers.py
+++ b/tests/unit/gui/test_workers.py
@@ -764,6 +764,36 @@ class TestCheckUpdates:
         ], force=True)
         assert checked == ["Plan one"]
 
+    def test_correlated_check_tags_progress(self, worker, event_bus, state,
+                                            monkeypatch):
+        import time
+        import memanga.downloader as downloader
+
+        def _fake_check(_manga, _state, return_all=False):
+            return ([], []) if return_all else []
+
+        monkeypatch.setattr(downloader, "check_for_updates", _fake_check)
+
+        progress = []
+        done = []
+        event_bus.subscribe("check_progress", lambda d: progress.append(d))
+        event_bus.subscribe("check_complete", lambda d: done.append(d))
+
+        worker.check_updates([
+            {"title": "Correlated one", "status": "reading",
+             "source": "mock.test", "url": "u"},
+        ], state, config=None, force=True, request_id="Correlated one:1")
+
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline and not done:
+            event_bus.poll()
+            time.sleep(0.02)
+        event_bus.poll()
+
+        assert progress
+        assert progress[0]["request_id"] == "Correlated one:1"
+        assert done[0]["request_id"] == "Correlated one:1"
+
 
 class TestSearchRelevanceFilter:
     """Regression for the 'searching Blue Lock returns Beastars, Tokyo

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -103,6 +103,26 @@ class TestChapterTracking:
         st = state.get_manga_state("never-added")
         assert isinstance(st, dict)
 
+    def test_labelled_chapter_sorts_by_embedded_number(self, state):
+        # Issue #107: reader prefetch can download labelled chapters like
+        # "2 Part 1"; they must sort after "1" (by Chapter.numeric-style
+        # extraction) or the reader's Next controls never find them.
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "2 Part 1")
+        assert state.get_downloaded_chapters("X") == ["1", "2 Part 1"]
+
+    def test_labelled_chapters_interleave_with_plain_numbers(self, state):
+        for ch in ["10 Part 1", "Chapter 2", "1", "3"]:
+            state.add_downloaded_chapter("X", ch)
+        assert state.get_downloaded_chapters("X") == [
+            "1", "Chapter 2", "3", "10 Part 1"]
+
+    def test_nonnumeric_chapter_keeps_sort_first_fallback(self, state):
+        # Fully non-numeric labels keep the old 0.0 fallback (sort first).
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "Extra")
+        assert state.get_downloaded_chapters("X") == ["Extra", "1"]
+
 
 class TestExternalChapters:
     def test_mark_and_check_external(self, state):
@@ -427,6 +447,14 @@ class TestResetManga:
         state.add_downloaded_chapter("X", "2 Part 1")
         state.reset_manga_progress("X", from_chapter=0)
         assert state.get_downloaded_chapters("X") == []
+
+    def test_reset_with_threshold_handles_labelled_chapters(self, state):
+        # float("2 Part 1") raises; the threshold filter must use the
+        # same numeric extraction as the downloaded-list sort (issue #107).
+        for c in ["1", "2 Part 1", "Chapter 3", "4"]:
+            state.add_downloaded_chapter("X", c)
+        state.reset_manga_progress("X", from_chapter=3)
+        assert state.get_downloaded_chapters("X") == ["1", "2 Part 1"]
 
     def test_remove_manga(self, state):
         state.add_downloaded_chapter("X", "1")


### PR DESCRIPTION
## Summary

Adds an opt-in reader setting to prefetch the next chapter for manual-mode manga while reading, using the existing download queue. The reader now refreshes Next controls when a prefetched chapter completes, duplicate queue entries are suppressed, and labelled chapter numbers stay ordered so prefetched labels remain reachable.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Testing

- `./venv/bin/pytest tests/unit/test_state.py tests/unit/gui/pages/test_reader_prefetch.py -q` (75 passed)
- `./venv/bin/pytest tests/unit/gui/test_workers.py tests/unit/gui/test_network_status.py -q` (62 passed)
- `./venv/bin/pytest tests/unit/gui/pages/test_pages.py::TestReaderPage -q` (2 passed)
- `./venv/bin/python -m compileall memanga`
- `git diff --check`
- Offscreen runtime check confirmed one queued `Live Prefetch Manga:2 Part 1` task and visible Next controls after labelled prefetch completion.

## Related issues

Closes #107