### PR TITLE
feat(downloads): track accepted partial chapters

### DIFF
--- a/memanga/backup.py
+++ b/memanga/backup.py
@@ -150,7 +150,7 @@ def merge_manga_state(local: Dict[str, Any], imported: Dict[str, Any]) -> Dict[s
     for key in ("available_chapters",):
         merged[key] = _merge_chapter_records(local.get(key), imported.get(key))
 
-    for key in ("failed_chapters", "pending_backup"):
+    for key in ("failed_chapters", "pending_backup", "partial_chapters"):
         imported_map = imported.get(key) if isinstance(imported.get(key), dict) else {}
         local_map = local.get(key) if isinstance(local.get(key), dict) else {}
         if imported_map or local_map:

--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -558,7 +558,7 @@ def cmd_check(args):
                     except EmailError as email_e:
                         console.print(f"     [red]📧 Email failed: {email_e}[/red]")
 
-                def _announce_saved(file_path, from_backup, partial):
+                def _announce_saved(file_path, from_backup, partial, source=None):
                     """Print the save line and, for partials, warn + log which
                     pages are missing so headless runs leave a trail."""
                     label = f"{file_path.parent.name}/{file_path.name}/" if file_path.is_dir() else file_path.name
@@ -575,7 +575,17 @@ def cmd_check(args):
                             f"'{title}' Chapter {ch.number} saved as partial: "
                             f"{len(miss)}/{total} page(s) missing (pages {miss}).",
                         )
+                        state.add_partial_chapter(
+                            title,
+                            ch.number,
+                            source=source or "",
+                            failed_pages=miss,
+                            total_pages=total,
+                            path=str(file_path),
+                            from_backup=from_backup,
+                        )
                     else:
+                        state.clear_partial_chapter(title, ch.number)
                         console.print(f"     [green]✅ Saved{src}: {label}[/green]")
 
                 try:
@@ -602,7 +612,12 @@ def cmd_check(args):
                         partial_threshold=partial_threshold,
                         on_partial=_capture_partial,
                     )
-                    _announce_saved(file_path, from_backup=False, partial=dict(partial_info))
+                    _announce_saved(
+                        file_path,
+                        from_backup=False,
+                        partial=dict(partial_info),
+                        source=getattr(ch, "source", None) or "unknown",
+                    )
                     _deliver_email(file_path)
 
                     # Update state
@@ -636,7 +651,12 @@ def cmd_check(args):
                                 max_retries=max_retries,
                                 post_processing=post_processing,
                             )
-                            _announce_saved(file_path, from_backup=True, partial=None)
+                            _announce_saved(
+                                file_path,
+                                from_backup=True,
+                                partial=None,
+                                source=getattr(backup_ch, "source", None),
+                            )
                             _deliver_email(file_path)
                             state.add_downloaded_chapter(title, ch.number)
                             state.clear_pending_backup(title, ch.number)
@@ -671,7 +691,12 @@ def cmd_check(args):
                                 )
                             except DownloaderError:
                                 continue
-                            _announce_saved(file_path, from_backup=from_backup, partial=dict(partial_info))
+                            _announce_saved(
+                                file_path,
+                                from_backup=from_backup,
+                                partial=dict(partial_info),
+                                source=getattr(cand, "source", None),
+                            )
                             _deliver_email(file_path)
                             state.add_downloaded_chapter(title, ch.number)
                             state.clear_pending_backup(title, ch.number)
@@ -1412,8 +1437,9 @@ def cmd_import(args):
 
 
 def cmd_failed(args):
-    """List and manage chapters that failed to download."""
+    """List and manage chapters that failed or were accepted as partial."""
     all_failed = state.get_all_failed_chapters()
+    all_partials = state.get_all_partial_chapters()
 
     # Filter by title if requested
     if args.title:
@@ -1421,36 +1447,59 @@ def cmd_failed(args):
             t: chapters for t, chapters in all_failed.items()
             if args.title.lower() in t.lower()
         }
+        all_partials = {
+            t: chapters for t, chapters in all_partials.items()
+            if args.title.lower() in t.lower()
+        }
 
-    if not all_failed:
-        console.print("[dim]No failed chapters recorded.[/dim]")
+    retryable = {}
+    for manga_title, chapters in all_failed.items():
+        retryable.setdefault(manga_title, {}).update(chapters)
+    for manga_title, chapters in all_partials.items():
+        bucket = retryable.setdefault(manga_title, {})
+        for chapter_num, info in chapters.items():
+            if chapter_num in bucket:
+                continue
+            bucket[chapter_num] = {
+                **info,
+                "partial": True,
+                "error": "Accepted partial download",
+            }
+
+    if not retryable:
+        console.print("[dim]No failed or partial chapters recorded.[/dim]")
         return
 
     table = Table(
-        title="⚠️  Failed Chapter Downloads",
+        title="⚠️  Retryable Chapter Downloads",
         box=box.ROUNDED,
         show_lines=True,
     )
     table.add_column("Manga", style="cyan bold")
     table.add_column("Chapter", style="yellow", justify="center")
-    table.add_column("Failed At", style="dim")
+    table.add_column("Status", justify="center")
+    table.add_column("Recorded At", style="dim")
     table.add_column("Source", style="green")
-    table.add_column("Pages Failed", justify="center")
+    table.add_column("Pages Missing", justify="center")
     table.add_column("Attempts", justify="center")
-    table.add_column("Error", style="red", no_wrap=False, max_width=40)
+    table.add_column("Reason", style="red", no_wrap=False, max_width=40)
 
-    for manga_title, chapters in sorted(all_failed.items()):
+    for manga_title, chapters in sorted(retryable.items()):
         for chapter_num, info in sorted(chapters.items(), key=lambda x: float(x[0]) if x[0].replace('.', '', 1).isdigit() else 0):
-            failed_at = info.get("failed_at", "")[:16].replace("T", " ")
+            is_partial = bool(info.get("partial")) or "accepted_at" in info
+            recorded_at = (
+                info.get("accepted_at") if is_partial else info.get("failed_at", "")
+            )[:16].replace("T", " ")
             pages = info.get("failed_pages", [])
             pages_str = str(pages) if pages else "—"
             table.add_row(
                 manga_title,
                 chapter_num,
-                failed_at,
+                "partial" if is_partial else "failed",
+                recorded_at,
                 info.get("source", "?"),
                 pages_str,
-                str(info.get("attempts", 1)),
+                "—" if is_partial else str(info.get("attempts", 1)),
                 info.get("error", ""),
             )
 
@@ -1461,7 +1510,10 @@ def cmd_failed(args):
         for manga_title, chapters in all_failed.items():
             for chapter_num in list(chapters):
                 state.clear_failed_chapter(manga_title, chapter_num)
-        console.print("[green]✅ Cleared all failure records.[/green]")
+        for manga_title, chapters in all_partials.items():
+            for chapter_num in list(chapters):
+                state.clear_partial_chapter(manga_title, chapter_num)
+        console.print("[green]✅ Cleared all failure and partial records.[/green]")
         return
 
     if args.retry:
@@ -1475,7 +1527,7 @@ def cmd_failed(args):
         retried = 0
         succeeded = 0
 
-        for manga_title, chapters in all_failed.items():
+        for manga_title, chapters in retryable.items():
             manga = manga_by_title.get(manga_title)
             if not manga:
                 console.print(f"  [yellow]⚠️  Manga not found in config: {manga_title}[/yellow]")
@@ -1532,6 +1584,7 @@ def cmd_failed(args):
 
                     state.add_downloaded_chapter(manga_title, chapter_num)
                     state.clear_failed_chapter(manga_title, chapter_num)
+                    state.clear_partial_chapter(manga_title, chapter_num)
                     succeeded += 1
                 except DownloaderError as retry_e:
                     # Try backup if available
@@ -1542,6 +1595,7 @@ def cmd_failed(args):
                             file_path = download_chapter(manga, backup_ch, download_dir, output_format, post_processing=post_processing)
                             state.add_downloaded_chapter(manga_title, chapter_num)
                             state.clear_failed_chapter(manga_title, chapter_num)
+                            state.clear_partial_chapter(manga_title, chapter_num)
                             label = f"{file_path.parent.name}/{file_path.name}/" if file_path.is_dir() else file_path.name
                             console.print(f"  [green]✅ Saved from backup: {label}[/green]")
                             succeeded += 1

--- a/memanga/gui/app.py
+++ b/memanga/gui/app.py
@@ -268,12 +268,22 @@ class MeMangaApp(QMainWindow):
         if partial:
             miss = partial.get("failed_pages", [])
             total = partial.get("total", 0)
+            self.app_state.add_partial_chapter(
+                title,
+                str(chapter),
+                source=data.get("source", ""),
+                failed_pages=miss,
+                total_pages=total,
+                path=path,
+                from_backup=bool(data.get("from_backup")),
+            )
             self.app_state.add_notification(
                 "warn",
                 f"Downloaded {title} Ch. {chapter} as partial: "
                 f"{len(miss)}/{total} page(s) missing (pages {miss}).",
             )
         else:
+            self.app_state.clear_partial_chapter(title, str(chapter))
             self.app_state.add_notification("download", f"Downloaded {title} Ch. {chapter}")
         self.events.publish("notification_added", {})
 

--- a/memanga/gui/assets/icons/__init__.py
+++ b/memanga/gui/assets/icons/__init__.py
@@ -162,6 +162,13 @@ ICONS: dict[str, str] = {
         '<path d="m10 14 10-10"/>'
         '</g></svg>'
     ),
+    "alert_triangle": (
+        '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">'
+        '<g fill="none" stroke="{color}" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round">'
+        '<path d="M10.3 4.5 2.7 18a2 2 0 0 0 1.7 3h15.2a2 2 0 0 0 1.7-3L13.7 4.5a2 2 0 0 0-3.4 0z"/>'
+        '<path d="M12 9v4"/><path d="M12 17h.01"/>'
+        '</g></svg>'
+    ),
 }
 
 

--- a/memanga/gui/pages/detail.py
+++ b/memanga/gui/pages/detail.py
@@ -451,6 +451,7 @@ class DetailPage(BasePage):
         downloaded = self.app.app_state.get_downloaded_chapters(title)
         available = self.app.app_state.get_available_chapters(title)
         external = self.app.app_state.get_external_chapters(title)
+        partials = self.app.app_state.get_partial_chapters(title)
 
         # Build the merged set, keyed by chapter number string.
         # Available entries provide source/url metadata; downloaded entries
@@ -484,6 +485,7 @@ class DetailPage(BasePage):
 
         # Section header: "Chapters" h3 + "{dl} downloaded · {total} total · {new} new"
         n_dl = len(downloaded)
+        n_partial = len(partials)
         n_total = len(merged)
         n_new = self.app.app_state.get_new_chapters(title) or 0
         head_row = QHBoxLayout()
@@ -492,7 +494,7 @@ class DetailPage(BasePage):
         head_row.addWidget(h_lbl)
         head_row.addStretch(1)
         sub = QLabel(
-            f"{n_dl} downloaded  ·  {n_total} total  ·  {n_new} new"
+            f"{n_dl} downloaded  ·  {n_partial} partial  ·  {n_total} total  ·  {n_new} new"
         )
         sub.setProperty("role", "mono_meta")
         head_row.addWidget(sub)
@@ -515,7 +517,7 @@ class DetailPage(BasePage):
         # runs on every chip click via _set_chapter_filter, so resetting to
         # "all" here would clobber the click before the new chips paint.
         # Same fix-shape as the Newest/Oldest sort combo two sessions ago.
-        valid_filters = {"all", "downloaded", "not_downloaded", "unread"}
+        valid_filters = {"all", "downloaded", "partial", "not_downloaded", "unread"}
         current_filter = getattr(self, "_chapter_filter", "all")
         if current_filter not in valid_filters:
             current_filter = "all"
@@ -524,6 +526,7 @@ class DetailPage(BasePage):
         for key, label, count in [
             ("all", "All", n_total),
             ("downloaded", "Downloaded", n_dl),
+            ("partial", "Partial", n_partial),
             ("not_downloaded", "Not downloaded", n_total - n_dl),
             ("unread", "Unread", n_unread),
         ]:
@@ -575,11 +578,14 @@ class DetailPage(BasePage):
         for i, num in enumerate(sorted_nums):
             entry = merged[num]
             is_dl = self.app.app_state.is_chapter_downloaded(title, num)
+            partial_info = partials.get(num) if is_dl else None
             is_external = (not is_dl and self.app.app_state.is_external_chapter(title, num))
 
             # Filter
             f = self._chapter_filter
             if f == "downloaded" and not is_dl:
+                continue
+            if f == "partial" and not partial_info:
                 continue
             if f == "not_downloaded" and is_dl:
                 continue
@@ -610,7 +616,14 @@ class DetailPage(BasePage):
             status_box.setFixedSize(28, 28)
             status_box.setAlignment(Qt.AlignmentFlag.AlignCenter)
             toks = T.tokens()
-            if is_read:
+            if partial_info:
+                status_box.setPixmap(
+                    _ic("alert_triangle", toks["status.warn"], 15).pixmap(QSize(15, 15)))
+                status_box.setStyleSheet(
+                    f"background-color: {toks['status.warn_soft']};"
+                    f"border-radius: 6px;"
+                )
+            elif is_read:
                 # Filled bright accent — strongest visual weight.
                 status_box.setPixmap(
                     _ic("check", toks["accent.on_primary"], 14).pixmap(QSize(14, 14)))
@@ -665,7 +678,14 @@ class DetailPage(BasePage):
                 f"font-size: 12pt; font-weight: {title_weight}; color: {title_color};"
             )
             title_l.addWidget(main_title)
-            if is_read:
+            if partial_info:
+                missing = partial_info.get("failed_pages", [])
+                total = partial_info.get("total_pages", 0)
+                sub_state = (
+                    f"Partial - {len(missing)}/{total} page(s) missing"
+                    if total else "Partial - missing pages"
+                )
+            elif is_read:
                 sub_state = "Read"
             elif is_dl:
                 sub_state = "Downloaded"
@@ -690,7 +710,27 @@ class DetailPage(BasePage):
                 ch_row.addWidget(date_lbl, 0, Qt.AlignmentFlag.AlignVCenter)
 
             # Action column
-            if is_dl:
+            if partial_info:
+                actions = QHBoxLayout()
+                actions.setSpacing(8)
+                retry_btn = QPushButton("Retry")
+                retry_btn.setProperty("size", "sm")
+                retry_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+                retry_btn.clicked.connect(
+                    lambda _, e=entry, b=retry_btn: self._download_chapter(
+                        e, b, retry_partial=True
+                    )
+                )
+                actions.addWidget(retry_btn, 0, Qt.AlignmentFlag.AlignVCenter)
+
+                read_btn = QPushButton("Read")
+                read_btn.setProperty("variant", "primary")
+                read_btn.setProperty("size", "sm")
+                read_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+                read_btn.clicked.connect(lambda _, c=num: self._read_chapter(c))
+                actions.addWidget(read_btn, 0, Qt.AlignmentFlag.AlignVCenter)
+                ch_row.addLayout(actions)
+            elif is_dl:
                 btn = QPushButton("Read")
                 btn.setProperty("variant", "primary")
                 btn.setProperty("size", "sm")
@@ -1095,7 +1135,7 @@ class DetailPage(BasePage):
 
     # ── Per-chapter manual download ──
 
-    def _download_chapter(self, ch_dict: dict, button=None):
+    def _download_chapter(self, ch_dict: dict, button=None, retry_partial=False):
         """Queue a single chapter for download (manual-mode flow).
 
         Reconstructs a ``ChapterWithSource`` from the cached entry and routes
@@ -1169,7 +1209,11 @@ class DetailPage(BasePage):
             button.setText("Queued")
             self._pending_downloads[f"{self._manga['title']}:{number}"] = button
 
-        Toast(self, f"Queued Chapter {number}", kind="info")
+        Toast(
+            self,
+            f"Retrying partial Chapter {number}" if retry_partial else f"Queued Chapter {number}",
+            kind="info",
+        )
 
     def _on_any_download_complete(self, data):
         """Refresh the chapter list when a download for the current manga

--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -464,7 +464,7 @@ class BackgroundWorker:
             partial_info["failed_pages"] = failed_pages
             partial_info["total"] = total
 
-        def _finish(path, from_backup):
+        def _finish(path, from_backup, source=None):
             """Deliver to Kindle (if configured) and publish
             download_complete, carrying any accepted partial detail."""
             # Kindle delivery
@@ -490,6 +490,7 @@ class BackgroundWorker:
                 "title": manga["title"],
                 "chapter": chapter.number,
                 "from_backup": from_backup,
+                "source": source or getattr(chapter, "source", None) or manga.get("source", "?"),
             }
             if partial_info:
                 complete_payload["partial"] = dict(partial_info)
@@ -536,7 +537,11 @@ class BackgroundWorker:
                 partial_threshold=partial_threshold,
                 on_partial=on_partial,
             )
-            _finish(path, from_backup=False)
+            _finish(
+                path,
+                from_backup=False,
+                source=getattr(chapter, "source", None) or manga.get("source", "?"),
+            )
         except InterruptedError:
             self._events.publish("download_cancelled", {"task_id": task_id})
         except DownloaderError as e:
@@ -634,7 +639,7 @@ class BackgroundWorker:
             partial_info.clear()
             try:
                 path = _dl(backup_ch, False)
-                finish(path, from_backup=True)
+                finish(path, from_backup=True, source=getattr(backup_ch, "source", None))
                 return
             except DownloaderError as be:
                 backup_err = be
@@ -656,7 +661,7 @@ class BackgroundWorker:
                     path = _dl(cand, True)
                 except DownloaderError:
                     continue
-                finish(path, from_backup=from_backup)
+                finish(path, from_backup=from_backup, source=getattr(cand, "source", None))
                 return
 
         # 3) Nothing worked — surface the failure.

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -390,6 +390,62 @@ class State:
                 del failed[chapter_str]
                 self.save()
 
+    # ========================================================================
+    # Accepted Partial Chapter Tracking
+    # ========================================================================
+
+    def add_partial_chapter(
+        self,
+        manga_title: str,
+        chapter: str,
+        source: str = "",
+        failed_pages: Optional[List[int]] = None,
+        total_pages: int = 0,
+        path: str = "",
+        from_backup: bool = False,
+    ):
+        """Record an accepted partial chapter so it remains retryable."""
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            chapter_str = str(chapter)
+            entry = data["manga"][manga_title]
+            entry.setdefault("partial_chapters", {})[chapter_str] = {
+                "accepted_at": datetime.now().isoformat(),
+                "source": source,
+                "failed_pages": self._snapshot(failed_pages or []),
+                "total_pages": int(total_pages or 0),
+                "path": path,
+                "from_backup": bool(from_backup),
+            }
+            self.save()
+
+    def get_partial_chapters(self, manga_title: str) -> Dict[str, Any]:
+        """Get accepted partial chapter records for a manga."""
+        return self._entry_value(manga_title, "partial_chapters", {})
+
+    def get_partial_chapter(self, manga_title: str, chapter: str) -> Optional[Dict[str, Any]]:
+        """Get one accepted partial chapter record."""
+        partials = self.get_partial_chapters(manga_title)
+        return partials.get(str(chapter))
+
+    def get_all_partial_chapters(self) -> Dict[str, Dict[str, Any]]:
+        """Get accepted partial chapters for all manga."""
+        with self._locked() as data:
+            return {
+                title: self._snapshot(partials)
+                for title, manga_state in data.get("manga", {}).items()
+                if (partials := manga_state.get("partial_chapters", {}))
+            }
+
+    def clear_partial_chapter(self, manga_title: str, chapter: str):
+        """Remove an accepted partial record after a complete re-download."""
+        with self._locked() as data:
+            chapter_str = str(chapter)
+            partials = data.get("manga", {}).get(manga_title, {}).get("partial_chapters", {})
+            if chapter_str in partials:
+                del partials[chapter_str]
+                self.save()
+
     def _ensure_manga_entry(self, manga_title: str):
         """Ensure manga entry exists in state. Caller must hold ``_lock``."""
         if "manga" not in self._data:
@@ -404,6 +460,7 @@ class State:
                 "new_chapters_available": 0,
                 "available_chapters": [],
                 "external_chapters": [],
+                "partial_chapters": {},
             }
 
     # ========================================================================
@@ -857,6 +914,7 @@ class State:
             if from_chapter == 0:
                 entry["last_chapter"] = None
                 entry["downloaded"] = []
+                entry["partial_chapters"] = {}
             else:
                 # Keep only chapters before from_chapter, remove the rest.
                 # Labelled chapters (e.g. "Chapter 3" or "3 Part 1") compare
@@ -870,6 +928,11 @@ class State:
                     ch for ch in entry.get("downloaded", [])
                     if _keep_downloaded(ch)
                 ]
+                entry["partial_chapters"] = {
+                    ch: info
+                    for ch, info in entry.get("partial_chapters", {}).items()
+                    if _keep_downloaded(ch)
+                }
                 entry["last_chapter"] = None
             entry["last_updated"] = datetime.now().isoformat()
             self.save()

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -349,6 +349,7 @@ class TestCheckCommand:
         assert rc == 0
         assert sent == [partial_path]
         assert cli.state.is_chapter_downloaded("Vinland Saga", "71")
+        assert cli.state.get_partial_chapter("Vinland Saga", "71")["failed_pages"] == [7]
         notifications = cli.state.get("notifications", [])
         assert any("saved as partial" in n["message"] for n in notifications)
 
@@ -397,6 +398,49 @@ class TestCheckCommand:
         assert not cli.state.is_chapter_downloaded("Vinland Saga", "71")
         failed = cli.state.get_failed_chapters("Vinland Saga")
         assert "71" in failed
+
+    def test_failed_retry_includes_accepted_partials(
+            self, run_cli, config, monkeypatch, tmp_path):
+        from memanga import cli
+        from memanga.scrapers.base import Chapter
+        from memanga.state import State
+
+        config.set("manga", [{
+            "title": "Vinland Saga",
+            "status": "reading",
+            "source": "primary.test",
+            "url": "https://primary.test/vs",
+        }])
+        config.save()
+
+        cli.state = State()
+        cli.state.add_downloaded_chapter("Vinland Saga", "71")
+        cli.state.add_partial_chapter(
+            "Vinland Saga",
+            "71",
+            source="primary.test",
+            failed_pages=[7],
+            total_pages=40,
+        )
+        fixed_path = tmp_path / "fixed.pdf"
+        fixed_path.write_bytes(b"%PDF")
+
+        primary_ch = Chapter(
+            number="71", title="", url="https://primary.test/c/71", date=None,
+        )
+
+        class FakeScraper:
+            def get_chapters(self, url):
+                return [primary_ch]
+
+        monkeypatch.setattr(cli, "get_scraper", lambda source: FakeScraper())
+        monkeypatch.setattr(cli, "download_chapter", lambda *a, **k: fixed_path)
+
+        rc = run_cli("failed", "--retry")
+
+        assert rc == 0
+        assert cli.state.is_chapter_downloaded("Vinland Saga", "71")
+        assert cli.state.get_partial_chapter("Vinland Saga", "71") is None
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -42,6 +42,29 @@ def test_download_complete_clears_failed_chapter(app_window, qapp):
     assert "1" not in app_window.app_state.get_failed_chapters("M")
 
 
+def test_download_complete_records_and_clears_partial_chapter(app_window, qapp):
+    app_window._on_download_complete({
+        "title": "M",
+        "chapter": "1",
+        "path": "/tmp/M-1.pdf",
+        "source": "mangadex.org",
+        "from_backup": True,
+        "partial": {"failed_pages": [4, 8], "total": 40},
+    })
+    qapp.processEvents()
+
+    partial = app_window.app_state.get_partial_chapter("M", "1")
+    assert partial["failed_pages"] == [4, 8]
+    assert partial["total_pages"] == 40
+    assert partial["source"] == "mangadex.org"
+    assert partial["from_backup"] is True
+
+    app_window._on_download_complete({"title": "M", "chapter": "1", "path": ""})
+    qapp.processEvents()
+
+    assert app_window.app_state.get_partial_chapter("M", "1") is None
+
+
 # ─────────────────────────────────────────────────────────────────────────
 # Library
 # ─────────────────────────────────────────────────────────────────────────
@@ -672,6 +695,37 @@ class TestDetailPage:
         # last_chapter set to 4.999 so check_for_updates returns 5+
         assert app_window.app_state.get_last_chapter(
             sample_manga["title"]) == "4.999"
+
+    def test_partial_chapter_retry_queues_even_when_downloaded(
+            self, app_window, qapp, sample_manga):
+        title = sample_manga["title"]
+        app_window.config.set("manga", [sample_manga])
+        app_window.app_state.set_available_chapters(title, [{
+            "number": "7",
+            "title": "Partial chapter",
+            "source": "mangadex.org",
+            "source_url": "https://mangadex.org/title/abc/test-manga",
+            "url": "https://mangadex.org/chapter/7",
+            "is_backup": False,
+        }])
+        app_window.app_state.add_downloaded_chapter(title, "7")
+        app_window.app_state.add_partial_chapter(
+            title, "7", failed_pages=[3], total_pages=20,
+        )
+        app_window.show_page("detail", manga=sample_manga); qapp.processEvents()
+        page = app_window._pages["detail"]
+
+        queued = []
+        app_window.worker.download_chapter = (
+            lambda **kw: queued.append(str(kw["chapter"].number))
+        )
+
+        page._download_chapter(
+            app_window.app_state.get_available_chapters(title)[0],
+            retry_partial=True,
+        )
+
+        assert queued == ["7"]
 
 
 class TestDownloadsQueueing:

--- a/tests/unit/gui/test_workers.py
+++ b/tests/unit/gui/test_workers.py
@@ -216,6 +216,7 @@ class TestPartialDownload:
         assert seen_kwargs == {"allow_partial": True, "partial_threshold": 5}
         assert completed and completed[0].get("partial") == {
             "failed_pages": [6], "total": 40}
+        assert completed[0].get("source") == "?"
 
 
 class TestBackupFirst:

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -69,6 +69,24 @@ class TestValidateBackup:
 
 
 class TestMergeMangaState:
+    def test_partial_chapters_preserve_imported_records_and_local_conflicts(self):
+        local = {
+            "partial_chapters": {
+                "4": {"pages": ["local-1.jpg"], "error": "local"},
+            }
+        }
+        imported = {
+            "partial_chapters": {
+                "4": {"pages": ["imported-1.jpg"], "error": "imported"},
+                "5": {"pages": ["imported-2.jpg"], "error": "backup"},
+            }
+        }
+
+        merged = merge_manga_state(local, imported)
+
+        assert merged["partial_chapters"]["4"] == local["partial_chapters"]["4"]
+        assert merged["partial_chapters"]["5"] == imported["partial_chapters"]["5"]
+
     def test_preserves_local_and_imported_progress_fields(self):
         local = {
             "downloaded": ["1", "3"],

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -124,6 +124,46 @@ class TestChapterTracking:
         assert state.get_downloaded_chapters("X") == ["Extra", "1"]
 
 
+class TestPartialChapters:
+    """Accepted partial downloads stay visible and retryable (#117)."""
+
+    def test_add_get_and_clear_partial_chapter(self, state):
+        state.add_partial_chapter(
+            "X",
+            "5",
+            source="mangadex.org",
+            failed_pages=[3, 9],
+            total_pages=40,
+            path="/tmp/x.pdf",
+            from_backup=True,
+        )
+
+        partial = state.get_partial_chapter("X", "5")
+        assert partial["source"] == "mangadex.org"
+        assert partial["failed_pages"] == [3, 9]
+        assert partial["total_pages"] == 40
+        assert partial["path"] == "/tmp/x.pdf"
+        assert partial["from_backup"] is True
+        assert "X" in state.get_all_partial_chapters()
+
+        state.clear_partial_chapter("X", "5")
+
+        assert state.get_partial_chapter("X", "5") is None
+
+    def test_reset_manga_progress_clears_requeued_partial_records(self, state):
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "5")
+        state.add_partial_chapter("X", "1", failed_pages=[2], total_pages=20)
+        state.add_partial_chapter("X", "5", failed_pages=[4], total_pages=20)
+
+        state.reset_manga_progress("X", from_chapter=5)
+
+        assert "1" in state.get_downloaded_chapters("X")
+        assert "5" not in state.get_downloaded_chapters("X")
+        assert "1" in state.get_partial_chapters("X")
+        assert "5" not in state.get_partial_chapters("X")
+
+
 class TestExternalChapters:
     def test_mark_and_check_external(self, state):
         state.mark_external_chapter("X", "3")


### PR DESCRIPTION
## Summary

Tracks accepted partial downloads separately from completed chapters so users can find and retry chapters that were saved with missing pages.

Closes #117

## Changes

- Store accepted partial chapter metadata, including missing pages, total page count, source, path, and backup origin.
- Surface partial chapters in the GUI detail view with a partial status and retry action.
- Include accepted partial chapters in `memanga failed`, including retry and clear flows.
- Preserve partial chapter records during backup state merges.

## Testing

- `python -m pytest tests/unit/test_backup.py tests/unit/test_state.py -q` (88 passed)
- `python -m pytest tests/unit/gui/test_workers.py -q` (42 passed)
- `python -m pytest tests/unit/cli/test_cli_commands.py -q` (56 passed)
- `python -m pytest tests/unit/gui/pages/test_pages.py::TestDetailPage tests/unit/gui/pages/test_pages.py::TestDownloadsQueueing tests/unit/gui/pages/test_pages.py::test_download_complete_clears_failed_chapter tests/unit/gui/pages/test_pages.py::test_download_complete_records_and_clears_partial_chapter -q` (11 passed)
- `python -m compileall -q memanga tests`
- Runtime GUI probe for partial recording, retry queueing, and clean-completion clearing
- Runtime CLI probe for `memanga failed --retry` partial recovery
- Runtime backup merge probe for preserving imported partial records
