### PR TITLE
feat(packaging): add Docker image from main

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+.git
+.github
+.pytest_cache
+.*/
+__pycache__
+*.py[cod]
+*.egg-info
+.eggs
+venv
+.venv
+build
+dist
+downloads
+test-output
+memanga.log
+*.log
+config.yaml
+state.json
+.DS_Store
+Thumbs.db
+
+# The GUI sub-package is excluded from the Docker build context.
+# The container runs the CLI only; memanga/gui/ is not needed and
+# would add unnecessary source from main's desktop-app layer.
+# Passing --gui inside the container will fail (the module is absent).
+memanga/gui

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,97 @@
+name: Docker Image
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      push:
+        description: "Push the image to GHCR and Docker Hub"
+        required: true
+        default: false
+        type: boolean
+      platforms:
+        description: "Target platforms"
+        required: true
+        default: "linux/amd64,linux/arm64"
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-image-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/memanga
+  DOCKERHUB_IMAGE: docker.io/meellm/memanga
+
+jobs:
+  build:
+    name: Build Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name == 'push' || inputs.push
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push' || inputs.push
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            ${{ env.GHCR_IMAGE }}
+            ${{ env.DOCKERHUB_IMAGE }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-') }}
+            type=sha,prefix=sha-
+
+      - name: Build image without publishing
+        if: github.event_name == 'workflow_dispatch' && !inputs.push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ inputs.platforms }}
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and publish image
+        if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ inputs.platforms || 'linux/amd64,linux/arm64' }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.title="MeManga" \
+      org.opencontainers.image.description="Automatic manga downloader with Kindle support (CLI)" \
+      org.opencontainers.image.source="https://github.com/meellm/MeManga" \
+      org.opencontainers.image.licenses="MIT"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
+    HOME=/home/memanga \
+    MEMANGA_CLI_ONLY=1
+
+WORKDIR /app
+
+# Install CLI-only dependencies and the Playwright Firefox runtime first so
+# this expensive layer stays cached when only application source changes.
+# requirements-docker.txt mirrors requirements.txt but omits PySide6 and
+# other GUI-only packages so the container stays lean and headless.
+COPY requirements-docker.txt ./
+RUN python -m pip install --upgrade pip \
+    && python -m pip install -r requirements-docker.txt \
+    && python -m playwright install --with-deps firefox \
+    && useradd --create-home --home-dir /home/memanga --shell /usr/sbin/nologin --uid 1000 memanga \
+    && mkdir -p /home/memanga/.config/memanga /home/memanga/Downloads/MeManga \
+    && chown -R memanga:memanga /home/memanga
+
+# Install the package itself (deps already satisfied above).
+# .dockerignore excludes memanga/gui so only the CLI source lands in the image.
+# pyproject.toml declares a memanga-gui console script; remove it so the image
+# exposes only the memanga CLI and does not leave a broken launcher in PATH.
+# The trailing test assertion makes the build fail if the path ever changes.
+COPY pyproject.toml README.md ./
+COPY memanga ./memanga
+RUN python -m pip install --no-deps . \
+    && rm -f /usr/local/bin/memanga-gui \
+    && test ! -f /usr/local/bin/memanga-gui
+
+USER memanga
+
+VOLUME ["/home/memanga/.config/memanga", "/home/memanga/Downloads/MeManga"]
+
+ENTRYPOINT ["memanga"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Works offline once chapters are downloaded.
 <p align="center">
   <a href="https://github.com/meellm/MeManga/releases"><img alt="latest release" src="https://img.shields.io/github/v/release/meellm/MeManga"></a>
   <a href="https://github.com/meellm/MeManga/releases"><img alt="release downloads" src="https://img.shields.io/github/downloads/meellm/MeManga/total?label=downloads"></a>
+  <a href="https://hub.docker.com/r/meellm/memanga"><img alt="Docker pulls" src="https://img.shields.io/docker/pulls/meellm/memanga?label=docker%20pulls"></a>
   <img alt="platforms" src="https://img.shields.io/badge/Windows%20%7C%20macOS%20%7C%20Linux-supported-success">
   <a href="LICENSE"><img alt="MIT license" src="https://img.shields.io/badge/license-MIT-blue"></a>
 </p>
@@ -175,14 +176,9 @@ PDFs over 18 MB are split automatically; EPUB / CBZ files can't be split so they
 
 # Part 2 — Command-line interface
 
-> **Just the light-weight CLI** A dedicated [`cli` branch](https://github.com/meellm/MeManga/tree/cli)
-> strips PySide6 and the GUI module out of the tree,
-> faster `pip install`, no Qt runtime to worry about, ideal for
-> headless servers and Docker images. `main` keeps both.
-
 The CLI ships in the source tree (not the release binary). It's the
-right tool and what I use for cron jobs, headless servers, batch operations, 
-and scripting. The desktop app and the CLI share the same config, state,
+right tool for cron jobs, headless servers, batch operations, and
+scripting. The desktop app and the CLI share the same config, state,
 and download files — you can drive your library from both interchangeably.
 
 ## Install
@@ -205,6 +201,62 @@ On macOS / Linux:
 
 ```bash
 ./scripts/run.sh <command>
+```
+
+## Docker
+
+The Docker image packages the CLI and Playwright Firefox runtime for
+headless servers, NAS boxes, Raspberry Pi systems, and cron-style
+automation. It does **not** include PySide6 or any other GUI runtime.
+
+```bash
+docker build -t memanga:cli .
+docker run --rm memanga:cli --help
+```
+
+Release tags publish the official image to Docker Hub and GitHub
+Container Registry:
+
+```bash
+docker pull meellm/memanga:latest
+docker run --rm meellm/memanga:latest --help
+
+docker pull ghcr.io/meellm/memanga:latest
+docker run --rm ghcr.io/meellm/memanga:latest --help
+```
+
+Stable releases are published with `X.Y.Z`, `X.Y`, and `latest` tags;
+pin to a specific `X.Y.Z` tag for reproducible runs. Build locally for
+unreleased changes.
+
+Persist config/state and downloads with two mounts:
+
+```bash
+mkdir -p memanga-data/config memanga-data/downloads
+
+docker run --rm \
+  -v "$PWD/memanga-data/config:/home/memanga/.config/memanga" \
+  -v "$PWD/memanga-data/downloads:/home/memanga/Downloads/MeManga" \
+  memanga:cli status
+```
+
+> The container runs as UID 1000, so bind-mounted directories must be
+> writable by UID 1000 (`sudo chown -R 1000:1000 memanga-data` if your
+> host user differs). The Compose setup below uses named volumes and
+> sidesteps this.
+
+Use the included `compose.yaml` for repeated commands:
+
+```bash
+docker compose build
+docker compose run --rm memanga list
+docker compose run --rm memanga check --auto
+```
+
+For a host cron job, run Compose from the repository directory:
+
+```cron
+0 6 * * * cd /path/to/MeManga && docker compose run --rm memanga check --auto --quiet >> memanga-docker.log 2>&1
 ```
 
 ## Commands

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  memanga:
+    build: .
+    image: memanga:cli
+    volumes:
+      - memanga-config:/home/memanga/.config/memanga
+      - memanga-downloads:/home/memanga/Downloads/MeManga
+    command: ["list"]
+
+volumes:
+  memanga-config:
+  memanga-downloads:

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -17,6 +17,7 @@ them to your Kindle.
 - [Setup — Windows](#setup--windows)
 - [Setup — macOS](#setup--macos)
 - [Setup — Linux](#setup--linux)
+- [Setup — Docker](#setup--docker)
 - [Your First Manga](#your-first-manga)
 - [Checking for New Chapters](#checking-for-new-chapters)
 - [Downloading From the Start](#downloading-from-the-start)
@@ -249,6 +250,93 @@ Or run directly through the virtual environment:
 /home/YourName/.config/memanga/state.json        # Download history
 /home/YourName/.config/memanga/downloads/        # Downloaded chapters
 ```
+
+---
+
+## Setup — Docker
+
+Docker is the easiest option for headless servers, NAS boxes, Raspberry
+Pi systems, and cron-style automation because the image includes the CLI
+and Playwright Firefox runtime without requiring a local Python install.
+The Docker image does **not** include PySide6 or any other GUI runtime.
+
+### Requirements
+
+- Docker
+- Docker Compose v2 if you want to use `compose.yaml`
+
+### Build and run
+
+```bash
+git clone https://github.com/meellm/MeManga.git
+cd MeManga
+docker build -t memanga:cli .
+docker run --rm memanga:cli --help
+```
+
+Official release images are published to Docker Hub and GitHub Container
+Registry when a release tag is pushed:
+
+```bash
+docker pull meellm/memanga:latest
+docker run --rm meellm/memanga:latest --help
+
+docker pull ghcr.io/meellm/memanga:latest
+docker run --rm ghcr.io/meellm/memanga:latest --help
+```
+
+Stable releases are published to both registries with `X.Y.Z`, `X.Y`,
+and `latest` tags; pin to a specific `X.Y.Z` tag for reproducible runs.
+Use a local `docker build` when testing unreleased code from the
+repository.
+
+### Persist config, state, and downloads
+
+MeManga stores config and state under
+`/home/memanga/.config/memanga` in the container. Downloads use the
+default path `/home/memanga/Downloads/MeManga`.
+
+```bash
+mkdir -p memanga-data/config memanga-data/downloads
+
+docker run --rm \
+  -v "$PWD/memanga-data/config:/home/memanga/.config/memanga" \
+  -v "$PWD/memanga-data/downloads:/home/memanga/Downloads/MeManga" \
+  memanga:cli status
+```
+
+> The container runs as a non-root user with UID 1000. With host bind
+> mounts like the ones above, the mounted directories must be writable by
+> UID 1000 or downloads and config saves will fail with permission
+> errors. This works automatically when your host user is UID 1000 (the
+> default first user on most Linux and Raspberry Pi systems); otherwise
+> run `sudo chown -R 1000:1000 memanga-data`. The Compose setup below
+> uses named volumes and avoids the issue entirely.
+
+### Compose
+
+The included `compose.yaml` keeps config/state and downloads in named
+volumes:
+
+```bash
+docker compose build
+docker compose run --rm memanga list
+docker compose run --rm memanga check --auto
+docker compose run --rm memanga config
+```
+
+For daily checks, add a host cron entry from the repository directory:
+
+```cron
+0 6 * * * cd /path/to/MeManga && docker compose run --rm memanga check --auto --quiet >> memanga-docker.log 2>&1
+```
+
+### Kindle delivery
+
+Run `docker compose run --rm memanga config`, choose email delivery, and
+enter the Kindle/Gmail settings. Keep the Docker config volume private:
+containers usually do not have a desktop keyring, so MeManga may store
+the Gmail app credential in the config volume as a fallback.
 
 ---
 

--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -6,6 +6,7 @@ A friendly CLI for tracking and downloading manga chapters.
 
 import argparse
 import json
+import os
 import platform
 import sys
 import subprocess
@@ -1754,10 +1755,9 @@ def cmd_tui(args):
 # ============================================================================
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="📖 MeManga - Automatic manga downloader",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
+    _cli_only = bool(os.environ.get("MEMANGA_CLI_ONLY"))
+
+    _epilog = """
 Examples:
   memanga list                          # Show tracked manga
   memanga add -i                        # Add manga interactively
@@ -1767,10 +1767,22 @@ Examples:
   memanga check --auto                  # Auto-download new chapters
   memanga cron install                  # Set up daily checks
   memanga config                        # Configure settings
-  memanga --gui                         # Launch graphical interface
-        """,
+"""
+    if not _cli_only:
+        _epilog += "  memanga --gui                         # Launch graphical interface\n"
+
+    parser = argparse.ArgumentParser(
+        description="📖 MeManga - Automatic manga downloader",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_epilog,
     )
-    parser.add_argument("--gui", action="store_true", help="Launch the graphical user interface")
+    # In CLI-only Docker images (MEMANGA_CLI_ONLY=1) the GUI is not installed;
+    # suppress the flag from help and reject it at runtime with a clear message.
+    parser.add_argument(
+        "--gui",
+        action="store_true",
+        help=argparse.SUPPRESS if _cli_only else "Launch the graphical user interface",
+    )
     
     subparsers = parser.add_subparsers(dest="command", title="commands")
     
@@ -1893,6 +1905,11 @@ Examples:
     args = parser.parse_args()
 
     if args.gui:
+        if _cli_only:
+            sys.stderr.write(
+                "error: --gui is not available in this image (CLI-only Docker build)\n"
+            )
+            sys.exit(1)
         from .gui import launch_gui
         launch_gui()
         return

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,0 +1,37 @@
+# CLI-only dependencies for the Docker image.
+# Identical to requirements.txt minus PySide6 and any other GUI-only packages.
+# The main requirements.txt includes PySide6 for the desktop app; this file
+# is used by the Dockerfile so the container stays lean and headless.
+
+# Core
+rich>=13.0.0
+pyyaml>=6.0
+requests>=2.28.0
+
+# PDF generation
+img2pdf>=0.5.0
+Pillow>=10.0.0
+
+# EPUB generation
+ebooklib>=0.18
+
+# Scrapers
+beautifulsoup4>=4.12.0
+playwright>=1.40.0
+cloudscraper>=1.2.71
+
+# PDF splitting (for email delivery of large files)
+pikepdf>=8.0.0
+
+# Secure credential storage
+keyring>=24.0.0
+# Backs keyring's Windows Credential Manager backend. keyring declares
+# this as a conditional dep already; pinning it explicitly shields
+# against version drift dropping it silently.
+pywin32-ctypes>=0.2.0; sys_platform == "win32"
+
+# Stealth mode for Playwright scrapers
+playwright-stealth>=1.0.0
+
+# SSL CA bundle -- pinned here too so build scripts can resolve it
+certifi>=2024.7.0

--- a/tests/unit/cli/test_cli_docker.py
+++ b/tests/unit/cli/test_cli_docker.py
@@ -1,0 +1,96 @@
+"""Tests for MEMANGA_CLI_ONLY=1 -- Docker image hides and rejects --gui.
+
+The env variable is set in the Dockerfile ENV block so it is present in
+every container process.  The three behaviours under test:
+
+  1. --help output omits --gui flag and the epilog example line.
+  2. Passing --gui exits 1 and writes a clear message to stderr.
+  3. Normal installs (env unset) are unaffected: --gui is visible in help.
+"""
+from __future__ import annotations
+
+import sys
+import types
+import pytest
+
+
+@pytest.fixture
+def invoke(monkeypatch, isolated_home):
+    """Call cli.main() with patched argv; return exit code."""
+    def _call(*argv):
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        monkeypatch.setattr(sys, "argv", ["memanga"] + list(argv))
+        try:
+            cli.main()
+            return 0
+        except SystemExit as exc:
+            return exc.code
+    return _call
+
+
+class TestCliOnlyEnvVar:
+    def test_help_hides_gui_flag(self, monkeypatch, isolated_home, capsys):
+        monkeypatch.setenv("MEMANGA_CLI_ONLY", "1")
+        monkeypatch.setattr(sys, "argv", ["memanga", "--help"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--gui" not in out
+        assert "graphical" not in out.lower()
+
+    def test_help_hides_epilog_gui_line(self, monkeypatch, isolated_home, capsys):
+        monkeypatch.setenv("MEMANGA_CLI_ONLY", "1")
+        monkeypatch.setattr(sys, "argv", ["memanga", "--help"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "memanga --gui" not in out
+
+    def test_gui_flag_rejected_exit_1(self, monkeypatch, isolated_home, capsys):
+        monkeypatch.setenv("MEMANGA_CLI_ONLY", "1")
+        monkeypatch.setattr(sys, "argv", ["memanga", "--gui"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "--gui" in err
+        assert "not available" in err
+
+    def test_gui_flag_visible_in_normal_mode(self, monkeypatch, isolated_home, capsys):
+        monkeypatch.delenv("MEMANGA_CLI_ONLY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["memanga", "--help"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--gui" in out
+        assert "memanga --gui" in out
+
+    def test_gui_flag_launches_gui_in_normal_mode(self, monkeypatch, isolated_home):
+        """Without MEMANGA_CLI_ONLY the --gui path reaches launch_gui(), not the error."""
+        monkeypatch.delenv("MEMANGA_CLI_ONLY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["memanga", "--gui"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        launched = []
+        fake_gui = types.SimpleNamespace(launch_gui=lambda: launched.append(True))
+        monkeypatch.setitem(sys.modules, "memanga.gui", fake_gui)
+        cli.main()
+        assert launched == [True]


### PR DESCRIPTION
## Summary
- Add a CLI-only Docker image build from the main branch
- Publish Docker images from release tags and manual dispatch only
- Document Docker Hub, GHCR, Compose, cron, volumes, and Kindle delivery usage

Closes #88.

## Changes
- Adds a Dockerfile, Compose setup, Docker-specific dependency file, and release/manual image workflow
- Keeps the container CLI-only by excluding GUI source, omitting PySide6, removing the GUI launcher, and hiding the GUI flag in CLI-only Docker mode
- Updates README and guide docs so the main branch shows desktop app, CLI, release packages, and Docker usage together

## Testing
- `python -m pytest tests/unit/cli -q`
- `python3 -m compileall -q memanga tests`
- `git diff --check`
- Parsed `.github/workflows/docker-image.yml` and verified only `v*` tags plus `workflow_dispatch` trigger it
- Verified referenced GitHub Action tags exist
- `sudo docker build -t memanga:main-cli-test .`
- `sudo docker run --rm memanga:main-cli-test --help`
- `sudo docker run --rm memanga:main-cli-test --gui`
- `sudo docker run --rm -v <tmp>/config:/home/memanga/.config/memanga -v <tmp>/downloads:/home/memanga/Downloads/MeManga memanga:main-cli-test status`
- Inspected the built image: no `memanga.gui`, no `PySide6`, no `memanga-gui` launcher, and zero installed `memanga/gui` files
