### PR TITLE
fix(emailer): clarify Kindle attachment limits

### DIFF
--- a/memanga/emailer.py
+++ b/memanga/emailer.py
@@ -162,7 +162,11 @@ def send_to_kindle(
         is_split = len(parts) > 1
         
         if is_split:
-            print(f"     📎 Split into {len(parts)} parts (exceeded 25MB limit)")
+            print(
+                f"     📎 Split into {len(parts)} parts (exceeded "
+                f"{_format_mb(MAX_ATTACHMENT_SIZE)} safe raw attachment limit; "
+                f"encoded email cap is {_format_mb(EMAIL_ATTACHMENT_LIMIT)})"
+            )
     
     # Send each part
     for i, part_path in enumerate(parts):

--- a/memanga/emailer.py
+++ b/memanga/emailer.py
@@ -22,8 +22,15 @@ class EmailError(Exception):
     pass
 
 
-# Gmail limit is 25MB, use 23MB to be safe (base64 encoding adds ~33% overhead)
-MAX_ATTACHMENT_SIZE = 18 * 1024 * 1024  # 18MB raw (~24MB after base64, under Gmail's 25MB limit)
+# Gmail's attachment cap is 25MB after email encoding. Base64 adds roughly
+# 33%, so keep raw files lower to stay under the encoded cap.
+EMAIL_ATTACHMENT_LIMIT = 25 * 1024 * 1024
+MAX_ATTACHMENT_SIZE = 18 * 1024 * 1024  # 18MB raw (~24MB after base64)
+
+
+def _format_mb(size: int) -> str:
+    """Format a byte count as MiB for user-facing messages."""
+    return f"{size / (1024 * 1024):.1f}MB"
 
 
 def split_pdf(pdf_path: Path, max_size: int = MAX_ATTACHMENT_SIZE) -> List[Path]:
@@ -139,8 +146,13 @@ def send_to_kindle(
         if file_size > MAX_ATTACHMENT_SIZE:
             fmt = suffix.lstrip('.').upper()
             raise EmailError(
-                f"{fmt} file is {file_size / (1024*1024):.1f}MB, exceeding the 25MB email limit. "
-                f"{fmt} files cannot be split. Use PDF format instead (set in 'memanga config')."
+                f"{fmt} file is {_format_mb(file_size)}, exceeding MeManga's "
+                f"{_format_mb(MAX_ATTACHMENT_SIZE)} safe raw attachment limit. "
+                f"Email attachments are base64 encoded, so the raw file must "
+                f"stay below this limit to fit under the "
+                f"{_format_mb(EMAIL_ATTACHMENT_LIMIT)} encoded email cap. "
+                f"{fmt} files cannot be split. Use PDF format instead "
+                f"(set in 'memanga config')."
             )
         parts = [pdf_path]
         is_split = False

--- a/tests/unit/test_emailer_pipeline.py
+++ b/tests/unit/test_emailer_pipeline.py
@@ -111,6 +111,25 @@ class TestSendToKindle:
             with pytest.raises((EmailError, smtplib.SMTPException)):
                 _call_send(good_cfg, tiny_pdf)
 
+    def test_large_single_file_error_explains_raw_and_encoded_limits(
+        self, good_cfg, tmp_path
+    ):
+        from memanga.emailer import EmailError, MAX_ATTACHMENT_SIZE
+        cbz = tmp_path / "large.cbz"
+        cbz.write_bytes(b"0" * (MAX_ATTACHMENT_SIZE + 1024 * 1024))
+
+        with patch("smtplib.SMTP") as smtp:
+            with pytest.raises(EmailError) as exc_info:
+                _call_send(good_cfg, cbz)
+
+        msg = str(exc_info.value)
+        assert "CBZ file is 19.0MB" in msg
+        assert "18.0MB safe raw attachment limit" in msg
+        assert "25.0MB encoded email cap" in msg
+        assert "base64 encoded" in msg
+        assert "exceeding the 25MB email limit" not in msg
+        smtp.assert_not_called()
+
 
 # ─────────────────────────────────────────────────────────────────────
 # split_pdf — chunk huge PDFs under the attachment limit

--- a/tests/unit/test_emailer_pipeline.py
+++ b/tests/unit/test_emailer_pipeline.py
@@ -130,6 +130,20 @@ class TestSendToKindle:
         assert "exceeding the 25MB email limit" not in msg
         smtp.assert_not_called()
 
+    def test_pdf_split_message_explains_raw_and_encoded_limits(
+        self, good_cfg, tiny_pdf, capsys
+    ):
+        smtp = _make_smtp_mock()
+        with patch("memanga.emailer.split_pdf", return_value=[tiny_pdf, tiny_pdf]):
+            with patch("smtplib.SMTP", return_value=smtp):
+                _call_send(good_cfg, tiny_pdf)
+
+        msg = capsys.readouterr().out
+        assert "Split into 2 parts" in msg
+        assert "18.0MB safe raw attachment limit" in msg
+        assert "25.0MB" in msg
+        assert "exceeded 25MB limit" not in msg
+
 
 # ─────────────────────────────────────────────────────────────────────
 # split_pdf — chunk huge PDFs under the attachment limit


### PR DESCRIPTION
## Summary

Clarifies Kindle attachment limit messages so oversized CBZ/EPUB/ZIP files report MeManga's safe raw attachment limit separately from the encoded email cap. Also updates the PDF split progress notice to use the same raw/encoded wording.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Tests

- `python -m pytest tests/unit/test_emailer.py tests/unit/test_emailer_pipeline.py -q`
- `python -m compileall -q memanga tests`
- `git diff --check`

## Related issues

Closes #113