### PR TITLE
fix(backup): merge imported manga state conservatively

### DIFF
--- a/memanga/backup.py
+++ b/memanga/backup.py
@@ -62,3 +62,140 @@ def validate_backup(data: Any) -> dict:
         version += 1
 
     return data
+
+
+def _chapter_sort_key(value: Any):
+    try:
+        return (0, float(value), str(value))
+    except (TypeError, ValueError):
+        return (1, str(value).lower())
+
+
+def _merge_unique_chapters(local: Any, imported: Any) -> list:
+    merged = {str(ch) for ch in (local or [])}
+    merged.update(str(ch) for ch in (imported or []))
+    return sorted(merged, key=_chapter_sort_key)
+
+
+def _chapter_record_key(record: Any):
+    if not isinstance(record, dict):
+        return repr(record)
+    return (
+        str(record.get("number", "")),
+        str(record.get("source_url") or record.get("url") or ""),
+        str(record.get("source", "")),
+        bool(record.get("is_backup", False)),
+    )
+
+
+def _merge_chapter_records(local: Any, imported: Any) -> list:
+    merged = []
+    seen = set()
+    for record in list(local or []) + list(imported or []):
+        key = _chapter_record_key(record)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(record)
+    return merged
+
+
+def _newer_progress(local: Any, imported: Any) -> dict:
+    if not isinstance(local, dict):
+        return imported if isinstance(imported, dict) else {}
+    if not isinstance(imported, dict):
+        return local
+
+    local_time = local.get("last_read")
+    imported_time = imported.get("last_read")
+    if imported_time and (not local_time or str(imported_time) > str(local_time)):
+        return {**local, **imported}
+    return {**imported, **local}
+
+
+def _max_value(local: Any, imported: Any):
+    if local in (None, ""):
+        return imported
+    if imported in (None, ""):
+        return local
+    return max(local, imported)
+
+
+def _max_chapter(local: Any, imported: Any):
+    if local in (None, ""):
+        return imported
+    if imported in (None, ""):
+        return local
+    return max((local, imported), key=_chapter_sort_key)
+
+
+def merge_manga_state(local: Dict[str, Any], imported: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge one manga's imported backup state into local state.
+
+    The policy is intentionally conservative: never replace the whole
+    local record, union list-like chapter state, merge per-chapter maps
+    without overwriting local entries, and only take imported scalar
+    metadata when the local record is missing it.
+    """
+    if not isinstance(local, dict):
+        local = {}
+    if not isinstance(imported, dict):
+        imported = {}
+
+    merged = {**imported, **local}
+
+    for key in ("downloaded", "read_chapters", "external_chapters"):
+        merged[key] = _merge_unique_chapters(local.get(key), imported.get(key))
+
+    for key in ("available_chapters",):
+        merged[key] = _merge_chapter_records(local.get(key), imported.get(key))
+
+    for key in ("failed_chapters", "pending_backup"):
+        imported_map = imported.get(key) if isinstance(imported.get(key), dict) else {}
+        local_map = local.get(key) if isinstance(local.get(key), dict) else {}
+        if imported_map or local_map:
+            merged[key] = {**imported_map, **local_map}
+
+    merged["reading_progress"] = _newer_progress(
+        local.get("reading_progress"),
+        imported.get("reading_progress"),
+    )
+    merged["new_chapters_available"] = _max_value(
+        local.get("new_chapters_available", 0),
+        imported.get("new_chapters_available", 0),
+    ) or 0
+
+    if "last_chapter" in imported or "last_chapter" in local:
+        merged["last_chapter"] = _max_chapter(
+            local.get("last_chapter"),
+            imported.get("last_chapter"),
+        )
+    if "last_updated" in imported or "last_updated" in local:
+        merged["last_updated"] = _max_value(
+            local.get("last_updated"),
+            imported.get("last_updated"),
+        )
+
+    if imported.get("created") and not local.get("created"):
+        merged["created"] = imported["created"]
+
+    return merged
+
+
+def merge_backup_state(
+    local_state: Dict[str, Dict[str, Any]],
+    imported_state: Dict[str, Dict[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
+    """Merge all imported manga state entries into local manga state."""
+    if not isinstance(local_state, dict):
+        local_state = {}
+    if not isinstance(imported_state, dict):
+        imported_state = {}
+
+    merged = dict(local_state)
+    for title, imported_entry in imported_state.items():
+        if title in merged:
+            merged[title] = merge_manga_state(merged[title], imported_entry)
+        else:
+            merged[title] = imported_entry
+    return merged

--- a/memanga/backup.py
+++ b/memanga/backup.py
@@ -12,7 +12,7 @@ show :class:`BackupVersionError` messages to the user as-is, so keep
 them short and self-explanatory.
 """
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Mapping, Optional
 
 EXPORT_VERSION = 1
 
@@ -185,16 +185,33 @@ def merge_manga_state(local: Dict[str, Any], imported: Dict[str, Any]) -> Dict[s
 def merge_backup_state(
     local_state: Dict[str, Dict[str, Any]],
     imported_state: Dict[str, Dict[str, Any]],
+    *,
+    title_aliases: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, Dict[str, Any]]:
     """Merge all imported manga state entries into local manga state."""
     if not isinstance(local_state, dict):
         local_state = {}
     if not isinstance(imported_state, dict):
         imported_state = {}
+    if title_aliases is None:
+        title_aliases = {}
+    casefolded_aliases = {
+        title.casefold(): canonical
+        for title, canonical in title_aliases.items()
+        if isinstance(title, str)
+    }
 
     merged = dict(local_state)
     for title, imported_entry in imported_state.items():
-        if title in merged:
+        alias_title = title_aliases.get(title) if isinstance(title, str) else None
+        if alias_title is None and isinstance(title, str):
+            alias_title = casefolded_aliases.get(title.casefold())
+        if alias_title and alias_title != title:
+            merged[alias_title] = merge_manga_state(
+                merged.get(alias_title, {}),
+                imported_entry,
+            )
+        elif title in merged:
             merged[title] = merge_manga_state(merged[title], imported_entry)
         else:
             merged[title] = imported_entry

--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -19,7 +19,11 @@ from rich.prompt import Prompt, Confirm
 from rich.table import Table
 from rich import box
 
-from .backup import EXPORT_VERSION, BackupVersionError, validate_backup
+from .backup import (
+    EXPORT_VERSION,
+    BackupVersionError,
+    validate_backup,
+)
 from .config import Config, get_app_password, set_app_password
 from .cron import build_cron_line
 from .state import State

--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -1380,15 +1380,24 @@ def cmd_import(args):
     else:
         # Merge mode: skip duplicates, merge chapter lists
         existing_manga = config.get("manga", [])
-        existing_titles = {m["title"].lower() for m in existing_manga}
+        existing_titles = {
+            m["title"].lower(): m["title"]
+            for m in existing_manga
+        }
+        state_title_aliases = {}
         added = 0
         skipped = 0
         for m in imported_manga:
-            if m["title"].lower() in existing_titles:
+            title = m["title"]
+            title_key = title.lower()
+            existing_title = existing_titles.get(title_key)
+            if existing_title is not None:
+                if title != existing_title:
+                    state_title_aliases[title] = existing_title
                 skipped += 1
                 continue
             existing_manga.append(m)
-            existing_titles.add(m["title"].lower())
+            existing_titles[title_key] = title
             added += 1
 
         config.set("manga", existing_manga)
@@ -1396,6 +1405,7 @@ def cmd_import(args):
         state.merge_missing_manga_state(
             imported_state,
             merge_existing_downloaded=True,
+            title_aliases=state_title_aliases,
         )
 
         console.print(f"[green]Imported: {added} added, {skipped} skipped (duplicate)[/green]")

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -1152,19 +1152,29 @@ class SettingsPage(BasePage):
                 Toast(self, f"Replaced with {len(manga_list)} manga", kind="success")
             else:
                 existing = self.app.config.get("manga", [])
-                existing_titles = {m.get("title", "").lower() for m in existing}
+                existing_titles = {
+                    m.get("title", "").lower(): m.get("title", "")
+                    for m in existing
+                }
+                state_title_aliases = {}
                 added = 0
                 for m in manga_list:
-                    title_key = m.get("title", "").lower()
-                    if title_key not in existing_titles:
-                        existing.append(m)
-                        existing_titles.add(title_key)
-                        added += 1
+                    title = m.get("title", "")
+                    title_key = title.lower()
+                    existing_title = existing_titles.get(title_key)
+                    if existing_title is not None:
+                        if title != existing_title:
+                            state_title_aliases[title] = existing_title
+                        continue
+                    existing.append(m)
+                    existing_titles[title_key] = title
+                    added += 1
                 self.app.config.set("manga", existing)
                 self.app.config.save()
                 self.app.app_state.merge_missing_manga_state(
                     data.get("state", {}),
                     merge_existing_downloaded=True,
+                    title_aliases=state_title_aliases,
                 )
                 Toast(self, f"Imported {added} manga", kind="success")
         except json.JSONDecodeError:

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -1162,7 +1162,10 @@ class SettingsPage(BasePage):
                         added += 1
                 self.app.config.set("manga", existing)
                 self.app.config.save()
-                self.app.app_state.merge_missing_manga_state(data.get("state", {}))
+                self.app.app_state.merge_missing_manga_state(
+                    data.get("state", {}),
+                    merge_existing_downloaded=True,
+                )
                 Toast(self, f"Imported {added} manga", kind="success")
         except json.JSONDecodeError:
             Toast(self, "Invalid JSON", kind="error")

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -11,7 +11,7 @@ import threading
 from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Mapping
 
 from .backup import merge_backup_state
 
@@ -175,6 +175,7 @@ class State:
         imported_state: Dict[str, Any],
         *,
         merge_existing_downloaded: bool = False,
+        title_aliases: Optional[Mapping[str, str]] = None,
     ):
         """Merge imported manga state entries without replacing local state.
 
@@ -191,7 +192,11 @@ class State:
             manga = data.setdefault("manga", {})
             if merge_existing_downloaded:
                 data["manga"] = self._snapshot(
-                    merge_backup_state(manga, imported_state)
+                    merge_backup_state(
+                        manga,
+                        imported_state,
+                        title_aliases=title_aliases,
+                    )
                 )
             else:
                 for title, state_data in imported_state.items():

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from datetime import datetime
 from typing import List, Optional, Dict, Any
 
+from .backup import merge_backup_state
+
 
 _LEADING_CHAPTER_RE = re.compile(r"\s*(\d+(?:\.\d+)?)")
 
@@ -187,21 +189,14 @@ class State:
             raise TypeError("imported_state must be a dict")
         with self._locked() as data:
             manga = data.setdefault("manga", {})
-            for title, state_data in imported_state.items():
-                if title in manga and merge_existing_downloaded:
-                    entry = manga[title]
-                    if not isinstance(entry, dict):
-                        entry = {}
-                        manga[title] = entry
-                    if isinstance(state_data, dict):
-                        existing_downloaded = set(entry.get("downloaded", []))
-                        imported_downloaded = set(state_data.get("downloaded", []))
-                        entry["downloaded"] = sorted(
-                            existing_downloaded | imported_downloaded,
-                            key=self._chapter_sort_key,
-                        )
-                elif not manga.get(title):
-                    manga[title] = self._snapshot(state_data)
+            if merge_existing_downloaded:
+                data["manga"] = self._snapshot(
+                    merge_backup_state(manga, imported_state)
+                )
+            else:
+                for title, state_data in imported_state.items():
+                    if not manga.get(title):
+                        manga[title] = self._snapshot(state_data)
             self.save()
 
     # ========================================================================

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -524,6 +524,61 @@ class TestExportImport:
             titles = [m["title"] for m in config.get("manga", []) or []]
             assert "FromImport" in titles
 
+    def test_import_merge_preserves_existing_manga_state(
+            self, run_cli, config, isolated_home, tmp_path):
+        from memanga import cli
+        from memanga.state import State
+
+        config.set("manga", [{"title": "Stateful", "url": "local",
+                              "source": "mangadex.org",
+                              "status": "reading"}])
+        config.save()
+        cli.state = State(config_dir=isolated_home / ".config" / "memanga")
+        cli.state.set("manga", {
+            "Stateful": {
+                "downloaded": ["1"],
+                "read_chapters": ["1"],
+                "failed_chapters": {
+                    "4": {"error": "local", "attempts": 2},
+                },
+                "reading_progress": {
+                    "last_chapter": "1",
+                    "last_read": "2026-07-17T09:00:00",
+                },
+            }
+        })
+        backup = tmp_path / "state.json"
+        backup.write_text(json.dumps({
+            "version": 1,
+            "manga": [{"title": "Stateful", "url": "imported",
+                       "source": "mangadex.org", "status": "reading"}],
+            "state": {
+                "Stateful": {
+                    "downloaded": ["2"],
+                    "read_chapters": ["2"],
+                    "external_chapters": ["3"],
+                    "failed_chapters": {
+                        "4": {"error": "imported", "attempts": 1},
+                        "5": {"error": "backup", "attempts": 1},
+                    },
+                    "reading_progress": {
+                        "last_chapter": "2",
+                        "last_read": "2026-07-17T10:00:00",
+                    },
+                }
+            },
+        }))
+
+        assert run_cli("import", str(backup)) == 0
+
+        merged = cli.state.get("manga", {})["Stateful"]
+        assert merged["downloaded"] == ["1", "2"]
+        assert merged["read_chapters"] == ["1", "2"]
+        assert merged["external_chapters"] == ["3"]
+        assert merged["failed_chapters"]["4"]["error"] == "local"
+        assert merged["failed_chapters"]["5"]["error"] == "backup"
+        assert merged["reading_progress"]["last_chapter"] == "2"
+
     def test_import_roundtrip(self, run_cli, config, tmp_path):
         """An export produced by the CLI must import cleanly (issue #42)."""
         config.set("manga", [{"title": "RoundTrip", "url": "u",

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -550,10 +550,10 @@ class TestExportImport:
         backup = tmp_path / "state.json"
         backup.write_text(json.dumps({
             "version": 1,
-            "manga": [{"title": "Stateful", "url": "imported",
+            "manga": [{"title": "stateful", "url": "imported",
                        "source": "mangadex.org", "status": "reading"}],
             "state": {
-                "Stateful": {
+                "stateful": {
                     "downloaded": ["2"],
                     "read_chapters": ["2"],
                     "external_chapters": ["3"],
@@ -571,13 +571,58 @@ class TestExportImport:
 
         assert run_cli("import", str(backup)) == 0
 
-        merged = cli.state.get("manga", {})["Stateful"]
+        titles = [m["title"] for m in config.get("manga", []) or []]
+        assert titles == ["Stateful"]
+        manga_state = cli.state.get("manga", {})
+        assert list(manga_state) == ["Stateful"]
+        assert "stateful" not in manga_state
+        merged = manga_state["Stateful"]
         assert merged["downloaded"] == ["1", "2"]
         assert merged["read_chapters"] == ["1", "2"]
         assert merged["external_chapters"] == ["3"]
         assert merged["failed_chapters"]["4"]["error"] == "local"
         assert merged["failed_chapters"]["5"]["error"] == "backup"
         assert merged["reading_progress"]["last_chapter"] == "2"
+
+    def test_import_merge_keeps_added_title_state_apart_from_orphan(
+            self, run_cli, config, isolated_home, tmp_path):
+        from memanga import cli
+        from memanga.state import State
+
+        config.set("manga", [])
+        config.save()
+        cli.state = State(config_dir=isolated_home / ".config" / "memanga")
+        cli.state.set("manga", {
+            "Stateful": {
+                "downloaded": ["1"],
+                "failed_chapters": {
+                    "4": {"error": "local", "attempts": 2},
+                },
+            }
+        })
+        backup = tmp_path / "orphan-state.json"
+        backup.write_text(json.dumps({
+            "version": 1,
+            "manga": [{"title": "stateful", "url": "imported",
+                       "source": "mangadex.org", "status": "reading"}],
+            "state": {
+                "stateful": {
+                    "downloaded": ["2"],
+                    "failed_chapters": {
+                        "5": {"error": "backup", "attempts": 1},
+                    },
+                }
+            },
+        }))
+
+        assert run_cli("import", str(backup)) == 0
+
+        titles = [m["title"] for m in config.get("manga", []) or []]
+        assert titles == ["stateful"]
+        manga_state = cli.state.get("manga", {})
+        assert manga_state["Stateful"]["downloaded"] == ["1"]
+        assert manga_state["stateful"]["downloaded"] == ["2"]
+        assert manga_state["stateful"]["failed_chapters"]["5"]["error"] == "backup"
 
     def test_import_roundtrip(self, run_cli, config, tmp_path):
         """An export produced by the CLI must import cleanly (issue #42)."""

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -415,6 +415,63 @@ class TestSettingsPage:
                   for m in app_window.config.get("manga", []) or []]
         assert titles == ["Existing", "Fresh"]
 
+    def test_import_merge_preserves_existing_manga_state(
+        self, app_window, qapp, monkeypatch, tmp_path
+    ):
+        import json
+        from PySide6.QtWidgets import QFileDialog
+
+        backup = tmp_path / "state.json"
+        backup.write_text(json.dumps({
+            "version": 1,
+            "manga": [{"title": "Stateful", "url": "imported",
+                       "source": "mangadex.org", "status": "reading"}],
+            "state": {
+                "Stateful": {
+                    "downloaded": ["2"],
+                    "read_chapters": ["2"],
+                    "external_chapters": ["3"],
+                    "failed_chapters": {
+                        "4": {"error": "imported", "attempts": 1},
+                        "5": {"error": "backup", "attempts": 1},
+                    },
+                    "reading_progress": {
+                        "last_chapter": "2",
+                        "last_read": "2026-07-17T10:00:00",
+                    },
+                }
+            },
+        }))
+        monkeypatch.setattr(QFileDialog, "getOpenFileName",
+                            staticmethod(lambda *a, **k: (str(backup), "")))
+        app_window.config.set("manga", [
+            {"title": "Stateful", "url": "local",
+             "source": "mangadex.org", "status": "reading"}
+        ])
+        app_window.app_state.set("manga", {
+            "Stateful": {
+                "downloaded": ["1"],
+                "read_chapters": ["1"],
+                "failed_chapters": {
+                    "4": {"error": "local", "attempts": 2},
+                },
+                "reading_progress": {
+                    "last_chapter": "1",
+                    "last_read": "2026-07-17T09:00:00",
+                },
+            }
+        })
+
+        app_window._pages["settings"]._import(replace=False)
+
+        merged = app_window.app_state.get("manga", {})["Stateful"]
+        assert merged["downloaded"] == ["1", "2"]
+        assert merged["read_chapters"] == ["1", "2"]
+        assert merged["external_chapters"] == ["3"]
+        assert merged["failed_chapters"]["4"]["error"] == "local"
+        assert merged["failed_chapters"]["5"]["error"] == "backup"
+        assert merged["reading_progress"]["last_chapter"] == "2"
+
     def test_import_rejects_versionless_backup(self, app_window, qapp,
                                                monkeypatch, tmp_path):
         # Regression for #42: import never read the export's `version`

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -424,10 +424,10 @@ class TestSettingsPage:
         backup = tmp_path / "state.json"
         backup.write_text(json.dumps({
             "version": 1,
-            "manga": [{"title": "Stateful", "url": "imported",
+            "manga": [{"title": "stateful", "url": "imported",
                        "source": "mangadex.org", "status": "reading"}],
             "state": {
-                "Stateful": {
+                "stateful": {
                     "downloaded": ["2"],
                     "read_chapters": ["2"],
                     "external_chapters": ["3"],
@@ -464,13 +464,59 @@ class TestSettingsPage:
 
         app_window._pages["settings"]._import(replace=False)
 
-        merged = app_window.app_state.get("manga", {})["Stateful"]
+        titles = [m["title"] for m in app_window.config.get("manga", []) or []]
+        assert titles == ["Stateful"]
+        manga_state = app_window.app_state.get("manga", {})
+        assert list(manga_state) == ["Stateful"]
+        assert "stateful" not in manga_state
+        merged = manga_state["Stateful"]
         assert merged["downloaded"] == ["1", "2"]
         assert merged["read_chapters"] == ["1", "2"]
         assert merged["external_chapters"] == ["3"]
         assert merged["failed_chapters"]["4"]["error"] == "local"
         assert merged["failed_chapters"]["5"]["error"] == "backup"
         assert merged["reading_progress"]["last_chapter"] == "2"
+
+    def test_import_merge_keeps_added_title_state_apart_from_orphan(
+        self, app_window, qapp, monkeypatch, tmp_path
+    ):
+        import json
+        from PySide6.QtWidgets import QFileDialog
+
+        backup = tmp_path / "orphan-state.json"
+        backup.write_text(json.dumps({
+            "version": 1,
+            "manga": [{"title": "stateful", "url": "imported",
+                       "source": "mangadex.org", "status": "reading"}],
+            "state": {
+                "stateful": {
+                    "downloaded": ["2"],
+                    "failed_chapters": {
+                        "5": {"error": "backup", "attempts": 1},
+                    },
+                }
+            },
+        }))
+        monkeypatch.setattr(QFileDialog, "getOpenFileName",
+                            staticmethod(lambda *a, **k: (str(backup), "")))
+        app_window.config.set("manga", [])
+        app_window.app_state.set("manga", {
+            "Stateful": {
+                "downloaded": ["1"],
+                "failed_chapters": {
+                    "4": {"error": "local", "attempts": 2},
+                },
+            }
+        })
+
+        app_window._pages["settings"]._import(replace=False)
+
+        titles = [m["title"] for m in app_window.config.get("manga", []) or []]
+        assert titles == ["stateful"]
+        manga_state = app_window.app_state.get("manga", {})
+        assert manga_state["Stateful"]["downloaded"] == ["1"]
+        assert manga_state["stateful"]["downloaded"] == ["2"]
+        assert manga_state["stateful"]["failed_chapters"]["5"]["error"] == "backup"
 
     def test_import_rejects_versionless_backup(self, app_window, qapp,
                                                monkeypatch, tmp_path):

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -15,6 +15,8 @@ import pytest
 from memanga.backup import (
     EXPORT_VERSION,
     BackupVersionError,
+    merge_backup_state,
+    merge_manga_state,
     validate_backup,
     _MIGRATIONS,
 )
@@ -64,3 +66,75 @@ class TestValidateBackup:
         )
         out = validate_backup({"version": 0, "manga": []})
         assert out["migrated"] is True
+
+
+class TestMergeMangaState:
+    def test_preserves_local_and_imported_progress_fields(self):
+        local = {
+            "downloaded": ["1", "3"],
+            "read_chapters": ["1"],
+            "external_chapters": ["7"],
+            "failed_chapters": {
+                "4": {"error": "local", "attempts": 2},
+            },
+            "available_chapters": [
+                {"number": "1", "source": "local", "source_url": "local/1"},
+            ],
+            "reading_progress": {
+                "last_chapter": "3",
+                "last_read": "2026-07-17T09:00:00",
+            },
+            "new_chapters_available": 1,
+        }
+        imported = {
+            "downloaded": ["2", "3"],
+            "read_chapters": ["2"],
+            "external_chapters": ["8"],
+            "failed_chapters": {
+                "4": {"error": "imported", "attempts": 1},
+                "5": {"error": "backup", "attempts": 1},
+            },
+            "available_chapters": [
+                {"number": "1", "source": "local", "source_url": "local/1"},
+                {"number": "2", "source": "backup", "source_url": "backup/2"},
+            ],
+            "reading_progress": {
+                "last_chapter": "5",
+                "last_read": "2026-07-17T10:00:00",
+            },
+            "new_chapters_available": 4,
+        }
+
+        merged = merge_manga_state(local, imported)
+
+        assert merged["downloaded"] == ["1", "2", "3"]
+        assert merged["read_chapters"] == ["1", "2"]
+        assert merged["external_chapters"] == ["7", "8"]
+        assert merged["failed_chapters"]["4"]["error"] == "local"
+        assert merged["failed_chapters"]["5"]["error"] == "backup"
+        assert merged["available_chapters"] == [
+            {"number": "1", "source": "local", "source_url": "local/1"},
+            {"number": "2", "source": "backup", "source_url": "backup/2"},
+        ]
+        assert merged["reading_progress"]["last_chapter"] == "5"
+        assert merged["new_chapters_available"] == 4
+
+    def test_merge_backup_state_adds_new_titles(self):
+        merged = merge_backup_state(
+            {"Local": {"downloaded": ["1"]}},
+            {
+                "Local": {"downloaded": ["2"]},
+                "Imported": {"read_chapters": ["9"]},
+            },
+        )
+
+        assert merged["Local"]["downloaded"] == ["1", "2"]
+        assert merged["Imported"]["read_chapters"] == ["9"]
+
+    def test_last_chapter_uses_chapter_order_not_string_order(self):
+        merged = merge_manga_state(
+            {"last_chapter": "9"},
+            {"last_chapter": "10"},
+        )
+
+        assert merged["last_chapter"] == "10"

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -131,6 +131,43 @@ class TestMergeMangaState:
         assert merged["Local"]["downloaded"] == ["1", "2"]
         assert merged["Imported"]["read_chapters"] == ["9"]
 
+    def test_merge_backup_state_alias_preserves_local_key_casing(self):
+        merged = merge_backup_state(
+            {
+                "Stateful": {
+                    "downloaded": ["1"],
+                    "failed_chapters": {
+                        "4": {"error": "local", "attempts": 2},
+                    },
+                }
+            },
+            {
+                "stateful": {
+                    "downloaded": ["2"],
+                    "failed_chapters": {
+                        "4": {"error": "imported", "attempts": 1},
+                        "5": {"error": "backup", "attempts": 1},
+                    },
+                }
+            },
+            title_aliases={"stateful": "Stateful"},
+        )
+
+        assert list(merged) == ["Stateful"]
+        assert merged["Stateful"]["downloaded"] == ["1", "2"]
+        assert merged["Stateful"]["failed_chapters"]["4"]["error"] == "local"
+        assert merged["Stateful"]["failed_chapters"]["5"]["error"] == "backup"
+        assert "stateful" not in merged
+
+    def test_merge_backup_state_keeps_new_import_casing_without_alias(self):
+        merged = merge_backup_state(
+            {"Stateful": {"downloaded": ["1"]}},
+            {"stateful": {"downloaded": ["2"]}},
+        )
+
+        assert merged["Stateful"]["downloaded"] == ["1"]
+        assert merged["stateful"]["downloaded"] == ["2"]
+
     def test_last_chapter_uses_chapter_order_not_string_order(self):
         merged = merge_manga_state(
             {"last_chapter": "9"},


### PR DESCRIPTION
## Summary

Merges imported backup state for existing manga through a shared helper used by both CLI and GUI import paths. The merge keeps local state as the conflict winner where appropriate while unioning chapter lists and preserving useful imported metadata.

Also preserves local title casing for case-insensitive duplicate imports and keeps newly added titles separate from stale orphan state entries.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #115