### PR TITLE
fix(state): synchronize state mutations

### DIFF
--- a/memanga/backup.py
+++ b/memanga/backup.py
@@ -49,6 +49,8 @@ def validate_backup(data: Any) -> dict:
             f"Backup version {version} is newer than this app supports "
             f"(max {EXPORT_VERSION}); update MeManga"
         )
+    if "state" in data and not isinstance(data["state"], dict):
+        raise BackupVersionError("Invalid backup: state must be an object")
 
     while version < EXPORT_VERSION:
         migrate = _MIGRATIONS.get(version)

--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -1377,8 +1377,6 @@ def cmd_import(args):
         # Merge mode: skip duplicates, merge chapter lists
         existing_manga = config.get("manga", [])
         existing_titles = {m["title"].lower() for m in existing_manga}
-        existing_state = state.get("manga", {})
-
         added = 0
         skipped = 0
         for m in imported_manga:
@@ -1389,28 +1387,12 @@ def cmd_import(args):
             existing_titles.add(m["title"].lower())
             added += 1
 
-        # Merge state (downloaded chapter lists)
-        for title, s in imported_state.items():
-            if title in existing_state:
-                # Merge downloaded lists
-                existing_downloaded = set(existing_state[title].get("downloaded", []))
-                imported_downloaded = set(s.get("downloaded", []))
-                def _sort_key(x):
-                    try:
-                        return float(x)
-                    except (ValueError, TypeError):
-                        return 0.0
-                merged = sorted(
-                    existing_downloaded | imported_downloaded,
-                    key=_sort_key,
-                )
-                existing_state[title]["downloaded"] = merged
-            else:
-                existing_state[title] = s
-
         config.set("manga", existing_manga)
         config.save()
-        state.set("manga", existing_state)
+        state.merge_missing_manga_state(
+            imported_state,
+            merge_existing_downloaded=True,
+        )
 
         console.print(f"[green]Imported: {added} added, {skipped} skipped (duplicate)[/green]")
 

--- a/memanga/gui/pages/detail.py
+++ b/memanga/gui/pages/detail.py
@@ -944,10 +944,7 @@ class DetailPage(BasePage):
                     m.pop("fallback_delay_days", None)
 
                 if new_title != old_title:
-                    old_state = self.app.app_state.get_manga_state(old_title)
-                    if old_state:
-                        self.app.app_state._data.setdefault("manga", {})[new_title] = old_state
-                        self.app.app_state.remove_manga(old_title)
+                    self.app.app_state.rename_manga(old_title, new_title)
                     # Move already-downloaded files to the new title so the
                     # reader can still find them (state migrates above, but
                     # the on-disk folder/filenames are keyed by title too).

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -1161,11 +1161,7 @@ class SettingsPage(BasePage):
                         existing.append(m)
                 self.app.config.set("manga", existing)
                 self.app.config.save()
-                merged_state = self.app.app_state.get("manga", {})
-                for t, sdata in data.get("state", {}).items():
-                    if not merged_state.get(t):
-                        merged_state[t] = sdata
-                self.app.app_state.set("manga", merged_state)
+                self.app.app_state.merge_missing_manga_state(data.get("state", {}))
                 Toast(self, f"Imported {added} manga", kind="success")
         except json.JSONDecodeError:
             Toast(self, "Invalid JSON", kind="error")

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -1121,7 +1121,7 @@ class SettingsPage(BasePage):
                 "version": EXPORT_VERSION,
                 "exported_at": datetime.now().isoformat(),
                 "manga": self.app.config.get("manga", []),
-                "state": self.app.app_state._data.get("manga", {}),
+                "state": self.app.app_state.get("manga", {}),
             }
             with open(path, "w") as f:
                 json.dump(data, f, indent=2, default=str)
@@ -1148,8 +1148,7 @@ class SettingsPage(BasePage):
             if replace:
                 self.app.config.set("manga", manga_list)
                 self.app.config.save()
-                self.app.app_state._data["manga"] = data.get("state", {})
-                self.app.app_state.save()
+                self.app.app_state.set("manga", data.get("state", {}))
                 Toast(self, f"Replaced with {len(manga_list)} manga", kind="success")
             else:
                 existing = self.app.config.get("manga", [])
@@ -1162,10 +1161,11 @@ class SettingsPage(BasePage):
                         existing.append(m)
                 self.app.config.set("manga", existing)
                 self.app.config.save()
+                merged_state = self.app.app_state.get("manga", {})
                 for t, sdata in data.get("state", {}).items():
-                    if not self.app.app_state.get_manga_state(t):
-                        self.app.app_state._data.setdefault("manga", {})[t] = sdata
-                self.app.app_state.save()
+                    if not merged_state.get(t):
+                        merged_state[t] = sdata
+                self.app.app_state.set("manga", merged_state)
                 Toast(self, f"Imported {added} manga", kind="success")
         except json.JSONDecodeError:
             Toast(self, "Invalid JSON", kind="error")

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -149,7 +149,19 @@ class State:
             data[key] = self._snapshot(value)
             self.save()
 
-    def merge_missing_manga_state(self, imported_state: Dict[str, Any]):
+    @staticmethod
+    def _chapter_sort_key(chapter):
+        try:
+            return float(chapter)
+        except (TypeError, ValueError):
+            return 0.0
+
+    def merge_missing_manga_state(
+        self,
+        imported_state: Dict[str, Any],
+        *,
+        merge_existing_downloaded: bool = False,
+    ):
         """Merge imported manga state entries without replacing local state.
 
         Issue #110: Settings backup import used to build a snapshot with
@@ -157,12 +169,26 @@ class State:
         between those calls could be overwritten. Keep the read/merge/save under
         the State lock so local worker mutations serialize with import.
         """
-        if not isinstance(imported_state, dict):
+        if imported_state is None:
             imported_state = {}
+        if not isinstance(imported_state, dict):
+            raise TypeError("imported_state must be a dict")
         with self._locked() as data:
             manga = data.setdefault("manga", {})
             for title, state_data in imported_state.items():
-                if not manga.get(title):
+                if title in manga and merge_existing_downloaded:
+                    entry = manga[title]
+                    if not isinstance(entry, dict):
+                        entry = {}
+                        manga[title] = entry
+                    if isinstance(state_data, dict):
+                        existing_downloaded = set(entry.get("downloaded", []))
+                        imported_downloaded = set(state_data.get("downloaded", []))
+                        entry["downloaded"] = sorted(
+                            existing_downloaded | imported_downloaded,
+                            key=self._chapter_sort_key,
+                        )
+                elif not manga.get(title):
                     manga[title] = self._snapshot(state_data)
             self.save()
 

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -149,6 +149,23 @@ class State:
             data[key] = self._snapshot(value)
             self.save()
 
+    def merge_missing_manga_state(self, imported_state: Dict[str, Any]):
+        """Merge imported manga state entries without replacing local state.
+
+        Issue #110: Settings backup import used to build a snapshot with
+        get("manga"), mutate it, then set("manga") wholesale. A worker update
+        between those calls could be overwritten. Keep the read/merge/save under
+        the State lock so local worker mutations serialize with import.
+        """
+        if not isinstance(imported_state, dict):
+            imported_state = {}
+        with self._locked() as data:
+            manga = data.setdefault("manga", {})
+            for title, state_data in imported_state.items():
+                if not manga.get(title):
+                    manga[title] = self._snapshot(state_data)
+            self.save()
+
     # ========================================================================
     # Manga State
     # ========================================================================

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -2,10 +2,12 @@
 State management for MeManga - tracks downloaded chapters and check history
 """
 
+import copy
 import json
 import os
 import tempfile
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
 from typing import List, Optional, Dict, Any
@@ -16,6 +18,13 @@ class State:
 
     Uses a dirty flag and thread lock to batch saves and prevent corruption.
     Call flush() explicitly when you need the file written immediately.
+
+    Issue #110: the GUI mutates state from background workers (checks,
+    downloads, source-health probes) while the main thread flushes it
+    periodically and on close. Every public method therefore takes the
+    same reentrant lock via ``_locked()``. Getters return deep snapshots
+    (nested containers included) and container-accepting setters store
+    snapshots, so no caller ever holds a live alias into ``_data``.
     """
 
     # Latency above which a successful probe is flagged "warning" instead
@@ -33,10 +42,12 @@ class State:
 
         self.state_path = self.config_dir / "state.json"
         self.config_dir.mkdir(parents=True, exist_ok=True)
-        self._lock = threading.Lock()
+        # Reentrant so mutators that persist immediately can call save()
+        # (and nested public getters) while already holding the lock.
+        self._lock = threading.RLock()
         self._dirty = False
         self._data = self._load()
-    
+
     def _load(self) -> Dict[str, Any]:
         """Load state from file."""
         if self.state_path.exists():
@@ -46,7 +57,7 @@ class State:
             except (json.JSONDecodeError, IOError):
                 return self._default_state()
         return self._default_state()
-    
+
     def _default_state(self) -> Dict[str, Any]:
         """Return default state structure."""
         return {
@@ -57,24 +68,62 @@ class State:
             "download_history": [],
             "source_health": {},
         }
-    
+
+    @contextmanager
+    def _locked(self):
+        """Hold the state lock around a read or nested update of ``_data``.
+
+        Issue #110: every public method accesses ``_data`` through this so
+        background workers can't interleave with the main thread's periodic
+        flush/save. Yields ``_data`` so method bodies stay readable.
+        """
+        with self._lock:
+            yield self._data
+
+    @staticmethod
+    def _snapshot(value):
+        """Deep-copy container values so nothing a caller receives (or
+        passes in) aliases ``_data`` — shallow copies still leaked the
+        dicts nested inside returned lists, e.g. editing a row from
+        get_available_chapters() changed stored state. Everything in
+        ``_data`` is plain JSON types, so deepcopy stays cheap relative
+        to the GUI work that consumes these snapshots.
+        """
+        return copy.deepcopy(value) if isinstance(value, (dict, list)) else value
+
+    @classmethod
+    def _copy_entry(cls, entry: Dict[str, Any]) -> Dict[str, Any]:
+        """Snapshot a manga entry, deep-copying its container values."""
+        return {k: cls._snapshot(v) for k, v in entry.items()}
+
+    def _entry_value(self, manga_title: str, key: str, default=None):
+        """Read one field of a manga entry under the lock.
+
+        Containers come back as deep snapshots (see _snapshot). Cheaper
+        than get_manga_state() for the per-chapter getters the GUI calls
+        in row-rendering loops, since it doesn't snapshot the whole entry
+        (notably the available_chapters cache).
+        """
+        with self._locked() as data:
+            value = data.get("manga", {}).get(manga_title, {}).get(key, default)
+            return self._snapshot(value)
+
     def save(self):
         """Save state to file atomically. Thread-safe."""
         with self._lock:
-            self._dirty = False
             data_snapshot = json.dumps(self._data, indent=None, default=str)
-
-        fd, tmp_path = tempfile.mkstemp(dir=self.config_dir, suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w") as f:
-                f.write(data_snapshot)
-            os.replace(tmp_path, self.state_path)
-        except Exception:
+            fd, tmp_path = tempfile.mkstemp(dir=self.config_dir, suffix=".tmp")
             try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+                with os.fdopen(fd, "w") as f:
+                    f.write(data_snapshot)
+                os.replace(tmp_path, self.state_path)
+                self._dirty = False
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
 
     def _mark_dirty(self):
         """Mark state as modified. Use flush() to write to disk."""
@@ -82,31 +131,37 @@ class State:
 
     def flush(self):
         """Write to disk only if state has been modified."""
-        if self._dirty:
-            self.save()
+        with self._lock:
+            if self._dirty:
+                self.save()
 
     def get(self, key: str, default=None):
-        """Get a state value."""
-        return self._data.get(key, default)
+        """Get a state value. Containers come back as deep copies so the
+        caller can't race concurrent mutators; write changes back with
+        set()."""
+        with self._locked() as data:
+            return self._snapshot(data.get(key, default))
 
     def set(self, key: str, value):
-        """Set a state value and save immediately."""
-        self._data[key] = value
-        self.save()
-    
+        """Set a state value and save immediately. Containers are stored
+        as snapshots so later mutation by the caller can't reach ``_data``."""
+        with self._locked() as data:
+            data[key] = self._snapshot(value)
+            self.save()
+
     # ========================================================================
     # Manga State
     # ========================================================================
-    
+
     def get_manga_state(self, manga_title: str) -> Dict[str, Any]:
-        """Get full state for a manga."""
-        return self._data.get("manga", {}).get(manga_title, {})
-    
+        """Get full state for a manga (a snapshot, not the live entry)."""
+        with self._locked() as data:
+            return self._copy_entry(data.get("manga", {}).get(manga_title, {}))
+
     def get_last_chapter(self, manga_title: str) -> Optional[str]:
         """Get the last downloaded chapter number for a manga."""
-        manga_state = self.get_manga_state(manga_title)
-        return manga_state.get("last_chapter")
-    
+        return self._entry_value(manga_title, "last_chapter")
+
     def set_last_chapter(self, manga_title: str, chapter: str):
         """Set the last downloaded chapter for a manga.
 
@@ -114,88 +169,91 @@ class State:
         closeEvent flush cover durability without thrashing disk on
         every per-chapter update.
         """
-        self._ensure_manga_entry(manga_title)
-        self._data["manga"][manga_title]["last_chapter"] = chapter
-        self._data["manga"][manga_title]["last_updated"] = datetime.now().isoformat()
-        self._mark_dirty()
-    
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            data["manga"][manga_title]["last_chapter"] = chapter
+            data["manga"][manga_title]["last_updated"] = datetime.now().isoformat()
+            self._mark_dirty()
+
     def get_downloaded_chapters(self, manga_title: str) -> List[str]:
         """Get list of all downloaded chapter numbers for a manga."""
-        manga_state = self.get_manga_state(manga_title)
-        return manga_state.get("downloaded", [])
-    
+        return self._entry_value(manga_title, "downloaded", [])
+
     def add_downloaded_chapter(self, manga_title: str, chapter: str):
         """Mark a chapter as downloaded."""
-        self._ensure_manga_entry(manga_title)
-        
-        if "downloaded" not in self._data["manga"][manga_title]:
-            self._data["manga"][manga_title]["downloaded"] = []
-        
-        chapter_str = str(chapter)
-        if chapter_str not in self._data["manga"][manga_title]["downloaded"]:
-            self._data["manga"][manga_title]["downloaded"].append(chapter_str)
-            def _sort_key(x):
-                try:
-                    return float(x)
-                except (ValueError, TypeError):
-                    return 0.0
-            self._data["manga"][manga_title]["downloaded"].sort(key=_sort_key)
-        
-        self._data["manga"][manga_title]["last_chapter"] = chapter_str
-        self._data["manga"][manga_title]["last_updated"] = datetime.now().isoformat()
-        self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+
+            if "downloaded" not in entry:
+                entry["downloaded"] = []
+
+            chapter_str = str(chapter)
+            if chapter_str not in entry["downloaded"]:
+                entry["downloaded"].append(chapter_str)
+                def _sort_key(x):
+                    try:
+                        return float(x)
+                    except (ValueError, TypeError):
+                        return 0.0
+                entry["downloaded"].sort(key=_sort_key)
+
+            entry["last_chapter"] = chapter_str
+            entry["last_updated"] = datetime.now().isoformat()
+            self._mark_dirty()
 
     def is_chapter_downloaded(self, manga_title: str, chapter: str) -> bool:
         """Check if a chapter has been downloaded."""
         return str(chapter) in self.get_downloaded_chapters(manga_title)
-    
+
     # ========================================================================
     # Backup Source Tracking
     # ========================================================================
-    
+
     def get_pending_backup(self, manga_title: str, chapter: str) -> Optional[Dict[str, Any]]:
         """Get pending backup info for a chapter (if waiting for primary to catch up)."""
-        manga_state = self.get_manga_state(manga_title)
-        pending = manga_state.get("pending_backup", {})
+        pending = self._entry_value(manga_title, "pending_backup", {})
         return pending.get(str(chapter))
-    
+
     def set_pending_backup(self, manga_title: str, chapter: str, backup_source: str, backup_url: str):
         """Mark a chapter as seen on backup source, start the waiting period."""
-        self._ensure_manga_entry(manga_title)
-        
-        if "pending_backup" not in self._data["manga"][manga_title]:
-            self._data["manga"][manga_title]["pending_backup"] = {}
-        
-        chapter_str = str(chapter)
-        if chapter_str not in self._data["manga"][manga_title]["pending_backup"]:
-            self._data["manga"][manga_title]["pending_backup"][chapter_str] = {
-                "first_seen": datetime.now().isoformat(),
-                "backup_source": backup_source,
-                "backup_url": backup_url,
-            }
-            self.save()
-    
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+
+            if "pending_backup" not in entry:
+                entry["pending_backup"] = {}
+
+            chapter_str = str(chapter)
+            if chapter_str not in entry["pending_backup"]:
+                entry["pending_backup"][chapter_str] = {
+                    "first_seen": datetime.now().isoformat(),
+                    "backup_source": backup_source,
+                    "backup_url": backup_url,
+                }
+                self.save()
+
     def clear_pending_backup(self, manga_title: str, chapter: str):
         """Clear pending backup for a chapter (downloaded from primary or backup)."""
-        manga_state = self.get_manga_state(manga_title)
-        pending = manga_state.get("pending_backup", {})
-        
-        chapter_str = str(chapter)
-        if chapter_str in pending:
-            del self._data["manga"][manga_title]["pending_backup"][chapter_str]
-            self.save()
-    
+        with self._locked() as data:
+            pending = data.get("manga", {}).get(manga_title, {}).get("pending_backup", {})
+
+            chapter_str = str(chapter)
+            if chapter_str in pending:
+                del pending[chapter_str]
+                self.save()
+
     def clear_all_pending_backups(self, manga_title: str):
         """Clear all pending backups for a manga."""
-        if manga_title in self._data.get("manga", {}):
-            self._data["manga"][manga_title]["pending_backup"] = {}
-            self.save()
-    
+        with self._locked() as data:
+            if manga_title in data.get("manga", {}):
+                data["manga"][manga_title]["pending_backup"] = {}
+                self.save()
+
     def get_all_pending_backups(self, manga_title: str) -> Dict[str, Dict[str, Any]]:
         """Get all pending backup chapters for a manga."""
-        manga_state = self.get_manga_state(manga_title)
-        return manga_state.get("pending_backup", {})
-    
+        return self._entry_value(manga_title, "pending_backup", {})
+
     # ========================================================================
     # Suspicious Batch Tracking
     # ========================================================================
@@ -204,20 +262,22 @@ class State:
         """Record a suspicious chapter batch that was held back from
         download/delivery. ``info`` should describe the batch (chapters,
         score, reasons, backup verification status, detected_at)."""
-        self._ensure_manga_entry(manga_title)
-        self._data["manga"][manga_title]["suspicious_batch"] = info
-        self.save()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            data["manga"][manga_title]["suspicious_batch"] = self._snapshot(info)
+            self.save()
 
     def get_suspicious_batch(self, manga_title: str) -> Optional[Dict[str, Any]]:
         """Get the held-back suspicious batch for a manga, if any."""
-        return self.get_manga_state(manga_title).get("suspicious_batch")
+        return self._entry_value(manga_title, "suspicious_batch")
 
     def clear_suspicious_batch(self, manga_title: str):
         """Clear the suspicious batch record (accepted, confirmed, or stale)."""
-        manga_state = self._data.get("manga", {}).get(manga_title, {})
-        if "suspicious_batch" in manga_state:
-            del manga_state["suspicious_batch"]
-            self.save()
+        with self._locked() as data:
+            manga_state = data.get("manga", {}).get(manga_title, {})
+            if "suspicious_batch" in manga_state:
+                del manga_state["suspicious_batch"]
+                self.save()
 
     # ========================================================================
     # Failed Chapter Tracking
@@ -232,46 +292,49 @@ class State:
         failed_pages: Optional[List[int]] = None,
     ):
         """Record a chapter download failure."""
-        self._ensure_manga_entry(manga_title)
-        chapter_str = str(chapter)
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            chapter_str = str(chapter)
+            entry = data["manga"][manga_title]
 
-        if "failed_chapters" not in self._data["manga"][manga_title]:
-            self._data["manga"][manga_title]["failed_chapters"] = {}
+            if "failed_chapters" not in entry:
+                entry["failed_chapters"] = {}
 
-        existing = self._data["manga"][manga_title]["failed_chapters"].get(chapter_str, {})
-        self._data["manga"][manga_title]["failed_chapters"][chapter_str] = {
-            "failed_at": datetime.now().isoformat(),
-            "source": source,
-            "error": error[:300],
-            "failed_pages": failed_pages or [],
-            "attempts": existing.get("attempts", 0) + 1,
-        }
-        self.save()
+            existing = entry["failed_chapters"].get(chapter_str, {})
+            entry["failed_chapters"][chapter_str] = {
+                "failed_at": datetime.now().isoformat(),
+                "source": source,
+                "error": error[:300],
+                "failed_pages": self._snapshot(failed_pages or []),
+                "attempts": existing.get("attempts", 0) + 1,
+            }
+            self.save()
 
     def get_failed_chapters(self, manga_title: str) -> Dict[str, Any]:
         """Get all failed chapter records for a manga."""
-        manga_state = self.get_manga_state(manga_title)
-        return manga_state.get("failed_chapters", {})
+        return self._entry_value(manga_title, "failed_chapters", {})
 
     def get_all_failed_chapters(self) -> Dict[str, Dict[str, Any]]:
         """Get failed chapters for all manga that have failures."""
-        result = {}
-        for title, manga_state in self._data.get("manga", {}).items():
-            failed = manga_state.get("failed_chapters", {})
-            if failed:
-                result[title] = failed
-        return result
+        with self._locked() as data:
+            result = {}
+            for title, manga_state in data.get("manga", {}).items():
+                failed = manga_state.get("failed_chapters", {})
+                if failed:
+                    result[title] = copy.deepcopy(failed)
+            return result
 
     def clear_failed_chapter(self, manga_title: str, chapter: str):
         """Remove a failed chapter record after successful re-download."""
-        chapter_str = str(chapter)
-        failed = self._data.get("manga", {}).get(manga_title, {}).get("failed_chapters", {})
-        if chapter_str in failed:
-            del self._data["manga"][manga_title]["failed_chapters"][chapter_str]
-            self.save()
+        with self._locked() as data:
+            chapter_str = str(chapter)
+            failed = data.get("manga", {}).get(manga_title, {}).get("failed_chapters", {})
+            if chapter_str in failed:
+                del failed[chapter_str]
+                self.save()
 
     def _ensure_manga_entry(self, manga_title: str):
-        """Ensure manga entry exists in state."""
+        """Ensure manga entry exists in state. Caller must hold ``_lock``."""
         if "manga" not in self._data:
             self._data["manga"] = {}
         if manga_title not in self._data["manga"]:
@@ -289,83 +352,87 @@ class State:
     # ========================================================================
     # Check History
     # ========================================================================
-    
+
     def update_last_check(self, new_chapters: int = 0, downloaded: int = 0):
         """Update the last check timestamp and optionally log to history."""
-        now = datetime.now().isoformat()
-        self._data["last_check"] = now
-        
-        # Add to history (keep last 50)
-        if "check_history" not in self._data:
-            self._data["check_history"] = []
-        
-        self._data["check_history"].append({
-            "timestamp": now,
-            "new_chapters": new_chapters,
-            "downloaded": downloaded,
-        })
-        
-        # Trim history
-        self._data["check_history"] = self._data["check_history"][-50:]
-        
-        self.save()
-    
+        with self._locked() as data:
+            now = datetime.now().isoformat()
+            data["last_check"] = now
+
+            # Add to history (keep last 50)
+            if "check_history" not in data:
+                data["check_history"] = []
+
+            data["check_history"].append({
+                "timestamp": now,
+                "new_chapters": new_chapters,
+                "downloaded": downloaded,
+            })
+
+            # Trim history
+            data["check_history"] = data["check_history"][-50:]
+
+            self.save()
+
     def get_check_history(self, limit: int = 10) -> List[Dict[str, Any]]:
         """Get recent check history."""
-        history = self._data.get("check_history", [])
-        return history[-limit:]
-    
+        with self._locked() as data:
+            return self._snapshot(data.get("check_history", [])[-limit:])
+
     # ========================================================================
     # Statistics
     # ========================================================================
-    
+
     def get_stats(self) -> Dict[str, Any]:
         """Get overall statistics."""
-        manga_data = self._data.get("manga", {})
-        
-        total_manga = len(manga_data)
-        total_chapters = sum(
-            len(m.get("downloaded", []))
-            for m in manga_data.values()
-        )
-        
-        return {
-            "total_manga": total_manga,
-            "total_chapters": total_chapters,
-            "last_check": self._data.get("last_check"),
-            "checks_logged": len(self._data.get("check_history", [])),
-        }
-    
+        with self._locked() as data:
+            manga_data = data.get("manga", {})
+
+            total_manga = len(manga_data)
+            total_chapters = sum(
+                len(m.get("downloaded", []))
+                for m in manga_data.values()
+            )
+
+            return {
+                "total_manga": total_manga,
+                "total_chapters": total_chapters,
+                "last_check": data.get("last_check"),
+                "checks_logged": len(data.get("check_history", [])),
+            }
+
     # ========================================================================
     # Reading Progress
     # ========================================================================
 
     def set_reading_progress(self, manga_title: str, chapter: str):
         """Update the last-read chapter for a manga."""
-        self._ensure_manga_entry(manga_title)
-        entry = self._data["manga"][manga_title]
-        if "reading_progress" not in entry:
-            entry["reading_progress"] = {}
-        entry["reading_progress"]["last_chapter"] = str(chapter)
-        entry["reading_progress"]["last_read"] = datetime.now().isoformat()
-        self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+            if "reading_progress" not in entry:
+                entry["reading_progress"] = {}
+            entry["reading_progress"]["last_chapter"] = str(chapter)
+            entry["reading_progress"]["last_read"] = datetime.now().isoformat()
+            self._mark_dirty()
 
     def get_reading_progress(self, manga_title: str) -> Dict[str, Any]:
         """Get reading progress for a manga."""
-        return self.get_manga_state(manga_title).get("reading_progress", {})
+        return self._entry_value(manga_title, "reading_progress", {})
 
     def get_continue_reading(self) -> Optional[Dict[str, Any]]:
         """Get the most recently read manga for 'Continue Reading' widget."""
-        best = None
-        best_time = None
-        for title, data in self._data.get("manga", {}).items():
-            progress = data.get("reading_progress", {})
-            last_read = progress.get("last_read")
-            if last_read and progress.get("last_chapter"):
-                if best_time is None or last_read > best_time:
-                    best_time = last_read
-                    best = {"title": title, **progress}
-        return best
+        with self._locked() as data:
+            best = None
+            best_time = None
+            for title, entry in data.get("manga", {}).items():
+                progress = entry.get("reading_progress", {})
+                last_read = progress.get("last_read")
+                if last_read and progress.get("last_chapter"):
+                    if best_time is None or last_read > best_time:
+                        best_time = last_read
+                        best = {"title": title, **progress}
+            return self._snapshot(best)
 
     # ── Per-chapter read tracking (issue #18) ──────────────────────────
     # `reading_progress.last_chapter` only tracks the cursor (the most-
@@ -377,32 +444,34 @@ class State:
         """Add `chapter` to the per-manga read set (idempotent)."""
         if chapter is None or str(chapter).strip() == "":
             return
-        self._ensure_manga_entry(manga_title)
-        entry = self._data["manga"][manga_title]
-        read_list = entry.setdefault("read_chapters", [])
-        ch = str(chapter)
-        if ch not in read_list:
-            read_list.append(ch)
-            self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+            read_list = entry.setdefault("read_chapters", [])
+            ch = str(chapter)
+            if ch not in read_list:
+                read_list.append(ch)
+                self._mark_dirty()
 
     def unmark_chapter_read(self, manga_title: str, chapter):
-        entry = self._data.get("manga", {}).get(manga_title)
-        if not entry:
-            return
-        read_list = entry.get("read_chapters", [])
-        ch = str(chapter)
-        if ch in read_list:
-            read_list.remove(ch)
-            self._mark_dirty()
+        with self._locked() as data:
+            entry = data.get("manga", {}).get(manga_title)
+            if not entry:
+                return
+            read_list = entry.get("read_chapters", [])
+            ch = str(chapter)
+            if ch in read_list:
+                read_list.remove(ch)
+                self._mark_dirty()
 
     def is_chapter_read(self, manga_title: str, chapter) -> bool:
         return str(chapter) in self.get_read_chapters(manga_title)
 
     def get_read_chapters(self, manga_title: str) -> List[str]:
-        return list(self.get_manga_state(manga_title).get("read_chapters", []) or [])
+        return self._entry_value(manga_title, "read_chapters", []) or []
 
     def get_read_count(self, manga_title: str) -> int:
-        return len(self.get_manga_state(manga_title).get("read_chapters", []) or [])
+        return len(self.get_read_chapters(manga_title))
 
     # ========================================================================
     # New Chapter Badges
@@ -410,28 +479,31 @@ class State:
 
     def set_new_chapters(self, manga_title: str, count: int):
         """Set the number of new chapters available for a manga."""
-        self._ensure_manga_entry(manga_title)
-        self._data["manga"][manga_title]["new_chapters_available"] = count
-        self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            data["manga"][manga_title]["new_chapters_available"] = count
+            self._mark_dirty()
 
     def get_new_chapters(self, manga_title: str) -> int:
         """Get the number of new chapters available."""
-        return self.get_manga_state(manga_title).get("new_chapters_available", 0)
+        return self._entry_value(manga_title, "new_chapters_available", 0)
 
     def clear_new_chapters(self, manga_title: str):
         """Clear the new chapters badge (e.g. after downloading)."""
-        state = self.get_manga_state(manga_title)
-        if state and state.get("new_chapters_available", 0) > 0:
-            self._data["manga"][manga_title]["new_chapters_available"] = 0
-            self._mark_dirty()
+        with self._locked() as data:
+            entry = data.get("manga", {}).get(manga_title, {})
+            if entry.get("new_chapters_available", 0) > 0:
+                entry["new_chapters_available"] = 0
+                self._mark_dirty()
 
     def decrement_new_chapters(self, manga_title: str):
         """Decrement the new chapters badge by 1 (used by manual single downloads)."""
-        state = self.get_manga_state(manga_title)
-        current = state.get("new_chapters_available", 0) if state else 0
-        if current > 0:
-            self._data["manga"][manga_title]["new_chapters_available"] = current - 1
-            self._mark_dirty()
+        with self._locked() as data:
+            entry = data.get("manga", {}).get(manga_title, {})
+            current = entry.get("new_chapters_available", 0)
+            if current > 0:
+                entry["new_chapters_available"] = current - 1
+                self._mark_dirty()
 
     # ========================================================================
     # Available Chapters Cache
@@ -444,13 +516,14 @@ class State:
         Used by the Detail page to show every chapter as 'Read' (downloaded) or
         'Download' (available) without re-scraping.
         """
-        self._ensure_manga_entry(manga_title)
-        self._data["manga"][manga_title]["available_chapters"] = chapters
-        self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            data["manga"][manga_title]["available_chapters"] = self._snapshot(list(chapters))
+            self._mark_dirty()
 
     def get_available_chapters(self, manga_title: str) -> List[Dict[str, Any]]:
         """Get the cached chapter list for a manga (empty list if never checked)."""
-        return self.get_manga_state(manga_title).get("available_chapters", [])
+        return self._entry_value(manga_title, "available_chapters", [])
 
     # ========================================================================
     # External Chapters (already read outside the app)
@@ -462,26 +535,27 @@ class State:
         Stored separately from `downloaded` so the app never lies about what's
         on disk; the Detail page renders these as "Read elsewhere" rows.
         """
-        self._ensure_manga_entry(manga_title)
-        entry = self._data["manga"][manga_title]
-        if "external_chapters" not in entry:
-            entry["external_chapters"] = []
-        ch_str = str(chapter)
-        if ch_str not in entry["external_chapters"]:
-            entry["external_chapters"].append(ch_str)
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+            if "external_chapters" not in entry:
+                entry["external_chapters"] = []
+            ch_str = str(chapter)
+            if ch_str not in entry["external_chapters"]:
+                entry["external_chapters"].append(ch_str)
 
-            def _sort_key(x):
-                try:
-                    return float(x)
-                except (ValueError, TypeError):
-                    return 0.0
+                def _sort_key(x):
+                    try:
+                        return float(x)
+                    except (ValueError, TypeError):
+                        return 0.0
 
-            entry["external_chapters"].sort(key=_sort_key)
-            self._mark_dirty()
+                entry["external_chapters"].sort(key=_sort_key)
+                self._mark_dirty()
 
     def get_external_chapters(self, manga_title: str) -> List[str]:
         """Get the chapters the user marked as already read elsewhere."""
-        return self.get_manga_state(manga_title).get("external_chapters", [])
+        return self._entry_value(manga_title, "external_chapters", [])
 
     def is_external_chapter(self, manga_title: str, chapter: str) -> bool:
         """Whether a chapter was previously marked as read-elsewhere."""
@@ -493,35 +567,42 @@ class State:
 
     def add_notification(self, ntype: str, message: str):
         """Add a notification to the log."""
-        if "notifications" not in self._data:
-            self._data["notifications"] = []
-        self._data["notifications"].append({
-            "type": ntype,
-            "message": message,
-            "timestamp": datetime.now().isoformat(),
-            "read": False,
-        })
-        self._data["notifications"] = self._data["notifications"][-100:]
-        self._mark_dirty()
+        with self._locked() as data:
+            if "notifications" not in data:
+                data["notifications"] = []
+            data["notifications"].append({
+                "type": ntype,
+                "message": message,
+                "timestamp": datetime.now().isoformat(),
+                "read": False,
+            })
+            data["notifications"] = data["notifications"][-100:]
+            self._mark_dirty()
 
     def get_notifications(self, limit: int = 20) -> List[Dict[str, Any]]:
-        """Get recent notifications."""
-        return list(reversed(self._data.get("notifications", [])[-limit:]))
+        """Get recent notifications. Items are copies — mark_notifications_read
+        mutates the stored dicts in place, so live references would race."""
+        with self._locked() as data:
+            return self._snapshot(
+                list(reversed(data.get("notifications", [])[-limit:])))
 
     def get_unread_count(self) -> int:
         """Count unread notifications."""
-        return sum(1 for n in self._data.get("notifications", []) if not n.get("read"))
+        with self._locked() as data:
+            return sum(1 for n in data.get("notifications", []) if not n.get("read"))
 
     def mark_notifications_read(self):
         """Mark all notifications as read."""
-        for n in self._data.get("notifications", []):
-            n["read"] = True
-        self._mark_dirty()
+        with self._locked() as data:
+            for n in data.get("notifications", []):
+                n["read"] = True
+            self._mark_dirty()
 
     def clear_notifications(self):
         """Wipe all notifications. Used by the GUI's 'Clear all' button."""
-        self._data["notifications"] = []
-        self._mark_dirty()
+        with self._locked() as data:
+            data["notifications"] = []
+            self._mark_dirty()
 
     def filter_notifications(self, kind: str, limit: int = 100) -> List[Dict[str, Any]]:
         """Return notifications filtered by category.
@@ -533,7 +614,9 @@ class State:
             downloads — download-complete / kindle-sent events
             system    — errors, warnings, generic system events
         """
-        all_notifs = list(reversed(self._data.get("notifications", [])[-limit:]))
+        with self._locked() as data:
+            all_notifs = self._snapshot(
+                list(reversed(data.get("notifications", [])[-limit:])))
         if kind == "all":
             return all_notifs
         bucket_map = {
@@ -553,19 +636,22 @@ class State:
         if not query or not query.strip():
             return
         q = query.strip()
-        history = self._data.get("search_history", []) or []
-        # Dedupe by case-insensitive match, then prepend.
-        history = [h for h in history if h.lower() != q.lower()]
-        history.insert(0, q)
-        self._data["search_history"] = history[:limit]
-        self._mark_dirty()
+        with self._locked() as data:
+            history = data.get("search_history", []) or []
+            # Dedupe by case-insensitive match, then prepend.
+            history = [h for h in history if h.lower() != q.lower()]
+            history.insert(0, q)
+            data["search_history"] = history[:limit]
+            self._mark_dirty()
 
     def get_recent_searches(self, limit: int = 8) -> List[str]:
-        return list(self._data.get("search_history", []) or [])[:limit]
+        with self._locked() as data:
+            return list(data.get("search_history", []) or [])[:limit]
 
     def clear_search_history(self):
-        self._data["search_history"] = []
-        self._mark_dirty()
+        with self._locked() as data:
+            data["search_history"] = []
+            self._mark_dirty()
 
     # ========================================================================
     # Download History
@@ -574,23 +660,26 @@ class State:
     def add_download_history(self, title: str, chapter: str, fmt: str,
                              path: str = "", size_mb: float = 0, kindle_sent: bool = False):
         """Log a completed download."""
-        if "download_history" not in self._data:
-            self._data["download_history"] = []
-        self._data["download_history"].append({
-            "title": title,
-            "chapter": chapter,
-            "format": fmt,
-            "path": path,
-            "size_mb": round(size_mb, 2),
-            "kindle_sent": kindle_sent,
-            "timestamp": datetime.now().isoformat(),
-        })
-        self._data["download_history"] = self._data["download_history"][-200:]
-        self._mark_dirty()
+        with self._locked() as data:
+            if "download_history" not in data:
+                data["download_history"] = []
+            data["download_history"].append({
+                "title": title,
+                "chapter": chapter,
+                "format": fmt,
+                "path": path,
+                "size_mb": round(size_mb, 2),
+                "kindle_sent": kindle_sent,
+                "timestamp": datetime.now().isoformat(),
+            })
+            data["download_history"] = data["download_history"][-200:]
+            self._mark_dirty()
 
     def get_download_history(self, limit: int = 50) -> List[Dict[str, Any]]:
         """Get recent download history."""
-        return list(reversed(self._data.get("download_history", [])[-limit:]))
+        with self._locked() as data:
+            return self._snapshot(
+                list(reversed(data.get("download_history", [])[-limit:])))
 
     # ========================================================================
     # Source Health
@@ -604,69 +693,90 @@ class State:
         probe that produced this status update. Drives the "Xms" badge
         in the Sources screen.
         """
-        if "source_health" not in self._data:
-            self._data["source_health"] = {}
-        now = datetime.now().isoformat()
-        health = self._data["source_health"].get(domain, {"error_count": 0})
-        if success:
-            health["last_success"] = now
-            health["error_count"] = 0
-            # Flag only genuinely slow responses; see SLOW_LATENCY_MS.
-            if latency_ms is not None and latency_ms > self.SLOW_LATENCY_MS:
-                health["status"] = "warning"
+        with self._locked() as data:
+            if "source_health" not in data:
+                data["source_health"] = {}
+            now = datetime.now().isoformat()
+            health = data["source_health"].get(domain, {"error_count": 0})
+            if success:
+                health["last_success"] = now
+                health["error_count"] = 0
+                # Flag only genuinely slow responses; see SLOW_LATENCY_MS.
+                if latency_ms is not None and latency_ms > self.SLOW_LATENCY_MS:
+                    health["status"] = "warning"
+                else:
+                    health["status"] = "ok"
             else:
-                health["status"] = "ok"
-        else:
-            health["last_error"] = now
-            health["last_error_msg"] = error_msg[:100]
-            health["error_count"] = health.get("error_count", 0) + 1
-            health["status"] = "warning" if health["error_count"] < 3 else "error"
-        if latency_ms is not None:
-            health["latency_ms"] = int(latency_ms)
-        self._data["source_health"][domain] = health
-        self._mark_dirty()
+                health["last_error"] = now
+                health["last_error_msg"] = error_msg[:100]
+                health["error_count"] = health.get("error_count", 0) + 1
+                health["status"] = "warning" if health["error_count"] < 3 else "error"
+            if latency_ms is not None:
+                health["latency_ms"] = int(latency_ms)
+            data["source_health"][domain] = health
+            self._mark_dirty()
 
     def get_source_health(self, domain: str) -> Dict[str, Any]:
         """Get health info for a source."""
-        return self._data.get("source_health", {}).get(domain, {})
+        with self._locked() as data:
+            return self._snapshot(data.get("source_health", {}).get(domain, {}))
 
     def get_all_source_health(self) -> Dict[str, Dict[str, Any]]:
-        """Get health info for all sources."""
-        return self._data.get("source_health", {})
+        """Get health info for all sources. Entries are copies — probes
+        update the stored dicts in place."""
+        with self._locked() as data:
+            return self._snapshot(data.get("source_health", {}))
 
     def reset_manga_progress(self, manga_title: str, from_chapter: float = 0):
         """Reset a manga's download progress to re-download from a specific chapter.
         If from_chapter is 0, clears everything for a full re-download.
         If from_chapter is N, keeps chapters < N downloaded and re-downloads N onwards.
         """
-        self._ensure_manga_entry(manga_title)
-        entry = self._data["manga"][manga_title]
-        if from_chapter == 0:
-            entry["last_chapter"] = None
-            entry["downloaded"] = []
-        else:
-            # Keep only chapters before from_chapter, remove the rest
-            entry["downloaded"] = [
-                ch for ch in entry.get("downloaded", [])
-                if float(ch) < from_chapter
-            ]
-            entry["last_chapter"] = None
-        entry["last_updated"] = datetime.now().isoformat()
-        self.save()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+            if from_chapter == 0:
+                entry["last_chapter"] = None
+                entry["downloaded"] = []
+            else:
+                # Keep only chapters before from_chapter, remove the rest
+                entry["downloaded"] = [
+                    ch for ch in entry.get("downloaded", [])
+                    if float(ch) < from_chapter
+                ]
+                entry["last_chapter"] = None
+            entry["last_updated"] = datetime.now().isoformat()
+            self.save()
 
     # ========================================================================
     # Cleanup
     # ========================================================================
-    
-    def remove_manga(self, manga_title: str) -> bool:
-        """Remove a manga from state."""
-        if manga_title in self._data.get("manga", {}):
-            del self._data["manga"][manga_title]
+
+    def rename_manga(self, old_title: str, new_title: str) -> bool:
+        """Move a manga's state entry to a new title (edit/rename flows).
+
+        Issue #110: replaces the GUI's direct ``_data`` pokes so renames go
+        through the lock like every other mutation.
+        """
+        with self._locked() as data:
+            manga = data.get("manga", {})
+            if old_title not in manga:
+                return False
+            manga[new_title] = manga.pop(old_title)
             self.save()
             return True
-        return False
-    
+
+    def remove_manga(self, manga_title: str) -> bool:
+        """Remove a manga from state."""
+        with self._locked() as data:
+            if manga_title in data.get("manga", {}):
+                del data["manga"][manga_title]
+                self.save()
+                return True
+            return False
+
     def clear_all(self):
         """Clear all state (fresh start)."""
-        self._data = self._default_state()
-        self.save()
+        with self._lock:
+            self._data = self._default_state()
+            self.save()

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -537,6 +537,32 @@ class TestExportImport:
         titles = [m["title"] for m in config.get("manga", []) or []]
         assert "RoundTrip" in titles
 
+    def test_import_merge_unions_downloaded_state(self, run_cli, config,
+                                                  isolated_home, monkeypatch,
+                                                  tmp_path):
+        from memanga import cli as cli_mod
+        from memanga.state import State
+
+        config.set("manga", [{"title": "Existing", "url": "u",
+                              "source": "mangadex.org", "status": "reading"}])
+        config.save()
+        state = State(config_dir=isolated_home / ".config" / "memanga")
+        monkeypatch.setattr(cli_mod, "state", state)
+        state.add_downloaded_chapter("Existing", "1")
+
+        backup = tmp_path / "merge-state.json"
+        backup.write_text(json.dumps({
+            "version": 1,
+            "manga": [{"title": "Existing", "url": "u",
+                       "source": "mangadex.org", "status": "reading"}],
+            "state": {"Existing": {"downloaded": ["2", "10"]}},
+        }))
+
+        assert run_cli("import", str(backup)) == 0
+
+        reloaded = State(config_dir=isolated_home / ".config" / "memanga")
+        assert reloaded.get_downloaded_chapters("Existing") == ["1", "2", "10"]
+
     def test_import_missing_version_rejected(self, run_cli, config, tmp_path,
                                              capsys):
         """Issue #42: a file without the export's `version` stamp is not

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -43,6 +43,10 @@ class TestValidateBackup:
         with pytest.raises(BackupVersionError, match="Invalid backup version"):
             validate_backup({"version": bad, "manga": []})
 
+    def test_non_dict_state_rejected(self):
+        with pytest.raises(BackupVersionError, match="state must be an object"):
+            validate_backup({"version": EXPORT_VERSION, "manga": [], "state": []})
+
     def test_newer_version_rejected_with_update_hint(self):
         with pytest.raises(BackupVersionError, match="newer.*update MeManga"):
             validate_backup({"version": EXPORT_VERSION + 1, "manga": []})

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -49,6 +49,69 @@ class TestAtomicSave:
         s = State(config_dir=cfg)
         assert s.get_notifications() == []
 
+    def test_older_save_cannot_overwrite_newer_state(self, state, monkeypatch):
+        """A delayed old save must not publish after a newer mutation."""
+        state.set("publication_order", "old")
+        original_replace = __import__("os").replace
+        first_replace_ready = threading.Event()
+        release_first_replace = threading.Event()
+        replace_count = 0
+        count_lock = threading.Lock()
+        publication_lock_held = []
+        thread_errors = []
+
+        def controlled_replace(src, dst):
+            nonlocal replace_count
+            with count_lock:
+                replace_count += 1
+                call_number = replace_count
+
+            probe_acquired_lock = []
+
+            def probe_lock():
+                acquired = state._lock.acquire(blocking=False)
+                probe_acquired_lock.append(acquired)
+                if acquired:
+                    state._lock.release()
+
+            probe = threading.Thread(target=probe_lock)
+            probe.start()
+            probe.join(timeout=5)
+            assert not probe.is_alive()
+            publication_lock_held.append(not probe_acquired_lock[0])
+
+            if call_number == 1:
+                first_replace_ready.set()
+                assert release_first_replace.wait(timeout=5)
+            original_replace(src, dst)
+
+        monkeypatch.setattr("memanga.state.os.replace", controlled_replace)
+
+        def capture_errors(fn, *args):
+            try:
+                fn(*args)
+            except Exception as exc:  # pragma: no cover - failure path
+                thread_errors.append(exc)
+
+        old_save = threading.Thread(target=capture_errors, args=(state.save,))
+        old_save.start()
+        assert first_replace_ready.wait(timeout=5)
+
+        newer_save = threading.Thread(
+            target=capture_errors,
+            args=(state.set, "publication_order", "new"))
+        newer_save.start()
+
+        release_first_replace.set()
+        old_save.join(timeout=5)
+        newer_save.join(timeout=5)
+
+        assert not old_save.is_alive()
+        assert not newer_save.is_alive()
+        assert thread_errors == []
+        assert publication_lock_held == [True, True]
+        assert json.loads(state.state_path.read_text())["publication_order"] == "new"
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Concurrent mutation — multiple workers writing State at once
@@ -153,3 +216,235 @@ class TestSchemaCompat:
         # Even with zero history, get_manga_state must not raise.
         st = state.get_manga_state("never-touched")
         assert isinstance(st, dict)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Getter isolation (issue #110) — returned containers are snapshots, so
+# GUI code can iterate them while workers mutate the underlying state
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGetterIsolation:
+    def test_downloaded_list_is_a_copy(self, state):
+        state.add_downloaded_chapter("X", "1")
+        state.get_downloaded_chapters("X").append("999")
+        assert state.get_downloaded_chapters("X") == ["1"]
+
+    def test_manga_state_is_a_snapshot(self, state):
+        state.add_downloaded_chapter("X", "1")
+        snap = state.get_manga_state("X")
+        snap["downloaded"].append("999")
+        snap["last_chapter"] = "999"
+        assert state.get_downloaded_chapters("X") == ["1"]
+        assert state.get_last_chapter("X") == "1"
+
+    def test_source_health_is_a_copy(self, state):
+        state.update_source_health("a.test", True, latency_ms=50)
+        state.get_all_source_health()["a.test"]["status"] = "error"
+        state.get_source_health("a.test")["status"] = "error"
+        assert state.get_source_health("a.test")["status"] == "ok"
+
+    def test_notifications_are_copies(self, state):
+        state.add_notification("info", "x")
+        state.get_notifications()[0]["read"] = True
+        assert state.get_unread_count() == 1
+
+    def test_generic_get_returns_copy(self, state):
+        state.set("custom", {"nested": [1]})
+        state.get("custom")["nested"].append(2)
+        assert state.get("custom") == {"nested": [1]}
+
+    @pytest.mark.parametrize("getter", [
+        lambda state: state.get_available_chapters("X"),
+        lambda state: state.get_download_history(),
+        lambda state: state.get_all_pending_backups("X"),
+        lambda state: state.get_failed_chapters("X"),
+        lambda state: state.get_source_health("src.test"),
+        lambda state: state.get_all_source_health(),
+        lambda state: state.get_reading_progress("X"),
+        lambda state: state.get_check_history(),
+    ])
+    def test_nested_getters_return_snapshots(self, state, getter):
+        state.set("manga", {"X": {
+            "available_chapters": [{"metadata": {"tags": ["original"]}}],
+            "pending_backup": {"1": {"metadata": {"tags": ["original"]}}},
+            "failed_chapters": {"1": {"failed_pages": [[1]]}},
+            "reading_progress": {"metadata": {"tags": ["original"]}},
+        }})
+        state.set("download_history", [
+            {"metadata": {"tags": ["original"]}},
+        ])
+        state.set("check_history", [
+            {"metadata": {"tags": ["original"]}},
+        ])
+        state.set("source_health", {
+            "src.test": {"metadata": {"tags": ["original"]}},
+        })
+
+        snapshot = getter(state)
+        original = state._snapshot(snapshot)
+
+        def mutate_nested(value):
+            if isinstance(value, dict):
+                for child in value.values():
+                    if isinstance(child, (dict, list)):
+                        mutate_nested(child)
+                        return
+            elif isinstance(value, list):
+                if value and isinstance(value[0], (dict, list)):
+                    mutate_nested(value[0])
+                else:
+                    value.append("changed")
+
+        mutate_nested(snapshot)
+        assert getter(state) == original
+
+    def test_setter_inputs_are_snapshotted(self, state):
+        available = [{"metadata": {"tags": ["original"]}}]
+        suspicious = {"chapters": [{"number": "1"}]}
+        failed_pages = [[1]]
+        custom = {"nested": ["original"]}
+
+        state.set_available_chapters("X", available)
+        state.set_suspicious_batch("X", suspicious)
+        state.add_failed_chapter("X", "1", "src.test", "boom", failed_pages)
+        state.set("custom", custom)
+
+        available[0]["metadata"]["tags"].append("changed")
+        suspicious["chapters"][0]["number"] = "999"
+        failed_pages[0].append(2)
+        custom["nested"].append("changed")
+
+        assert state.get_available_chapters("X") == [
+            {"metadata": {"tags": ["original"]}},
+        ]
+        assert state.get_suspicious_batch("X") == {
+            "chapters": [{"number": "1"}],
+        }
+        assert state.get_failed_chapters("X")["1"]["failed_pages"] == [[1]]
+        assert state.get("custom") == {"nested": ["original"]}
+
+    def test_mutator_that_saves_does_not_deadlock(self, state):
+        # Immediate-save mutators call save() while holding the state
+        # lock — the reentrant lock must let that through.
+        state.set_pending_backup("X", "1", "backup.test", "https://b/1")
+        state.add_failed_chapter("X", "2", "src.test", "boom")
+        state.clear_pending_backup("X", "1")
+        assert state.get_pending_backup("X", "1") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stress (issue #110) — GUI-style worker mutations interleaved with the
+# main thread's periodic flush + close-time save
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestFlushMutationStress:
+    N_MANGA = 4
+    N_CHAPTERS = 25
+    N_SOURCES = 4
+    N_NOTIFICATIONS = 80
+
+    def test_no_lost_updates_under_interleaved_flush(self, state):
+        """Simulate the GUI: download/check/health workers mutating state
+        while the flush timer and close handler serialize it. No chapter,
+        read mark, notification, history entry, or health entry may be
+        lost, and the file on disk must stay valid JSON."""
+        stop = threading.Event()
+        errors = []
+
+        def guarded(fn):
+            def run(*args):
+                try:
+                    fn(*args)
+                except Exception as e:  # pragma: no cover - failure path
+                    errors.append(e)
+            return run
+
+        @guarded
+        def flusher():
+            while True:
+                state.flush()
+                state.save()
+                if stop.is_set():
+                    return
+                time.sleep(0.001)
+
+        @guarded
+        def download_worker(idx):
+            title = "Manga %d" % idx
+            for n in range(1, self.N_CHAPTERS + 1):
+                state.add_downloaded_chapter(title, str(n))
+                state.mark_chapter_read(title, str(n))
+                state.add_download_history(title, str(n), "cbz", size_mb=1.0)
+                state.add_failed_chapter(title, "f%d" % n, "src.test", "boom")
+
+        @guarded
+        def check_worker(idx):
+            title = "Manga %d" % idx
+            for n in range(self.N_CHAPTERS):
+                state.set_new_chapters(title, n)
+                state.set_available_chapters(
+                    title, [dict(number=str(i)) for i in range(n + 1)])
+                state.get_manga_state(title)  # GUI refresh-style read
+                state.get_stats()
+
+        @guarded
+        def health_worker(idx):
+            domain = "src%d.test" % idx
+            for n in range(self.N_CHAPTERS):
+                state.update_source_health(domain, n % 4 != 0,
+                                           "timeout", latency_ms=100 + n)
+                state.get_all_source_health()
+
+        @guarded
+        def notify_worker():
+            for n in range(self.N_NOTIFICATIONS):
+                state.add_notification("download", "n%d" % n)
+                state.get_notifications()
+
+        flush_thread = threading.Thread(target=flusher, daemon=True)
+        workers = []
+        for i in range(self.N_MANGA):
+            workers.append(threading.Thread(target=download_worker, args=(i,)))
+            workers.append(threading.Thread(target=check_worker, args=(i,)))
+        for i in range(self.N_SOURCES):
+            workers.append(threading.Thread(target=health_worker, args=(i,)))
+        workers.append(threading.Thread(target=notify_worker))
+
+        flush_thread.start()
+        for t in workers:
+            t.start()
+        for t in workers:
+            t.join(timeout=60)
+        stop.set()
+        flush_thread.join(timeout=60)
+        alive = [t for t in workers + [flush_thread] if t.is_alive()]
+        assert not alive, "threads deadlocked or still running"
+        assert errors == []
+
+        # In-memory: nothing lost.
+        expected = [str(n) for n in range(1, self.N_CHAPTERS + 1)]
+        for i in range(self.N_MANGA):
+            title = "Manga %d" % i
+            assert sorted(state.get_downloaded_chapters(title),
+                          key=float) == expected
+            assert sorted(state.get_read_chapters(title),
+                          key=float) == expected
+            assert len(state.get_failed_chapters(title)) == self.N_CHAPTERS
+            assert len(state.get_available_chapters(title)) == self.N_CHAPTERS
+        assert len(state.get_download_history(limit=1000)) == \
+            self.N_MANGA * self.N_CHAPTERS
+        assert len(state.get_notifications(limit=1000)) == self.N_NOTIFICATIONS
+        for i in range(self.N_SOURCES):
+            health = state.get_source_health("src%d.test" % i)
+            assert health.get("latency_ms") == 100 + self.N_CHAPTERS - 1
+
+        # On disk: valid JSON that round-trips the same data.
+        data = json.loads(state.state_path.read_text())
+        for i in range(self.N_MANGA):
+            assert sorted(data["manga"]["Manga %d" % i]["downloaded"],
+                          key=float) == expected
+        assert len(data["download_history"]) == self.N_MANGA * self.N_CHAPTERS
+        assert len(data["notifications"]) == self.N_NOTIFICATIONS
+        assert len(data["source_health"]) == self.N_SOURCES

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -192,6 +192,24 @@ class TestConcurrency:
         assert state.get_downloaded_chapters("Existing") == ["1", "2"]
         assert state.get_downloaded_chapters("Missing") == ["9"]
 
+    def test_cli_import_merge_unions_downloaded_under_lock(self, state):
+        state.add_downloaded_chapter("Existing", "1")
+
+        state.merge_missing_manga_state(
+            {
+                "Existing": {"downloaded": ["2", "10"]},
+                "Missing": {"downloaded": ["3"]},
+            },
+            merge_existing_downloaded=True,
+        )
+
+        assert state.get_downloaded_chapters("Existing") == ["1", "2", "10"]
+        assert state.get_downloaded_chapters("Missing") == ["3"]
+
+    def test_import_merge_rejects_non_dict_state(self, state):
+        with pytest.raises(TypeError):
+            state.merge_missing_manga_state([])
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Config persistence — YAML round-trip

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -152,6 +152,46 @@ class TestConcurrency:
         data = json.loads(state.state_path.read_text())
         assert "notifications" in data
 
+    def test_import_merge_serializes_with_worker_mutation(self, state):
+        """Backup merge must not publish an old manga snapshot over workers."""
+        state.add_downloaded_chapter("Existing", "1")
+        worker_started = threading.Event()
+        worker_done = threading.Event()
+        worker_errors = []
+        worker_threads = []
+
+        class InterleavingImport(dict):
+            def items(self):
+                def worker():
+                    try:
+                        worker_started.set()
+                        state.add_downloaded_chapter("Existing", "2")
+                        worker_done.set()
+                    except Exception as exc:  # pragma: no cover - failure path
+                        worker_errors.append(exc)
+
+                thread = threading.Thread(target=worker)
+                worker_threads.append(thread)
+                thread.start()
+                assert worker_started.wait(timeout=5)
+                time.sleep(0.02)
+                assert not worker_done.is_set()
+                return super().items()
+
+        imported = InterleavingImport({
+            "Existing": {"downloaded": ["imported"]},
+            "Missing": {"downloaded": ["9"]},
+        })
+
+        state.merge_missing_manga_state(imported)
+
+        for thread in worker_threads:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+        assert worker_errors == []
+        assert state.get_downloaded_chapters("Existing") == ["1", "2"]
+        assert state.get_downloaded_chapters("Missing") == ["9"]
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Config persistence — YAML round-trip
@@ -331,6 +371,18 @@ class TestGetterIsolation:
         state.add_failed_chapter("X", "2", "src.test", "boom")
         state.clear_pending_backup("X", "1")
         assert state.get_pending_backup("X", "1") is None
+
+    def test_rename_manga_moves_state_entry_and_persists(self, state):
+        state.add_downloaded_chapter("Old", "1")
+
+        assert state.rename_manga("Old", "New") is True
+        assert state.get_manga_state("Old") == {}
+        assert state.get_downloaded_chapters("New") == ["1"]
+        assert "New" in json.loads(state.state_path.read_text())["manga"]
+
+    def test_rename_manga_returns_false_for_missing_entry(self, state):
+        assert state.rename_manga("Missing", "New") is False
+        assert state.get_manga_state("New") == {}
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Make State access consistently synchronized for background GUI workers and import flows, and harden backup state imports against malformed data.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Changes

- Guard State reads, writes, snapshots, flushes, and save publication with one reentrant lock.
- Replace direct GUI state mutation with State APIs and locked backup-state merges.
- Validate backup `state` payloads as objects before import and preserve CLI merge-mode downloaded chapter unions.
- Add regression coverage for concurrent mutation/flush behavior, GUI import serialization, CLI import preservation, and backup validation.

## Testing

- `venv/bin/python -m pytest tests/unit/test_backup.py tests/unit/test_state_persistence.py tests/unit/cli/test_cli_commands.py::TestExportImport -q` (53 passed)
- `venv/bin/python -m pytest tests/unit/test_state.py tests/unit/test_state_persistence.py tests/unit/test_suspicion.py tests/unit/test_backup.py -q` (119 passed)
- `venv/bin/python -m pytest tests/unit/cli/test_cli_commands.py -q` (53 passed)
- `venv/bin/python -m pytest tests/unit/gui/pages/test_pages.py::TestSettingsPage -q` (15 passed)
- `venv/bin/python -m compileall -q memanga tests`
- `git diff --check`

## Related issues

Closes #110
