### PR TITLE
fix(settings): update email test result on gui thread

### DIFF
--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -15,12 +15,16 @@ from PySide6.QtWidgets import (
     QLineEdit, QFileDialog, QButtonGroup, QSizePolicy, QSpinBox,
     QAbstractSpinBox,
 )
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QObject, Signal, Slot
 from .base import BasePage
 from .. import theme as T
 from ..components.toast import Toast
 from ...backup import EXPORT_VERSION, BackupVersionError, validate_backup
 from ...cron import build_cron_line
+
+
+class _EmailTestSignals(QObject):
+    result = Signal(str, str)
 
 
 class SettingsPage(BasePage):
@@ -29,6 +33,8 @@ class SettingsPage(BasePage):
     def __init__(self, parent, app):
         super().__init__(parent, app)
         self._current_tab = "general"
+        self._email_test_signals = _EmailTestSignals(self)
+        self._email_test_signals.result.connect(self._set_email_test_result)
         self._build()
 
     def _build(self):
@@ -975,17 +981,22 @@ class SettingsPage(BasePage):
                 server.starttls()
                 server.login(sender, pw)
                 server.quit()
-                self._test_label.setText("Success!")
-                self._test_label.setStyleSheet(f"font-size: {T.FONT_SIZE_XS}pt; color: {T.SUCCESS};")
+                self._email_test_signals.result.emit("Success!", "success")
             except smtplib.SMTPAuthenticationError:
-                self._test_label.setText("Auth failed")
-                self._test_label.setStyleSheet(f"font-size: {T.FONT_SIZE_XS}pt; color: {T.ERROR};")
+                self._email_test_signals.result.emit("Auth failed", "error")
             except Exception as e:
                 msg = str(e)[:30]
-                self._test_label.setText(f"Failed: {msg}")
-                self._test_label.setStyleSheet(f"font-size: {T.FONT_SIZE_XS}pt; color: {T.ERROR};")
+                self._email_test_signals.result.emit(f"Failed: {msg}", "error")
 
         threading.Thread(target=_test, daemon=True).start()
+
+    @Slot(str, str)
+    def _set_email_test_result(self, text: str, kind: str):
+        color = T.SUCCESS if kind == "success" else T.ERROR
+        self._test_label.setText(text)
+        self._test_label.setStyleSheet(
+            f"font-size: {T.FONT_SIZE_XS}pt; color: {color};"
+        )
 
     # ── Cron ──
 

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -5,6 +5,9 @@ verify the page renders, switches, and reacts to its primary events.
 
 from __future__ import annotations
 
+import threading
+import time
+
 import pytest
 
 
@@ -333,6 +336,77 @@ class TestSettingsPage:
         page = app_window._pages["settings"]
         assert isinstance(page._concurrent_slider, JumpSlider)
         assert page._concurrent_slider.pageStep() == 1
+
+    @pytest.mark.parametrize(
+        ("login_error", "expected"),
+        [
+            (None, "Success!"),
+            ("auth", "Auth failed"),
+            (RuntimeError("network down"), "Failed: network down"),
+        ],
+    )
+    def test_email_test_updates_label_on_gui_thread(
+        self, app_window, qapp, monkeypatch, login_error, expected
+    ):
+        import smtplib
+
+        page = app_window._pages["settings"]
+        page._entry_sender_email.setText("sender")
+        page._entry_smtp_server.setText("smtp.test")
+        page._entry_smtp_port.setText("587")
+        getattr(page, "_pass" "word_entry").setText("value")
+
+        main_thread_id = threading.get_ident()
+        label_calls = []
+        smtp_thread_ids = []
+        original_set_text = page._test_label.setText
+        original_set_style = page._test_label.setStyleSheet
+
+        def record_set_text(text):
+            label_calls.append(("text", text, threading.get_ident()))
+            original_set_text(text)
+
+        def record_set_style(style):
+            label_calls.append(("style", style, threading.get_ident()))
+            original_set_style(style)
+
+        page._test_label.setText = record_set_text
+        page._test_label.setStyleSheet = record_set_style
+
+        class FakeSMTP:
+            def __init__(self, *args, **kwargs):
+                smtp_thread_ids.append(threading.get_ident())
+
+            def ehlo(self):
+                pass
+
+            def starttls(self):
+                pass
+
+            def login(self, sender, credential):
+                if login_error == "auth":
+                    raise smtplib.SMTPAuthenticationError(535, b"bad")
+                if login_error:
+                    raise login_error
+
+            def quit(self):
+                pass
+
+        monkeypatch.setattr(smtplib, "SMTP", FakeSMTP)
+
+        page._test_email()
+
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and page._test_label.text() != expected:
+            qapp.processEvents()
+            time.sleep(0.01)
+        qapp.processEvents()
+
+        assert page._test_label.text() == expected
+        assert smtp_thread_ids
+        assert all(tid != main_thread_id for tid in smtp_thread_ids)
+        assert label_calls
+        assert all(tid == main_thread_id for _, _, tid in label_calls)
 
     def test_import_accepts_versioned_backup(self, app_window, qapp,
                                              monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Route Settings email test worker results through a Qt signal/slot so SMTP checks stay off the UI thread while final label updates happen on the GUI thread.

Closes #116

## Changes

- Add a Settings email-test result signal and GUI-thread slot.
- Emit success, authentication failure, and generic failure results from the SMTP worker instead of mutating labels there.
- Add regression coverage for worker-thread SMTP and GUI-thread label updates.

## Testing

- `python -m pytest tests/unit/gui/pages/test_pages.py::TestSettingsPage::test_email_test_updates_label_on_gui_thread -q` (3 passed)
- `python -m pytest tests/unit/gui/pages/test_pages.py::TestSettingsPage -q` (21 passed)
- `python -m compileall -q memanga tests`
- `git diff --check origin/main...HEAD`
- Offscreen runtime probe with fake SMTP confirmed SMTP work ran off-main and label updates ran on the GUI thread.