### PR TITLE
fix(downloads): settle auto badge by batch

### DIFF
--- a/memanga/gui/app.py
+++ b/memanga/gui/app.py
@@ -45,6 +45,7 @@ class MeMangaApp(QMainWindow):
         # Cover URLs we already tried to replace after a failed fetch —
         # once per URL per session, see _on_cover_load_failed.
         self._cover_fallback_attempted: set = set()
+        self._new_chapter_batches: dict[str, dict[str, set[str]]] = {}
 
         # Centralised network status — probes connectivity in a daemon
         # thread, publishes `network_online` / `network_offline` events.
@@ -62,6 +63,7 @@ class MeMangaApp(QMainWindow):
         self.events.subscribe("cover_loaded", self._on_cover_load_failed)
         self.events.subscribe("download_complete", self._on_download_complete)
         self.events.subscribe("download_error", self._on_download_error)
+        self.events.subscribe("download_cancelled", self._on_download_cancelled)
         self.events.subscribe("check_complete", self._on_check_complete)
         self.events.subscribe("check_error", self._on_check_error)
         self.events.subscribe("kindle_sent", self._on_kindle_sent)
@@ -301,12 +303,66 @@ class MeMangaApp(QMainWindow):
         self.app_state.add_downloaded_chapter(title, str(chapter))
         self.app_state.clear_failed_chapter(title, str(chapter))
 
-        # Badge update depends on mode:
-        #   auto   → batch download flushes the whole badge at once
-        #   manual → user picked one chapter; just decrement
-        if self._get_manga_mode(title) == "manual":
+        self._settle_new_chapter_download(
+            title, data.get("task_id"), failed=False
+        )
+
+    def register_new_chapter_batch(
+        self,
+        title: str,
+        task_ids,
+        already_resolved: int = 0,
+    ):
+        """Track an auto-mode batch so badges clear only after it settles."""
+        if not title or self._get_manga_mode(title) != "auto":
+            return
+
+        if already_resolved > 0:
+            current = self.app_state.get_new_chapters(title)
+            remaining = max(0, current - int(already_resolved))
+            if remaining:
+                self.app_state.set_new_chapters(title, remaining)
+            else:
+                self.app_state.clear_new_chapters(title)
+
+        accepted = set(task_ids)
+        if not accepted:
+            return
+
+        batch = self._new_chapter_batches.setdefault(
+            title, {"pending": set(), "failed": set()}
+        )
+        batch["pending"].update(accepted)
+
+    def _settle_new_chapter_download(
+        self, title: str, task_id: str | None, failed: bool
+    ):
+        """Update new-chapter badges when a queued chapter reaches terminal state."""
+        if not title:
+            return
+
+        batch = self._new_chapter_batches.get(title)
+        if batch:
+            if not task_id or task_id not in batch["pending"]:
+                return
+            batch["pending"].remove(task_id)
+            if failed:
+                batch["failed"].add(task_id)
+            else:
+                self.app_state.decrement_new_chapters(title)
+            if batch["pending"]:
+                return
+
+            self._new_chapter_batches.pop(title, None)
+            if not self.app_state.get_new_chapters(title):
+                self.app_state.clear_new_chapters(title)
+            return
+
+        # Non-batch fallback: manual downloads are one-offs; legacy auto
+        # paths that bypass DownloadsPage keep the old clear-on-success behavior.
+        if self._get_manga_mode(title) == "manual" and not failed:
             self.app_state.decrement_new_chapters(title)
-        else:
+        elif not failed:
             self.app_state.clear_new_chapters(title)
 
     def _resolve_external_threshold(self, manga, threshold_raw, all_chapters) -> bool:
@@ -405,6 +461,19 @@ class MeMangaApp(QMainWindow):
         error = data.get("error", "Unknown")
         self.app_state.add_notification("error", f"Failed: {title} - {error[:50]}")
         self.events.publish("notification_added", {})
+        self._settle_new_chapter_download(
+            title, data.get("task_id"), failed=True
+        )
+
+    def _on_download_cancelled(self, data):
+        title = data.get("title", "")
+        if not title:
+            task_id = data.get("task_id", "")
+            if ":" in task_id:
+                title = task_id.rsplit(":", 1)[0]
+        self._settle_new_chapter_download(
+            title, data.get("task_id"), failed=True
+        )
 
     def _on_check_complete(self, data):
         results = data.get("results", [])

--- a/memanga/gui/pages/downloads.py
+++ b/memanga/gui/pages/downloads.py
@@ -571,9 +571,12 @@ class DownloadsPage(BasePage):
         post_processing = self.app.config.get("delivery.post_processing")
 
         skipped = 0
+        jobs = []
+        auto_batches: dict[str, dict[str, object]] = {}
         for r in to_queue:
             manga = r["manga"]
             m_title = manga.get("title", "")
+            is_auto = manga.get("mode", "auto") == "auto"
             for ch in r["chapters"]:
                 # Issue #15: never re-queue a chapter that's already on
                 # disk. Belt-and-suspenders against any caller that
@@ -581,6 +584,11 @@ class DownloadsPage(BasePage):
                 # auto-check, etc.).
                 if self.app.app_state.is_chapter_downloaded(m_title, str(ch.number)):
                     skipped += 1
+                    if is_auto:
+                        batch = auto_batches.setdefault(
+                            m_title, {"task_ids": [], "resolved": 0}
+                        )
+                        batch["resolved"] += 1
                     continue
 
                 kindle_cfg = None
@@ -594,15 +602,39 @@ class DownloadsPage(BasePage):
                         "smtp_port": self.app.config.get("email.smtp_port", 587),
                     }
 
-                self.app.worker.download_chapter(
-                    manga=manga, chapter=ch,
-                    output_dir=self.app.config.download_dir,
-                    output_format=self.app.config.output_format,
-                    state=self.app.app_state, kindle_cfg=kindle_cfg,
-                    naming_template=naming_template,
-                    post_processing=post_processing,
-                    allow_partial=self.app.config.partial_enabled,
-                    partial_threshold=self.app.config.partial_threshold,
-                )
+                jobs.append({
+                    "manga": manga,
+                    "chapter": ch,
+                    "kindle_cfg": kindle_cfg,
+                    "task_id": f"{m_title}:{ch.number}",
+                })
+
+                if is_auto:
+                    batch = auto_batches.setdefault(
+                        m_title, {"task_ids": [], "resolved": 0}
+                    )
+                    batch["task_ids"].append(jobs[-1]["task_id"])
+
+        # Worker task ids follow the title:chapter-number contract. Register
+        # every expected auto task before enqueue so even an immediate terminal
+        # event can settle the batch.
+        for title, batch in auto_batches.items():
+            self.app.register_new_chapter_batch(
+                title,
+                task_ids=batch["task_ids"],
+                already_resolved=batch["resolved"],
+            )
+
+        for job in jobs:
+            self.app.worker.download_chapter(
+                manga=job["manga"], chapter=job["chapter"],
+                output_dir=self.app.config.download_dir,
+                output_format=self.app.config.output_format,
+                state=self.app.app_state, kindle_cfg=job["kindle_cfg"],
+                naming_template=naming_template,
+                post_processing=post_processing,
+                allow_partial=self.app.config.partial_enabled,
+                partial_threshold=self.app.config.partial_threshold,
+            )
         if skipped:
             Toast(self, f"Skipped {skipped} chapter(s) already on disk", kind="info")

--- a/memanga/gui/workers.py
+++ b/memanga/gui/workers.py
@@ -189,7 +189,7 @@ class BackgroundWorker:
                 cache.mark_failed(url)
             self._events.publish("cover_loaded", {"url": url, "error": True,
                                                     "offline": True})
-            return
+            return None
 
         def _task():
             try:
@@ -375,7 +375,7 @@ class BackgroundWorker:
             # and a check outside the lock leaves a duplicate race.
             existing = self._cancel_flags.get(task_id)
             if existing is not None and not existing.is_set():
-                return
+                return None
             cancel = threading.Event()
             self._cancel_flags[task_id] = cancel
             item = {
@@ -404,6 +404,7 @@ class BackgroundWorker:
                     "title": manga["title"],
                     "chapter": chapter.number,
                 })
+        return task_id
 
     def cancel_download(self, task_id: str):
         """Signal a download to cancel."""

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -716,9 +716,11 @@ class TestDetailPage:
         page = app_window._pages["detail"]
 
         queued = []
-        app_window.worker.download_chapter = (
-            lambda **kw: queued.append(str(kw["chapter"].number))
-        )
+        def accept(**kw):
+            number = str(kw["chapter"].number)
+            queued.append(number)
+            return f"{title}:{number}"
+        app_window.worker.download_chapter = accept
 
         page._download_chapter(
             app_window.app_state.get_available_chapters(title)[0],
@@ -809,6 +811,220 @@ class TestDownloadsQueueing:
         })
         # Chapter 1 is already on disk; only 2 is queued.
         assert queued == ["2"]
+
+    def test_auto_badge_clears_after_batch_finishes(self, app_window, qapp,
+                                                    sample_manga):
+        manga = {**sample_manga, "mode": "auto"}
+        title = manga["title"]
+        app_window.config.set("manga", [manga])
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+        queued = []
+        def accept(**kw):
+            number = str(kw["chapter"].number)
+            queued.append(number)
+            return f"{title}:{number}"
+        app_window.worker.download_chapter = accept
+        data = {"results": [self._result(manga, "1", "2")]}
+
+        app_window._on_check_complete(data)
+        page._on_check_complete(data)
+
+        assert queued == ["1", "2"]
+        assert app_window.app_state.get_new_chapters(title) == 2
+
+        app_window._on_download_complete({
+            "task_id": f"{title}:1", "title": title, "chapter": "1", "path": "",
+        })
+
+        assert app_window.app_state.get_new_chapters(title) == 1
+
+        app_window._on_download_complete({
+            "task_id": f"{title}:2", "title": title, "chapter": "2", "path": "",
+        })
+
+        assert app_window.app_state.get_new_chapters(title) == 0
+
+    def test_auto_badge_keeps_failed_batch_count(self, app_window, qapp,
+                                                 sample_manga):
+        manga = {**sample_manga, "mode": "auto"}
+        title = manga["title"]
+        app_window.config.set("manga", [manga])
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+        app_window.worker.download_chapter = (
+            lambda **kw: f"{title}:{kw['chapter'].number}"
+        )
+        data = {"results": [self._result(manga, "1", "2")]}
+
+        app_window._on_check_complete(data)
+        page._on_check_complete(data)
+        app_window._on_download_complete({
+            "task_id": f"{title}:1", "title": title, "chapter": "1", "path": "",
+        })
+        app_window._on_download_error({
+            "title": title,
+            "chapter": "2",
+            "task_id": f"{title}:2",
+            "error": "boom",
+        })
+
+        assert app_window.app_state.get_new_chapters(title) == 1
+
+    def test_manual_badge_unchanged_after_download_error(
+            self, app_window, sample_manga):
+        manga = {**sample_manga, "mode": "manual"}
+        title = manga["title"]
+        app_window.config.set("manga", [manga])
+        app_window.app_state.set_new_chapters(title, 2)
+
+        app_window._on_download_error({
+            "title": title,
+            "chapter": "1",
+            "task_id": f"{title}:1",
+            "error": "boom",
+        })
+
+        assert app_window.app_state.get_new_chapters(title) == 2
+
+    def test_manual_badge_unchanged_after_download_cancelled(
+            self, app_window, sample_manga):
+        manga = {**sample_manga, "mode": "manual"}
+        title = manga["title"]
+        app_window.config.set("manga", [manga])
+        app_window.app_state.set_new_chapters(title, 2)
+
+        app_window._on_download_cancelled({
+            "title": title,
+            "task_id": f"{title}:1",
+        })
+
+        assert app_window.app_state.get_new_chapters(title) == 2
+
+    def test_auto_batch_cancelled_uses_task_id_title_fallback(
+            self, app_window, sample_manga):
+        manga = {**sample_manga, "mode": "auto"}
+        title = manga["title"]
+        task_id = f"{title}:1"
+        app_window.config.set("manga", [manga])
+        app_window.app_state.set_new_chapters(title, 1)
+        app_window.register_new_chapter_batch(title, [task_id])
+
+        app_window._on_download_cancelled({"task_id": task_id})
+
+        assert app_window.app_state.get_new_chapters(title) == 1
+        assert title not in app_window._new_chapter_batches
+
+    def test_auto_badge_accounts_for_skipped_downloaded_chapters(
+            self, app_window, qapp, sample_manga):
+        manga = {**sample_manga, "mode": "auto"}
+        title = manga["title"]
+        app_window.config.set("manga", [manga])
+        app_window.app_state.add_downloaded_chapter(title, "1")
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+        queued = []
+        def accept(**kw):
+            number = str(kw["chapter"].number)
+            queued.append(number)
+            return f"{title}:{number}"
+        app_window.worker.download_chapter = accept
+        data = {"results": [self._result(manga, "1", "2")]}
+
+        app_window._on_check_complete(data)
+        page._on_check_complete(data)
+
+        assert queued == ["2"]
+        assert app_window.app_state.get_new_chapters(title) == 1
+
+        app_window._on_download_complete({
+            "task_id": f"{title}:2", "title": title, "chapter": "2", "path": "",
+        })
+
+        assert app_window.app_state.get_new_chapters(title) == 0
+
+    def test_overlapping_duplicate_check_waits_for_original_terminal_event(
+            self, app_window, qapp, sample_manga):
+        manga = {**sample_manga, "mode": "auto"}
+        title = manga["title"]
+        app_window.config.set("manga", [manga])
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+        accepted = iter((f"{title}:1", None))
+        app_window.worker.download_chapter = lambda **kw: next(accepted)
+        task_id = f"{title}:1"
+        data = {"results": [self._result(manga, "1")]}
+
+        # The first check starts the download. A second overlapping check sees
+        # the same task id and the worker rejects that duplicate enqueue.
+        app_window._on_check_complete(data)
+        page._on_check_complete(data)
+        app_window._on_check_complete(data)
+        page._on_check_complete(data)
+
+        assert app_window._new_chapter_batches[title]["pending"] == {task_id}
+
+        # The original download's terminal event still owns and settles it.
+        app_window._on_download_complete({
+            "task_id": task_id, "title": title, "chapter": "1", "path": "",
+        })
+
+        assert app_window.app_state.get_new_chapters(title) == 0
+        assert title not in app_window._new_chapter_batches
+
+    def test_immediate_terminal_event_settles_pre_registered_task(
+            self, app_window, qapp, sample_manga):
+        manga = {**sample_manga, "mode": "auto"}
+        title = manga["title"]
+        task_id = f"{title}:1"
+        app_window.config.set("manga", [manga])
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+
+        def complete_immediately(**kw):
+            app_window._on_download_complete({
+                "task_id": task_id,
+                "title": title,
+                "chapter": str(kw["chapter"].number),
+                "path": "",
+            })
+            return task_id
+
+        app_window.worker.download_chapter = complete_immediately
+        data = {"results": [self._result(manga, "1")]}
+
+        app_window._on_check_complete(data)
+        page._on_check_complete(data)
+
+        assert app_window.app_state.get_new_chapters(title) == 0
+        assert title not in app_window._new_chapter_batches
+
+    def test_unrelated_same_title_completion_does_not_consume_batch(
+            self, app_window, qapp, sample_manga):
+        manga = {**sample_manga, "mode": "auto"}
+        title = manga["title"]
+        app_window.config.set("manga", [manga])
+        app_window.show_page("downloads"); qapp.processEvents()
+        page = app_window._pages["downloads"]
+        app_window.worker.download_chapter = (
+            lambda **kw: f"{title}:{kw['chapter'].number}"
+        )
+        data = {"results": [self._result(manga, "1")]}
+
+        app_window._on_check_complete(data)
+        page._on_check_complete(data)
+        app_window._on_download_complete({
+            "task_id": f"manual-{title}:99", "title": title,
+            "chapter": "99", "path": "",
+        })
+
+        assert app_window.app_state.get_new_chapters(title) == 1
+
+        app_window._on_download_complete({
+            "task_id": f"{title}:1", "title": title,
+            "chapter": "1", "path": "",
+        })
+        assert app_window.app_state.get_new_chapters(title) == 0
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Track auto-mode new-chapter batches by download task id instead of title-level counters.
- Keep badges accurate through multi-chapter batches, failures, cancellations, skipped chapters, overlapping checks, and immediate terminal events.
- Keep existing manual download fallback behavior while preserving manual failed/cancelled badges.

## Tests
- python -m pytest tests/unit/gui/pages/test_pages.py::TestDownloadsQueueing tests/unit/gui/pages/test_pages.py::test_download_complete_clears_failed_chapter -q
- python -m pytest tests/unit/gui/test_workers.py -q
- python -m pytest tests/unit/gui/pages/test_pages.py::TestDetailPage -q
- python -m compileall -q memanga tests && git diff --check

Closes #118