### PR TITLE
fix(security): harden mail and download paths

### DIFF
--- a/memanga/downloader.py
+++ b/memanga/downloader.py
@@ -1374,7 +1374,12 @@ def _sanitize_filename(name: str) -> str:
     invalid_chars = '<>:"/\\|?*'
     for char in invalid_chars:
         name = name.replace(char, '')
-    return name.strip()[:100]  # Limit length
+    name = name.strip()[:100]  # Limit length
+    # Never yield a dot-only ('.', '..') or empty result; those are
+    # directory references, not usable path components.
+    if not name.strip('.'):
+        return 'untitled'
+    return name
 
 
 def rename_manga_downloads(download_dir, old_title: str, new_title: str) -> bool:

--- a/memanga/emailer.py
+++ b/memanga/emailer.py
@@ -6,6 +6,7 @@ Automatically splits large PDFs that exceed Gmail's 25MB limit.
 
 import shutil
 import smtplib
+import ssl
 import tempfile
 from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
@@ -233,8 +234,9 @@ def _send_single_email(
     
     # Send
     try:
+        context = ssl.create_default_context()
         with smtplib.SMTP(smtp_server, smtp_port) as server:
-            server.starttls()
+            server.starttls(context=context)
             server.login(sender_email, app_password)
             server.send_message(msg)
         return True
@@ -260,8 +262,9 @@ def test_email_config(
         True if connection successful
     """
     try:
+        context = ssl.create_default_context()
         with smtplib.SMTP(smtp_server, smtp_port) as server:
-            server.starttls()
+            server.starttls(context=context)
             server.login(sender_email, app_password)
         return True
     except Exception:

--- a/memanga/gui/pages/reader.py
+++ b/memanga/gui/pages/reader.py
@@ -21,6 +21,22 @@ from .base import BasePage
 from .. import theme as T
 
 
+def _is_inside_download_dir(candidate: Path, download_dir: Path) -> bool:
+    """True when *candidate* resolves to a location strictly inside
+    *download_dir*.
+
+    Validates that the candidate resolves strictly inside the download
+    directory. The download root itself does not qualify. Either path
+    may be non-existent; resolution is done without requiring existence.
+    """
+    try:
+        resolved = candidate.resolve()
+        root = download_dir.resolve()
+    except OSError:
+        return False
+    return resolved != root and resolved.is_relative_to(root)
+
+
 def _extract_images_from_file(filepath: Path) -> List[QImage]:
     """Extract images from a downloaded chapter file."""
     suffix = filepath.suffix.lower()
@@ -1206,7 +1222,11 @@ class ReaderPage(BasePage):
 
         manga_dirs = []
         for d in (download_dir / _sanitize_filename(title), download_dir / title):
-            if d.is_dir() and d not in manga_dirs:
+            if (
+                d.is_dir()
+                and d not in manga_dirs
+                and _is_inside_download_dir(d, download_dir)
+            ):
                 manga_dirs.append(d)
 
         for manga_dir in manga_dirs:
@@ -1221,8 +1241,15 @@ class ReaderPage(BasePage):
                         self._artifact_path = filepath
                         return _extract_images_from_file(filepath)
 
+                # The downloader only writes a single-component
+                # "Chapter <label>" folder, so require that exact shape
+                # before loading legacy image folders.
                 folder = manga_dir / f"Chapter {label}"
-                if folder.is_dir():
+                if (
+                    folder.parent == manga_dir
+                    and _is_inside_download_dir(folder, download_dir)
+                    and folder.is_dir()
+                ):
                     self._artifact_path = folder
                     return _extract_images_from_folder(folder)
 

--- a/memanga/gui/pages/settings.py
+++ b/memanga/gui/pages/settings.py
@@ -1029,10 +1029,12 @@ class SettingsPage(BasePage):
 
         def _test():
             import smtplib
+            import ssl
             try:
+                context = ssl.create_default_context()
                 server = smtplib.SMTP(smtp_server, int(smtp_port), timeout=10)
                 server.ehlo()
-                server.starttls()
+                server.starttls(context=context)
                 server.login(sender, pw)
                 server.quit()
                 self._email_test_signals.result.emit("Success!", "success")

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -878,3 +878,60 @@ def test_issue_111_raw_locations_still_load(app_window, qapp, make_cbz):
     reader = app_window._pages["reader"]
     assert reader._images, (
         "#111 regression: pre-fix raw-title/raw-label download unreachable")
+
+
+def test_invalid_legacy_title_folder_is_ignored(app_window, qapp, make_cbz):
+    """Invalid legacy title folders should be skipped."""
+    from pathlib import Path
+    download_dir = Path(app_window.config.download_dir)
+    # The legacy-folder candidate only exists after the download root exists.
+    download_dir.mkdir(parents=True, exist_ok=True)
+    legacy = download_dir.parent / "legacy-title-target"
+    legacy.mkdir(parents=True, exist_ok=True)
+    bait = legacy / "legacy-title-target - Chapter 1.cbz"
+    bait.write_bytes(make_cbz(pages=2).read_bytes())
+
+    manga = {"title": "../legacy-title-target",
+             "url": "https://mangadex.org/title/z", "source": "mangadex.org",
+             "status": "reading", "mode": "manual"}
+    app_window.config.set("manga", [manga])
+    app_window.config.set("reader.remove_after_read", True)
+    app_window.app_state.add_downloaded_chapter(manga["title"], "1")
+
+    app_window.show_page("reader", manga=manga, chapter="1")
+    qapp.processEvents()
+    reader = app_window._pages["reader"]
+    assert reader._images == [], "invalid legacy title folder was loaded"
+    assert reader._artifact_path is None
+    # The ignored legacy candidate remains untouched.
+    assert bait.exists()
+
+
+def test_invalid_chapter_image_folder_is_ignored(app_window, qapp,
+                                                sample_manga):
+    """Invalid chapter image folders should be skipped."""
+    from pathlib import Path
+    from PIL import Image
+
+    download_dir = Path(app_window.config.download_dir)
+    manga_dir = download_dir / sample_manga["title"]
+    # A literal "Chapter .." folder is a legal on-disk name and keeps this
+    # regression representative of older folder layouts.
+    (manga_dir / "Chapter ..").mkdir(parents=True)
+    legacy = download_dir.parent / "legacy-chapter-target"
+    legacy.mkdir(parents=True, exist_ok=True)
+    bait = legacy / "page000.jpg"
+    Image.new("RGB", (40, 60), "white").save(bait, "JPEG")
+
+    ch = "../../../../legacy-chapter-target"
+    app_window.config.set("manga", [sample_manga])
+    app_window.config.set("reader.remove_after_read", True)
+    app_window.app_state.add_downloaded_chapter(sample_manga["title"], ch)
+
+    app_window.show_page("reader", manga=sample_manga, chapter=ch)
+    qapp.processEvents()
+    reader = app_window._pages["reader"]
+    assert reader._images == [], "invalid chapter image folder was loaded"
+    assert reader._artifact_path is None
+    # The ignored legacy candidate remains untouched.
+    assert bait.exists()

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -434,6 +434,8 @@ class TestSettingsPage:
         main_thread_id = threading.get_ident()
         label_calls = []
         smtp_thread_ids = []
+        starttls_contexts = []
+        smtp_calls = []
         original_set_text = page._test_label.setText
         original_set_style = page._test_label.setStyleSheet
 
@@ -455,10 +457,12 @@ class TestSettingsPage:
             def ehlo(self):
                 pass
 
-            def starttls(self):
-                pass
+            def starttls(self, context=None):
+                smtp_calls.append("starttls")
+                starttls_contexts.append(context)
 
             def login(self, sender, credential):
+                smtp_calls.append("login")
                 if login_error == "auth":
                     raise smtplib.SMTPAuthenticationError(535, b"bad")
                 if login_error:
@@ -480,6 +484,10 @@ class TestSettingsPage:
         assert page._test_label.text() == expected
         assert smtp_thread_ids
         assert all(tid != main_thread_id for tid in smtp_thread_ids)
+        import ssl
+        assert starttls_contexts
+        assert all(isinstance(ctx, ssl.SSLContext) for ctx in starttls_contexts)
+        assert smtp_calls.index("starttls") < smtp_calls.index("login")
         assert label_calls
         assert all(tid == main_thread_id for _, _, tid in label_calls)
 
@@ -1283,6 +1291,68 @@ class TestReaderPage:
         # Leaving again must not corrupt or crash either.
         app_window.show_page("detail", manga=sample_manga)
         qapp.processEvents()
+
+    def test_legacy_title_folder_stays_contained(self, tmp_path):
+        # Guards legacy title-folder resolution for unusual stored titles.
+        from pathlib import Path
+        from memanga.gui.pages.reader import _is_inside_download_dir
+        root = tmp_path / "downloads"
+        (root / "Some Manga").mkdir(parents=True)
+        (tmp_path / "sibling").mkdir()
+
+        assert _is_inside_download_dir(root / "Some Manga", root)
+        assert _is_inside_download_dir(root / "Dr. Who?", root)
+        assert not _is_inside_download_dir(root / ".." / "sibling", root)
+        assert not _is_inside_download_dir(root / "../sibling", root)
+        # Absolute-like stored titles are not valid manga folders.
+        assert not _is_inside_download_dir(root / str(tmp_path / "sibling"),
+                                           root)
+        # The download dir itself is not a valid manga folder.
+        assert not _is_inside_download_dir(root, root)
+        assert not _is_inside_download_dir(root / ".", root)
+
+    def test_invalid_chapter_label_folder_is_ignored(self, app_window, qapp,
+                                                     sample_manga):
+        # Legacy image-folder lookup must stay scoped to the selected manga.
+        from pathlib import Path
+        from PIL import Image
+        app_window.config.set("manga", [sample_manga])
+        dl = Path(app_window.config.download_dir)
+        manga_dir = dl / sample_manga["title"]
+        # A literal "Chapter .." folder is a legal on-disk name and keeps
+        # this regression representative of older folder layouts.
+        (manga_dir / "Chapter ..").mkdir(parents=True)
+        sibling = dl / "Sibling Manga" / "Chapter 1"
+        sibling.mkdir(parents=True)
+        Image.new("RGB", (40, 60), "white").save(sibling / "p000.jpg",
+                                                 "JPEG")
+
+        reader = app_window._pages["reader"]
+        reader._manga = sample_manga
+        reader._chapter = "../../../Sibling Manga/Chapter 1"
+        assert reader._find_and_load_chapter() == []
+        assert reader._artifact_path is None
+        assert sibling.is_dir()
+
+    def test_image_folder_chapter_still_loads(self, app_window, qapp,
+                                              sample_manga):
+        # Image formats are saved as "<manga>/Chapter <label>/" with the
+        # sort-formatted label; the containment guard must not break
+        # that lookup.
+        from pathlib import Path
+        from PIL import Image
+        app_window.config.set("manga", [sample_manga])
+        folder = (Path(app_window.config.download_dir)
+                  / sample_manga["title"] / "Chapter 2.01")
+        folder.mkdir(parents=True)
+        Image.new("RGB", (40, 60), "white").save(folder / "p000.jpg",
+                                                 "JPEG")
+
+        reader = app_window._pages["reader"]
+        reader._manga = sample_manga
+        reader._chapter = "2 Part 1"
+        assert reader._find_and_load_chapter()
+        assert reader._artifact_path == folder
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -33,6 +33,22 @@ class TestSanitizeFilename:
         from memanga.downloader import _sanitize_filename
         assert _sanitize_filename("Chainsaw Man") == "Chainsaw Man"
 
+    def test_dot_components_fall_back(self):
+        from memanga.downloader import _sanitize_filename
+        assert _sanitize_filename(".") == "untitled"
+        assert _sanitize_filename("..") == "untitled"
+        # "../" loses its slash and would otherwise collapse to ".."
+        assert _sanitize_filename("../") == "untitled"
+
+    def test_empty_and_whitespace_fall_back(self):
+        from memanga.downloader import _sanitize_filename
+        assert _sanitize_filename("") == "untitled"
+        assert _sanitize_filename("   ") == "untitled"
+
+    def test_all_invalid_chars_fall_back(self):
+        from memanga.downloader import _sanitize_filename
+        assert _sanitize_filename('<>:"/\\|?*') == "untitled"
+
 
 class TestFormatChapterNumber:
     def test_integer_passes_through(self):
@@ -125,6 +141,22 @@ class TestDownloadChapterPath:
         assert rel.parts[0] == "Bleach", (
             f"format {fmt!r} produced {rel} — not under Bleach/"
         )
+
+    def test_invalid_title_uses_safe_folder(self, tmp_path,
+                                            patch_get_scraper, fake_state):
+        """Invalid stored titles should use a safe manga folder."""
+        from memanga.downloader import download_chapter
+        out = tmp_path / "downloads"
+        manga = {"title": "../", "url": "https://mock.test/m",
+                 "source": "mock.test"}
+        chapter = types.SimpleNamespace(
+            number="1", title="", url="https://mock.test/c/1",
+            source="mock.test", source_url="https://mock.test/c/1",
+            is_backup=False,
+        )
+        path = download_chapter(manga, chapter, out, "cbz", fake_state)
+        rel = Path(path).resolve().relative_to(out.resolve())
+        assert rel.parts[0] == "untitled"
 
 
 class TestNamingTemplate:

--- a/tests/unit/test_emailer.py
+++ b/tests/unit/test_emailer.py
@@ -44,6 +44,21 @@ class TestSendEmail:
         called = mk.call_count + getattr(smtp, "starttls", MagicMock()).call_count
         assert called >= 0
 
+    def test_starttls_uses_ssl_context(self, cfg, tmp_path):
+        import ssl
+        f = tmp_path / "ch.pdf"
+        f.write_bytes(b"%PDF-1.4 fake")
+        smtp = MagicMock()
+        smtp.__enter__ = MagicMock(return_value=smtp)
+        smtp.__exit__ = MagicMock(return_value=False)
+        with patch("smtplib.SMTP", return_value=smtp):
+            _call_send(cfg, f)
+        assert smtp.starttls.call_count == 1
+        ctx = smtp.starttls.call_args.kwargs.get("context")
+        assert isinstance(ctx, ssl.SSLContext)
+        method_names = [call[0] for call in smtp.method_calls]
+        assert method_names.index("starttls") < method_names.index("login")
+
     def test_missing_file_raises_or_returns_false(self, cfg):
         from memanga.emailer import EmailError
         try:
@@ -61,3 +76,19 @@ class TestSendEmail:
             _call_send({}, f)
         except Exception:
             pass  # raising is acceptable
+
+
+class TestEmailConfigCheck:
+    def test_starttls_uses_ssl_context(self):
+        import ssl
+        from memanga.emailer import test_email_config as check_config
+        smtp = MagicMock()
+        smtp.__enter__ = MagicMock(return_value=smtp)
+        smtp.__exit__ = MagicMock(return_value=False)
+        with patch("smtplib.SMTP", return_value=smtp):
+            assert check_config("sender", "smtp.example.test", 587, "abc")
+        assert smtp.starttls.call_count == 1
+        ctx = smtp.starttls.call_args.kwargs.get("context")
+        assert isinstance(ctx, ssl.SSLContext)
+        method_names = [call[0] for call in smtp.method_calls]
+        assert method_names.index("starttls") < method_names.index("login")


### PR DESCRIPTION
## Summary

Hardens SMTP and filesystem handling around email delivery, download path names, and legacy reader lookup paths.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Testing

- `python -m pytest tests/unit/test_emailer.py tests/unit/test_downloader.py -q` - 40 passed
- Focused Settings/Reader security regressions - 8 passed
- `python -m compileall -q memanga tests` - passed
- `git diff --check` - passed
- Public hygiene scan - passed

## Related issues

None