### PR TITLE
perf(gui): improve library refresh responsiveness

### DIFF
--- a/memanga/config.py
+++ b/memanga/config.py
@@ -8,6 +8,8 @@ import threading
 import yaml
 from pathlib import Path
 
+from .perf import timed
+
 
 class Config:
     """Manages configuration file.
@@ -139,6 +141,7 @@ class Config:
             data = data[k]
         data[keys[-1]] = value
     
+    @timed("config.save")
     def save(self):
         """Save config to file atomically. Thread-safe.
 

--- a/memanga/gui/pages/library.py
+++ b/memanga/gui/pages/library.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import (
 )
 from PySide6.QtCore import Qt, QTimer
 from .base import BasePage
+from ...perf import timed
 from .. import theme as T
 from ..components.manga_card import MangaCard
 from ..components.manga_row import MangaRow
@@ -25,6 +26,16 @@ class LibraryPage(BasePage):
         self._search_query = ""
         self._sort_by = self.app.config.get("gui.sort_by", "title")
         self._cards: list = []
+        # Coalesces event-driven refreshes (check/download/read/library
+        # events) so a burst - e.g. every chapter of a batch download
+        # completing - triggers one grid rebuild, not one per event.
+        self._refresh_pending = False
+        # Debounces the filter box: rebuilding the grid on every
+        # keystroke made typing feel laggy on larger libraries.
+        self._filter_debounce = QTimer(self)
+        self._filter_debounce.setSingleShot(True)
+        self._filter_debounce.setInterval(250)
+        self._filter_debounce.timeout.connect(self._on_filter_debounce)
 
         self._build()
 
@@ -307,6 +318,7 @@ class LibraryPage(BasePage):
             # Tick must never raise — it fires on a timer.
             pass
 
+    @timed("gui.library.refresh")
     def _refresh(self):
         # Continue Reading rail first
         self._refresh_continue_rail()
@@ -381,7 +393,7 @@ class LibraryPage(BasePage):
             # Issue #18: pass per-chapter read / total counts so the card
             # can render "Read X/N" and a read-based progress bar.
             read_count = self.app.app_state.get_read_count(title)
-            total_count = len(self.app.app_state.get_available_chapters(title) or [])
+            total_count = self.app.app_state.get_available_chapter_count(title)
 
             card = MangaCard(
                 self._scroll_content, manga=manga, cover_image=cover_img,
@@ -490,6 +502,11 @@ class LibraryPage(BasePage):
 
     def _on_search(self, text):
         self._search_query = text.strip()
+        # Restart on each keystroke - the grid rebuilds once, when the
+        # user pauses typing.
+        self._filter_debounce.start()
+
+    def _on_filter_debounce(self):
         self._refresh()
 
     def _on_status_filter(self, value):
@@ -617,5 +634,12 @@ class LibraryPage(BasePage):
             self._refresh()
 
     def _on_check_done(self):
+        if not self.isVisible() or self._refresh_pending:
+            return
+        self._refresh_pending = True
+        QTimer.singleShot(300, self._run_pending_refresh)
+
+    def _run_pending_refresh(self):
+        self._refresh_pending = False
         if self.isVisible():
-            QTimer.singleShot(300, self._refresh)
+            self._refresh()

--- a/memanga/perf.py
+++ b/memanga/perf.py
@@ -1,0 +1,85 @@
+"""
+Lightweight opt-in timing instrumentation shared by the GUI and CLI.
+
+Disabled by default so production runs stay quiet. Enable with the
+``MEMANGA_PERF`` environment variable (``1``/``true``/``yes``/``on``)
+or programmatically via :func:`set_enabled` (used by tests).
+
+When enabled, each timed block logs its duration at DEBUG level on the
+``memanga.perf`` logger and appends a ``(name, duration_ms)`` sample to
+a bounded in-memory buffer readable via :func:`recent_samples`. When
+disabled, :func:`timed` costs a single boolean check per call.
+
+Usage::
+
+    from .perf import timed
+
+    @timed("state.save")          # as a decorator
+    def save(self): ...
+
+    with timed("gui.library.refresh"):   # or as a context manager
+        rebuild()
+"""
+
+import logging
+import os
+import threading
+import time
+from collections import deque
+from contextlib import contextmanager
+from typing import Deque, List, Optional, Tuple
+
+logger = logging.getLogger("memanga.perf")
+
+# Bounded so a long session can't grow memory. Samples arrive from worker
+# threads, so append/clear/snapshot share a lock: iterating a deque while
+# another thread appends raises "deque mutated during iteration".
+_MAX_SAMPLES = 200
+_samples: Deque[Tuple[str, float]] = deque(maxlen=_MAX_SAMPLES)
+_samples_lock = threading.Lock()
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# None means "not resolved yet - read the environment on first use".
+_enabled: Optional[bool] = None
+
+
+def is_enabled() -> bool:
+    """Whether timing collection is active."""
+    global _enabled
+    if _enabled is None:
+        _enabled = os.environ.get("MEMANGA_PERF", "").strip().lower() in _TRUTHY
+    return _enabled
+
+
+def set_enabled(value: Optional[bool]):
+    """Force collection on/off; ``None`` re-reads the environment."""
+    global _enabled
+    _enabled = value
+
+
+def clear_samples():
+    with _samples_lock:
+        _samples.clear()
+
+
+def recent_samples() -> List[Tuple[str, float]]:
+    """Snapshot of the most recent ``(name, duration_ms)`` samples."""
+    with _samples_lock:
+        return list(_samples)
+
+
+@contextmanager
+def timed(name: str):
+    """Time a block (or, used as a decorator, a call) under ``name``."""
+    if not is_enabled():
+        yield
+        return
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        with _samples_lock:
+            _samples.append((name, duration_ms))
+        logger.debug("%s took %.1f ms", name, duration_ms)

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from typing import List, Optional, Dict, Any, Mapping
 
 from .backup import merge_backup_state
+from .perf import timed
 
 
 _CHAPTER_NUMBER_RE = re.compile(r"(\d+(?:\.\d+)?)")
@@ -136,6 +137,7 @@ class State:
             value = data.get("manga", {}).get(manga_title, {}).get(key, default)
             return self._snapshot(value)
 
+    @timed("state.save")
     def save(self):
         """Save state to file atomically. Thread-safe."""
         with self._lock:
@@ -645,7 +647,16 @@ class State:
         return self._entry_value(manga_title, "read_chapters", []) or []
 
     def get_read_count(self, manga_title: str) -> int:
-        return len(self.get_read_chapters(manga_title))
+        """Number of chapters read, without snapshotting the read list.
+
+        The Library page calls this per manga on every refresh (grid
+        cards + the header's read total), so it counts under the lock
+        instead of paying get_read_chapters()'s deep copy each time.
+        """
+        with self._locked() as data:
+            return len(
+                data.get("manga", {}).get(manga_title, {}).get("read_chapters", []) or []
+            )
 
     # ========================================================================
     # New Chapter Badges
@@ -698,6 +709,18 @@ class State:
     def get_available_chapters(self, manga_title: str) -> List[Dict[str, Any]]:
         """Get the cached chapter list for a manga (empty list if never checked)."""
         return self._entry_value(manga_title, "available_chapters", [])
+
+    def get_available_chapter_count(self, manga_title: str) -> int:
+        """Number of cached available chapters, without snapshotting them.
+
+        Callers that only need the total (Library cards' "Read X/N"
+        line) would otherwise deep-copy the whole cached list - per
+        card, per refresh - just to call len() on it.
+        """
+        with self._locked() as data:
+            return len(
+                data.get("manga", {}).get(manga_title, {}).get("available_chapters", []) or []
+            )
 
     def get_catalogue_baseline(self, manga_title: str) -> Optional[float]:
         """Highest chapter number the source has legitimately exposed so far.

--- a/tests/unit/gui/pages/test_pages.py
+++ b/tests/unit/gui/pages/test_pages.py
@@ -103,6 +103,48 @@ class TestLibraryPage:
                                    {"title": "X", "chapter": "1"})
         app_window.events.poll(); qapp.processEvents()
 
+    def test_search_is_debounced(self, app_window, qapp):
+        # Typing must not rebuild the grid per keystroke - only once,
+        # after the pause timer fires.
+        page = app_window._pages["library"]
+        calls = []
+        page._refresh = lambda: calls.append(1)
+
+        page._on_search("a")
+        page._on_search("ab")
+        assert calls == []
+        assert page._search_query == "ab"
+        assert page._filter_debounce.isActive()
+
+        # Fire the pending timeout now instead of waiting 250 ms.
+        page._filter_debounce.setInterval(0)
+        page._filter_debounce.start()
+        deadline = time.time() + 2
+        while not calls and time.time() < deadline:
+            qapp.processEvents()
+        assert calls == [1]
+
+    def test_check_done_coalesces_bursts(self, app_window, qapp):
+        # A burst of completion events (e.g. batch download) must fold
+        # into a single deferred refresh.
+        app_window.show()
+        app_window.show_page("library"); qapp.processEvents()
+        page = app_window._pages["library"]
+        assert page.isVisible()
+        calls = []
+        page._refresh = lambda: calls.append(1)
+
+        for _ in range(5):
+            page._on_check_done()
+        assert page._refresh_pending
+        assert calls == []
+
+        deadline = time.time() + 2
+        while not calls and time.time() < deadline:
+            qapp.processEvents()
+        assert calls == [1]
+        assert not page._refresh_pending
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Downloads

--- a/tests/unit/test_perf.py
+++ b/tests/unit/test_perf.py
@@ -1,0 +1,166 @@
+"""Tests for memanga.perf - opt-in timing instrumentation.
+
+Covers both usage forms (decorator and context manager), the
+enabled/disabled gate, environment resolution, and the bounded
+sample buffer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga import perf
+from memanga.perf import timed
+
+
+@pytest.fixture(autouse=True)
+def clean_perf(monkeypatch):
+    """Each test starts disabled with an empty buffer and no env leak."""
+    monkeypatch.delenv("MEMANGA_PERF", raising=False)
+    perf.set_enabled(None)
+    perf.clear_samples()
+    yield
+    perf.set_enabled(None)
+    perf.clear_samples()
+
+
+class TestEnabledGate:
+    def test_disabled_by_default(self):
+        assert not perf.is_enabled()
+
+    @pytest.mark.parametrize("value", ["1", "true", "YES", " on "])
+    def test_truthy_env_values_enable(self, monkeypatch, value):
+        monkeypatch.setenv("MEMANGA_PERF", value)
+        perf.set_enabled(None)
+        assert perf.is_enabled()
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "off", "nope"])
+    def test_other_env_values_stay_disabled(self, monkeypatch, value):
+        monkeypatch.setenv("MEMANGA_PERF", value)
+        perf.set_enabled(None)
+        assert not perf.is_enabled()
+
+    def test_set_enabled_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("MEMANGA_PERF", "1")
+        perf.set_enabled(False)
+        assert not perf.is_enabled()
+        perf.set_enabled(True)
+        assert perf.is_enabled()
+
+    def test_disabled_records_nothing(self):
+        with timed("quiet"):
+            pass
+        assert perf.recent_samples() == []
+
+
+class TestTimedContextManager:
+    def test_records_name_and_duration(self):
+        perf.set_enabled(True)
+        with timed("block"):
+            pass
+        samples = perf.recent_samples()
+        assert len(samples) == 1
+        name, duration_ms = samples[0]
+        assert name == "block"
+        assert duration_ms >= 0
+
+    def test_records_even_when_body_raises(self):
+        perf.set_enabled(True)
+        with pytest.raises(ValueError):
+            with timed("boom"):
+                raise ValueError("bad")
+        assert perf.recent_samples()[0][0] == "boom"
+
+
+class TestTimedDecorator:
+    def test_preserves_return_value_and_name(self):
+        perf.set_enabled(True)
+
+        @timed("fn")
+        def add(a, b=1):
+            return a + b
+
+        assert add(2, b=3) == 5
+        assert add.__name__ == "add"
+        assert perf.recent_samples()[0][0] == "fn"
+
+    def test_reusable_across_calls(self):
+        # A generator-based context manager is single-use; the decorator
+        # form must recreate it per call.
+        perf.set_enabled(True)
+
+        @timed("fn")
+        def noop():
+            pass
+
+        noop()
+        noop()
+        assert [n for n, _ in perf.recent_samples()] == ["fn", "fn"]
+
+    def test_enabled_checked_at_call_time(self):
+        # Decorators are applied at import time, before tests (or the
+        # user) flip the switch - the gate must not be baked in.
+        @timed("late")
+        def noop():
+            pass
+
+        noop()
+        assert perf.recent_samples() == []
+        perf.set_enabled(True)
+        noop()
+        assert [n for n, _ in perf.recent_samples()] == ["late"]
+
+    def test_decorated_state_save_records_sample(self, state):
+        # Integration: State.save carries @timed("state.save").
+        perf.set_enabled(True)
+        state.save()
+        assert "state.save" in [n for n, _ in perf.recent_samples()]
+
+    def test_decorated_config_save_records_sample(self, config):
+        perf.set_enabled(True)
+        config.save()
+        assert "config.save" in [n for n, _ in perf.recent_samples()]
+
+
+class TestSampleBuffer:
+    def test_clear_samples(self):
+        perf.set_enabled(True)
+        with timed("x"):
+            pass
+        perf.clear_samples()
+        assert perf.recent_samples() == []
+
+    def test_buffer_is_bounded(self):
+        perf.set_enabled(True)
+        for i in range(perf._MAX_SAMPLES + 50):
+            with timed(f"s{i}"):
+                pass
+        samples = perf.recent_samples()
+        assert len(samples) == perf._MAX_SAMPLES
+        # Oldest entries were dropped, newest kept.
+        assert samples[-1][0] == f"s{perf._MAX_SAMPLES + 49}"
+
+    def test_snapshot_safe_under_concurrent_appends(self):
+        # Without the lock, list(_samples) can raise "deque mutated
+        # during iteration" while a worker thread appends.
+        import threading
+
+        perf.set_enabled(True)
+        stop = threading.Event()
+
+        def writer():
+            while not stop.is_set():
+                with timed("w"):
+                    pass
+
+        threads = [threading.Thread(target=writer) for _ in range(2)]
+        for t in threads:
+            t.start()
+        try:
+            for _ in range(500):
+                snapshot = perf.recent_samples()
+                assert all(name == "w" for name, _ in snapshot)
+        finally:
+            stop.set()
+            for t in threads:
+                t.join()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -213,6 +213,13 @@ class TestExternalChapters:
         state.set_available_chapters("X", chapters)
         assert state.get_available_chapters("X") == chapters
 
+    def test_available_chapter_count(self, state):
+        state.set_available_chapters("X", [{"number": "1"}, {"number": "2"}])
+        assert state.get_available_chapter_count("X") == 2
+
+    def test_available_chapter_count_unknown_manga_is_zero(self, state):
+        assert state.get_available_chapter_count("never") == 0
+
 
 class TestReadChapters:
     """Issue #18 — per-chapter read tracking."""
@@ -222,6 +229,9 @@ class TestReadChapters:
         state.mark_chapter_read("X", "5")
         assert state.get_read_chapters("X") == ["5"]
         assert state.get_read_count("X") == 1
+
+    def test_read_count_unknown_manga_is_zero(self, state):
+        assert state.get_read_count("never") == 0
 
     def test_unmark_chapter_read(self, state):
         state.mark_chapter_read("X", "5")


### PR DESCRIPTION
## Summary

Adds opt-in performance timing around shared save and library refresh paths, then reduces repeated Library page rebuild work by debouncing search input and coalescing burst refresh events.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] No scraper files touched

## Related issues

Closes #108