### PR TITLE
fix(settings): group reader controls

### DIFF
--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -493,6 +493,40 @@ class SettingsPage(BasePage):
     def _build_advanced(self):
         f = self._advanced_layout
 
+        # Reader prefetch (issue #107)
+        self._section(f, "Reader")
+        prefetch_hint = QLabel(
+            "While reading a manual-mode manga, download the next chapter "
+            "in the background so Next continues without leaving the reader."
+        )
+        prefetch_hint.setProperty("role", "hint")
+        prefetch_hint.setWordWrap(True)
+        f.addWidget(prefetch_hint)
+
+        self._prefetch_check = QCheckBox("Prefetch the next chapter while reading")
+        self._prefetch_check.setChecked(self.app.config.reader_prefetch_enabled)
+        f.addWidget(self._prefetch_check)
+
+        # Remove chapters after reading (issue #104)
+        remove_read_hint = QLabel(
+            "Delete a chapter's local download once you finish it in the "
+            "built-in reader. Read progress is kept, so the chapter simply "
+            "returns to the Download state on the Detail page."
+        )
+        remove_read_hint.setProperty("role", "hint")
+        remove_read_hint.setWordWrap(True)
+        f.addWidget(remove_read_hint)
+
+        self._remove_after_read_check = QCheckBox(
+            "Remove chapters after reading"
+        )
+        self._remove_after_read_check.setChecked(
+            self.app.config.get("reader.remove_after_read", False)
+        )
+        f.addWidget(self._remove_after_read_check)
+
+        f.addSpacing(T.PAD_XL)
+
         # Scheduled checks
         self._section(f, "Scheduled Checks")
         cron_row = QHBoxLayout()
@@ -579,22 +613,6 @@ class SettingsPage(BasePage):
 
         f.addSpacing(T.PAD_XL)
 
-        # Reader prefetch (issue #107)
-        self._section(f, "Reader")
-        prefetch_hint = QLabel(
-            "While reading a manual-mode manga, download the next chapter "
-            "in the background so Next continues without leaving the reader."
-        )
-        prefetch_hint.setProperty("role", "hint")
-        prefetch_hint.setWordWrap(True)
-        f.addWidget(prefetch_hint)
-
-        self._prefetch_check = QCheckBox("Prefetch the next chapter while reading")
-        self._prefetch_check.setChecked(self.app.config.reader_prefetch_enabled)
-        f.addWidget(self._prefetch_check)
-
-        f.addSpacing(T.PAD_XL)
-
         # Post-processing
         self._section(f, "Post-Processing")
 
@@ -644,27 +662,6 @@ class SettingsPage(BasePage):
         pp_hint.setProperty("role", "hint")
         f.addWidget(pp_hint)
         self._refresh_post_processing_enabled()
-
-        f.addSpacing(T.PAD_XL)
-
-        # Remove chapters after reading (issue #104)
-        self._section(f, "Reader Cleanup")
-        remove_read_hint = QLabel(
-            "Delete a chapter's local download once you finish it in the "
-            "built-in reader. Read progress is kept, so the chapter simply "
-            "returns to the Download state on the Detail page."
-        )
-        remove_read_hint.setProperty("role", "hint")
-        remove_read_hint.setWordWrap(True)
-        f.addWidget(remove_read_hint)
-
-        self._remove_after_read_check = QCheckBox(
-            "Remove chapters after reading"
-        )
-        self._remove_after_read_check.setChecked(
-            self.app.config.get("reader.remove_after_read", False)
-        )
-        f.addWidget(self._remove_after_read_check)
 
         f.addSpacing(T.PAD_XL)
 

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -347,6 +347,38 @@ class TestSettingsPage:
         assert app_window.config.get("reader.remove_after_read") is False
         assert not page._remove_after_read_check.isChecked()
 
+    def test_advanced_tab_section_order(self, app_window, qapp):
+        # The remove-after-read toggle lives in the Reader section next to
+        # the prefetch toggle, and Reader leads the Advanced tab.
+        from PySide6.QtWidgets import QLabel
+
+        page = app_window._pages["settings"]
+        layout = page._advanced_layout
+        titles = {}
+        positions = {}
+        for i in range(layout.count()):
+            w = layout.itemAt(i).widget()
+            if w is None:
+                continue
+            positions[w] = i
+            if isinstance(w, QLabel) and "bold" in w.styleSheet():
+                titles[w.text()] = i
+
+        assert list(titles) == [
+            "Reader",
+            "Scheduled Checks",
+            "Partial Chapters",
+            "Post-Processing",
+            "Import / Export",
+            "Diagnostics",
+        ]
+        assert (
+            titles["Reader"]
+            < positions[page._prefetch_check]
+            < positions[page._remove_after_read_check]
+            < titles["Scheduled Checks"]
+        )
+
     def test_template_preview_substitutes(self, app_window, qapp):
         page = app_window._pages["settings"]
         page._naming_entry.setText("X-{chapter}")


### PR DESCRIPTION
## Summary

Moves the Advanced tab's Reader section to the top and groups the remove-after-read setting with the existing reader prefetch setting.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Testing

- `python -m pytest tests/unit/gui/pages/test_pages.py -k 'SettingsPage and (remove_after_read or advanced_tab_section_order)' -q` - 3 passed, 80 deselected
- `python -m pytest tests/unit/gui/pages/test_pages.py::TestSettingsPage -q` - 24 passed
- `python -m compileall -q memanga tests` - passed
- `git diff --check` - passed
- Offscreen Settings probe verified Reader is first, Reader Cleanup is absent, and prefetch appears before remove-after-read.

## Related issues

Refs #104
