### PR TITLE
fix(settings): deduplicate merged backup imports

### DIFF
--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -1153,12 +1153,13 @@ class SettingsPage(BasePage):
             else:
                 existing = self.app.config.get("manga", [])
                 existing_titles = {m.get("title", "").lower() for m in existing}
-                added = sum(
-                    1 for m in manga_list if m.get("title", "").lower() not in existing_titles
-                )
+                added = 0
                 for m in manga_list:
-                    if m.get("title", "").lower() not in existing_titles:
+                    title_key = m.get("title", "").lower()
+                    if title_key not in existing_titles:
                         existing.append(m)
+                        existing_titles.add(title_key)
+                        added += 1
                 self.app.config.set("manga", existing)
                 self.app.config.save()
                 self.app.app_state.merge_missing_manga_state(data.get("state", {}))

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -383,6 +383,38 @@ class TestSettingsPage:
         assert expected in submitted["crontab"].splitlines()
         assert f"'{project_dir}'" in submitted["crontab"]
 
+    def test_import_merge_deduplicates_titles_within_backup(
+        self, app_window, qapp, monkeypatch, tmp_path
+    ):
+        import json
+        from PySide6.QtWidgets import QFileDialog
+
+        backup = tmp_path / "duplicates.json"
+        backup.write_text(json.dumps({
+            "version": 1,
+            "manga": [
+                {"title": "Existing", "url": "old",
+                 "source": "mangadex.org", "status": "reading"},
+                {"title": "Fresh", "url": "new",
+                 "source": "mangadex.org", "status": "reading"},
+                {"title": "fresh", "url": "duplicate",
+                 "source": "mangadex.org", "status": "reading"},
+            ],
+            "state": {},
+        }))
+        monkeypatch.setattr(QFileDialog, "getOpenFileName",
+                            staticmethod(lambda *a, **k: (str(backup), "")))
+        app_window.config.set("manga", [
+            {"title": "Existing", "url": "local",
+             "source": "mangadex.org", "status": "reading"}
+        ])
+
+        app_window._pages["settings"]._import(replace=False)
+
+        titles = [m.get("title")
+                  for m in app_window.config.get("manga", []) or []]
+        assert titles == ["Existing", "Fresh"]
+
     def test_import_rejects_versionless_backup(self, app_window, qapp,
                                                monkeypatch, tmp_path):
         # Regression for #42: import never read the export's `version`


### PR DESCRIPTION
## Summary

Deduplicates GUI backup merge imports while processing a single backup file, so repeated imported manga titles only append once during merge mode.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Verification

- `python -m pytest tests/unit/gui/pages/test_pages.py::TestSettingsPage::test_import_merge_deduplicates_titles_within_backup -q` (1 passed)
- `python -m pytest tests/unit/gui/pages/test_pages.py::TestSettingsPage -q` (16 passed)
- `python -m compileall -q memanga tests`
- `git diff --check`
- Offscreen `MeMangaApp` import simulation produced `['Existing', 'Fresh']`

## Related issues

Closes #114