### PR TITLE
fix(tests): isolate Windows user paths

### DIFF
--- a/memanga/config.py
+++ b/memanga/config.py
@@ -32,7 +32,9 @@ class Config:
     def _load(self):
         """Load config from file."""
         if self.config_path.exists():
-            with open(self.config_path, "r") as f:
+            # Explicit UTF-8: titles are arbitrary Unicode and the
+            # platform default encoding may not represent them.
+            with open(self.config_path, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
             # Merge with defaults to ensure new fields exist
             defaults = self._default_config()
@@ -151,7 +153,7 @@ class Config:
 
         fd, tmp_path = tempfile.mkstemp(dir=self.config_dir, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(payload)
             os.replace(tmp_path, self.config_path)
         except Exception:

--- a/memanga/cron.py
+++ b/memanga/cron.py
@@ -4,7 +4,7 @@ by the CLI (`memanga cron install`) and the GUI Settings page.
 """
 
 import shlex
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 
 def quote_cron_path(path) -> str:
@@ -19,7 +19,8 @@ def quote_cron_path(path) -> str:
 
 def build_cron_line(minute, hour, project_dir, python_path) -> str:
     """Build the daily auto-check crontab entry with shell-safe paths."""
-    project_dir = Path(project_dir)
+    project_dir = PurePosixPath(Path(project_dir).as_posix())
+    python_path = Path(python_path).as_posix()
     command = (
         f"cd {quote_cron_path(project_dir)} && "
         f"{quote_cron_path(python_path)} -m memanga check --auto --quiet"

--- a/memanga/downloader.py
+++ b/memanga/downloader.py
@@ -1375,6 +1375,9 @@ def _sanitize_filename(name: str) -> str:
     for char in invalid_chars:
         name = name.replace(char, '')
     name = name.strip()[:100]  # Limit length
+    # Windows trims trailing dots/spaces from path components, so remove
+    # them explicitly after truncation to keep generated paths stable.
+    name = name.rstrip(". ")
     # Never yield a dot-only ('.', '..') or empty result; those are
     # directory references, not usable path components.
     if not name.strip('.'):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,6 +47,10 @@ def isolated_home(monkeypatch, tmp_path) -> Path:
     Returns the new home path so tests can poke at created files.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
+    # Path.home() on Windows resolves USERPROFILE and ignores HOME
+    # (Python 3.8+), so without this the suite reads and writes the
+    # developer's real config/state and download directories.
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setenv("APPDATA", str(tmp_path))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
     (tmp_path / ".config" / "memanga").mkdir(parents=True, exist_ok=True)

--- a/tests/integration/test_issue_regressions.py
+++ b/tests/integration/test_issue_regressions.py
@@ -863,13 +863,15 @@ def test_issue_111_part_style_chapter_label(app_window, qapp, sample_manga,
 def test_issue_111_raw_locations_still_load(app_window, qapp, make_cbz):
     """Backward compatibility: downloads that ended up under the raw
     title folder with a raw chapter label must stay reachable."""
+    import os
     from pathlib import Path
-    manga = {"title": "Dr. Who?", "url": "https://mangadex.org/title/y",
+    title = "Dr. Who" if os.name == "nt" else "Dr. Who?"
+    manga = {"title": title, "url": "https://mangadex.org/title/y",
              "source": "mangadex.org", "status": "reading", "mode": "manual"}
     app_window.config.set("manga", [manga])
-    dl = Path(app_window.config.download_dir) / "Dr. Who?"
+    dl = Path(app_window.config.download_dir) / title
     dl.mkdir(parents=True, exist_ok=True)
-    (dl / "Dr. Who? - Chapter 2 Part 1.cbz").write_bytes(
+    (dl / f"{title} - Chapter 2 Part 1.cbz").write_bytes(
         make_cbz(pages=2).read_bytes())
     app_window.app_state.add_downloaded_chapter(manga["title"], "2 Part 1")
 

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -49,6 +49,12 @@ class TestSanitizeFilename:
         from memanga.downloader import _sanitize_filename
         assert _sanitize_filename('<>:"/\\|?*') == "untitled"
 
+    def test_truncation_never_leaves_trailing_dot_or_space(self):
+        from memanga.downloader import _sanitize_filename
+        assert _sanitize_filename("a" * 99 + " b") == "a" * 99
+        assert _sanitize_filename("a" * 99 + ".b") == "a" * 99
+        assert _sanitize_filename("Vol. 2.") == "Vol. 2"
+
 
 class TestFormatChapterNumber:
     def test_integer_passes_through(self):
@@ -356,7 +362,7 @@ class TestPostProcessing:
         }
 
         download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
-                         post_processing=pp)
+                         post_processing=pp, naming_template="{chapter}")
 
         assert marker.read_text() == manga["title"]
         assert not injected.exists()


### PR DESCRIPTION
## Summary

Fixes Windows pytest failures caused by tests reading the real user profile instead of the temporary test home, and addresses Windows-specific path/encoding issues surfaced by the full suite.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

None.

## Test evidence

- Focused Windows/path, CLI/sidebar/cover, and GUI reader/prefetch regression checks passed.
- `python -m pytest tests/unit/test_downloader.py -q` and `python -m pytest tests/unit/test_config.py tests/unit/test_state_persistence.py -q` passed.
- `python -m compileall -q memanga tests` and `git diff --check` passed.
