### PR TITLE
chore(release): sync cli for v0.4.0

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,9 @@ config.yaml
 state.json
 .DS_Store
 Thumbs.db
+
+# The GUI sub-package is excluded from the Docker build context.
+# The container runs the CLI only; memanga/gui/ is not needed and
+# would add unnecessary source from main's desktop-app layer.
+# Passing --gui inside the container will fail (the module is absent).
+memanga/gui

--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,23 @@ Thumbs.db
 # Test output
 test-output/
 
-# Generic build / dist scratch dirs (unused on this branch but kept
-# ignored in case a downstream user runs setup.py with extras).
+# PyInstaller scratch dirs — build/ is the temp area, dist/ is the
+# default output location. Our build scripts move the final .exe to
+# the repo root and remove both, but on a failed build they may
+# linger; never commit them.
 build/
 dist/
+
+# Final build artifacts — single-file PyInstaller output lands in
+# the `release/` subdir (chosen so a `MeManga` binary cannot collide
+# with the `memanga/` package on case-insensitive macOS/Windows
+# filesystems). Don't ever check binaries into git; they belong in
+# GitHub Releases.
+/release/
+/MeManga.exe
+/MeManga-Dev.exe
+*.exe
+*.app
 
 # pytest cache
 .pytest_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,45 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-07-19
+
+### Added
+- #88 Official Docker images are now supported for headless servers, NAS boxes,
+  Raspberry Pi systems, and cron-style automation. Release tags publish a
+  CLI-only image to Docker Hub and GitHub Container Registry, while local
+  `docker build` and Compose workflows remain available for testing.
+- #89 Downloads can now run a configurable post-processing command after a
+  chapter finishes, making it easier to plug MeManga into local conversion,
+  sync, or automation pipelines.
+- #90 CBZ downloads now include ComicInfo.xml metadata so compatible comic
+  readers can show series, chapter, and title details.
+- #117 Accepted partial downloads are now tracked so missing pages can be
+  retried without discarding pages that were already saved.
+
+### Changed
+- #102 Manual backlog checks now use a trusted chapter catalogue baseline so
+  suspicious-batch protection does not incorrectly reject intentional backlog
+  downloads.
+
+### Fixed
+- #109 Unix cron setup now quotes scheduled-check paths, so installs work when
+  the repository path contains spaces or shell-sensitive characters.
+- #110 State mutations are consistently synchronized to avoid races between
+  background and persistence paths.
+- #112 Download-from-chapter actions no longer crash when history contains
+  non-numeric or part-style chapter labels.
+- #113 Kindle attachment-size errors now report the correct limit and recovery
+  guidance.
+- #114 Backup imports no longer append duplicate titles from the same file.
+- #115 Backup imports now preserve existing manga state while merging incoming
+  records.
+- #118 Auto-mode new-chapter badges now remain stable until the active download
+  batch finishes.
+
+### Security
+- Mail credential handling and download path handling were hardened to reduce
+  the risk of unsafe paths or credential exposure during local workflows.
+
 ## [0.3.3] - 2026-07-12
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ memanga/
 ├── state.py            # State journal (downloaded chapters, etc.)
 ├── downloader.py       # Chapter download + format conversion
 ├── emailer.py          # Kindle/SMTP delivery
+├── cron.py             # Crontab line builder
+├── perf.py             # Optional timing instrumentation
 └── scrapers/           # 200+ site scrapers
     ├── base.py         # BaseScraper / Chapter / Manga dataclasses
     ├── playwright_base.py
@@ -71,7 +73,8 @@ pytest -m live tests/scrapers/live/test_live_parsing.py -v
 pytest -m live tests/scrapers/live/ --health-report=health.json
 ```
 
-All checked-in tests should pass before you push.
+All checked-in tests should pass before you push. CI runs `pytest` on
+every push.
 
 ## Adding a scraper
 
@@ -83,6 +86,20 @@ All checked-in tests should pass before you push.
 4. Register the domain in `memanga/scrapers/__init__.py` (or the
    registry's `TEMPLATE_SCRAPERS` map for template-based scrapers).
 5. Add a fixture-based test under `tests/scrapers/`.
+
+## Dependency pinning
+
+The dev install (`pip install -r requirements.txt`) uses `>=` ranges so
+you get the latest patch-level updates while iterating.
+
+**When to refresh the lock for Docker/reproducible builds:**
+
+```bash
+pip install pip-tools
+pip-compile --output-file=requirements-docker.txt --strip-extras requirements.txt
+git add requirements-docker.txt
+git commit -m "chore(deps): refresh requirements-docker.txt"
+```
 
 ## Commit style
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,15 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PIP_NO_CACHE_DIR=1 \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright \
-    HOME=/home/memanga
+    HOME=/home/memanga \
+    MEMANGA_CLI_ONLY=1
 
 WORKDIR /app
 
-# Install dependencies and the Playwright Firefox runtime first so this
-# expensive layer stays cached when only application source changes.
+# Install CLI-only dependencies and the Playwright Firefox runtime first so
+# this expensive layer stays cached when only application source changes.
+# The cli branch's requirements.txt already excludes PySide6 and other
+# GUI-only packages, so the container stays lean and headless.
 COPY requirements.txt ./
 RUN python -m pip install --upgrade pip \
     && python -m pip install -r requirements.txt \
@@ -24,6 +27,7 @@ RUN python -m pip install --upgrade pip \
     && chown -R memanga:memanga /home/memanga
 
 # Install the package itself (deps already satisfied above).
+# .dockerignore excludes memanga/gui so only the CLI source lands in the image.
 COPY pyproject.toml README.md ./
 COPY memanga ./memanga
 RUN python -m pip install --no-deps .

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ engine and a cron-friendly CLI.
 - **Power-user CLI** — scriptable, cron-friendly, works on headless servers
 - **Library tracking** — read/unread state survives reboots
 - **Multi-source search** — 15 popular aggregators pre-checked, ranked by reliability
-- **PDF / EPUB / CBZ / ZIP / JPG / PNG / WEBP** output
+- **PDF / EPUB / CBZ / ZIP / JPG / PNG / WEBP** output (CBZ includes ComicInfo.xml)
 - **E-Reader delivery** — auto-send chapters by email after download
+- **Post-processing hooks** — run a custom command after each chapter download
+- **Partial chapter tolerance** — keep and retry chapters with a few missing pages
 - **Backup sources** — fall back to a second source if the primary stops updating
 - **Offline-aware** — gracefully fails on network actions when offline
 - **No telemetry, no accounts, no cloud** — everything stays on your machine
@@ -74,8 +76,8 @@ docker build -t memanga:cli .
 docker run --rm memanga:cli --help
 ```
 
-Official prebuilt images are published to Docker Hub and GitHub
-Container Registry from release tags on the `main` branch:
+Official release images are published to Docker Hub and GitHub Container
+Registry when a release tag is pushed:
 
 ```bash
 docker pull meellm/memanga:latest
@@ -87,9 +89,8 @@ docker run --rm ghcr.io/meellm/memanga:latest --help
 
 Stable releases are published to both registries with `X.Y.Z`, `X.Y`,
 and `latest` tags; pin to a specific `X.Y.Z` tag for reproducible runs.
-The `cli` branch does not publish images; for local testing or
-unreleased changes from this branch, build the image locally as shown
-above.
+Use a local `docker build` when testing unreleased code from the
+repository.
 
 Persist MeManga's config/state and downloads with two mounts:
 

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -1,13 +1,13 @@
-# MeManga Setup & Usage Guide (CLI)
+# MeManga Setup & Usage Guide
 
-Automatic manga downloader with Kindle support. Track manga from 224
-scrapers / 319 domains, download chapters as PDF / EPUB / CBZ / ZIP /
-JPG / PNG / WEBP, and optionally email them to your Kindle.
+CLI manga downloader. Track manga from 224 scrapers / 319 domains,
+download chapters as PDF / EPUB / CBZ / ZIP / JPG / PNG / WEBP, and
+optionally email them to your Kindle.
 
-> This guide covers the CLI flow. For the desktop app, switch to the
-> [`main` branch](https://github.com/meellm/MeManga/tree/main) and
-> follow that README — the GUI ships there as a single-file
-> `MeManga.exe` / `MeManga`.
+> This guide covers the CLI flow only. For the desktop app, grab the
+> latest `MeManga.exe` / `MeManga` from the
+> [GitHub releases page](https://github.com/meellm/MeManga/releases)
+> and double-click — there's nothing to configure up front.
 
 ---
 
@@ -23,6 +23,7 @@ JPG / PNG / WEBP, and optionally email them to your Kindle.
 - [Downloading From a Specific Chapter](#downloading-from-a-specific-chapter)
 - [Managing Status](#managing-status)
 - [Changing Output Format](#changing-output-format)
+- [Post-Processing After Download](#post-processing-after-download)
 - [Setting Up Kindle Email](#setting-up-kindle-email)
 - [Backup Sources](#backup-sources)
 - [Updating Manga Details](#updating-manga-details)
@@ -255,7 +256,8 @@ Or run directly through the virtual environment:
 
 Docker is the easiest option for headless servers, NAS boxes, Raspberry
 Pi systems, and cron-style automation because the image includes the CLI
-and Playwright Firefox runtime.
+and Playwright Firefox runtime without requiring a local Python install.
+The Docker image does **not** include PySide6 or any other GUI runtime.
 
 ### Requirements
 
@@ -265,14 +267,14 @@ and Playwright Firefox runtime.
 ### Build and run
 
 ```bash
-git clone -b cli <repo-url>
+git clone -b cli https://github.com/meellm/MeManga.git
 cd MeManga
 docker build -t memanga:cli .
 docker run --rm memanga:cli --help
 ```
 
-Official prebuilt images are published to Docker Hub and GitHub
-Container Registry from release tags on the `main` branch:
+Official release images are published to Docker Hub and GitHub Container
+Registry when a release tag is pushed:
 
 ```bash
 docker pull meellm/memanga:latest
@@ -284,8 +286,8 @@ docker run --rm ghcr.io/meellm/memanga:latest --help
 
 Stable releases are published to both registries with `X.Y.Z`, `X.Y`,
 and `latest` tags; pin to a specific `X.Y.Z` tag for reproducible runs.
-The `cli` branch does not publish images; use a local `docker build`
-when running code from this branch or testing unreleased changes.
+Use a local `docker build` when testing unreleased code from the
+repository.
 
 ### Persist config, state, and downloads
 
@@ -617,6 +619,93 @@ Download one manga in CBZ:
 
 ```bash
 run check -t "One Piece" --format cbz --auto
+```
+
+---
+
+## Post-Processing After Download
+
+MeManga can run a command of your choice after each chapter's output
+file (or image folder) is created - for converting, compressing, copying to an
+archive, or triggering another tool.
+
+Post-processing is **disabled by default**.
+
+> ⚠️ The command runs on your machine. Only enable commands you trust and
+> understand.
+
+### Enable it
+
+Run the config wizard and answer the post-processing prompts:
+
+```bash
+run config
+```
+
+Or edit `~/.config/memanga/config.yaml` directly:
+
+```yaml
+delivery:
+  post_processing:
+    enabled: true
+    command: 'cp -R {output_path} /mnt/archive/'
+    fail_on_error: false
+```
+
+### Available values
+
+Each value is available both as a `{placeholder}` in the command string and as
+an environment variable:
+
+| Placeholder | Environment variable | Meaning |
+|-------------|----------------------|---------|
+| `{output_path}` | `MEMANGA_OUTPUT_PATH` | Final file or folder path |
+| `{title}` | `MEMANGA_MANGA_TITLE` | Manga title |
+| `{chapter}` | `MEMANGA_CHAPTER` | Chapter number |
+| `{source}` | `MEMANGA_SOURCE` | Source the chapter came from |
+| `{format}` | `MEMANGA_OUTPUT_FORMAT` | Output format (`pdf`, `cbz`, `jpg`, …) |
+| `{is_dir}` | `MEMANGA_IS_DIR` | `1` if the output is a folder (image formats), else `0` |
+
+The hook receives the final output path whether it is an archive/document file
+(`pdf`, `epub`, `cbz`, `zip`) or an image folder (`jpg`, `png`, `webp`).
+The command is split into arguments and run directly, without a shell.
+Placeholder values are substituted after splitting, so manga metadata cannot
+become shell syntax. For shell features like pipes, redirects, or globbing,
+invoke a shell explicitly and prefer the `MEMANGA_*` environment variables.
+
+### Failure behavior
+
+- `fail_on_error: false` (default) - a failed command prints a warning but the
+  chapter is still recorded as downloaded.
+- `fail_on_error: true` - a failed command marks the chapter as failed, so it
+  shows up under `run failed` for retry. During CLI checks, backup-source
+  handling applies the same way it does for other download failures.
+
+A command is considered failed if it exits non-zero, times out (10 minute
+limit), or can't be launched.
+
+### Examples
+
+Copy every download into an archive directory:
+
+```yaml
+command: 'cp -R {output_path} /mnt/archive/'
+```
+
+Optimize a CBZ/ZIP or run a script with the passed environment variables:
+
+```yaml
+command: '/opt/memanga-hooks/process-chapter.sh'
+```
+
+```bash
+#!/usr/bin/env bash
+# process-chapter.sh
+echo "Finished $MEMANGA_MANGA_TITLE chapter $MEMANGA_CHAPTER ($MEMANGA_OUTPUT_FORMAT)"
+if [ "$MEMANGA_IS_DIR" = "1" ]; then
+  # image-folder output, e.g. compress each image
+  find "$MEMANGA_OUTPUT_PATH" -name '*.png' -print
+fi
 ```
 
 ---

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -24,6 +24,24 @@ delivery:
   delete_after_send: false  # Delete PDF after sending to Kindle (email mode only)
   output_format: pdf  # "pdf", "epub", "cbz", "zip", "jpg", "png", or "webp"
 
+  # Optional post-processing command, run after each chapter's output
+  # file/folder is created. Disabled by default. Only enable commands you trust.
+  # The command is split into arguments and run directly, without a shell.
+  # Placeholder values are substituted after splitting. Scripts can read the
+  # MEMANGA_* environment variables instead.
+  #
+  # Available placeholders (also passed as MEMANGA_* environment variables):
+  #   {output_path} MEMANGA_OUTPUT_PATH   - final file or folder path
+  #   {title}       MEMANGA_MANGA_TITLE   - manga title
+  #   {chapter}     MEMANGA_CHAPTER       - chapter number
+  #   {source}      MEMANGA_SOURCE        - source the chapter came from
+  #   {format}      MEMANGA_OUTPUT_FORMAT - output format
+  #   {is_dir}      MEMANGA_IS_DIR        - "1" if output is a folder, else "0"
+  post_processing:
+    enabled: false
+    command: ""            # e.g. 'cp -R {output_path} /mnt/archive/'
+    fail_on_error: false   # true = a failed command marks the chapter failed
+
 # Email settings (only needed if delivery.mode = "email")
 email:
   kindle_email: ""        # your-kindle@kindle.com

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"

--- a/memanga/backup.py
+++ b/memanga/backup.py
@@ -12,7 +12,7 @@ show :class:`BackupVersionError` messages to the user as-is, so keep
 them short and self-explanatory.
 """
 
-from typing import Any, Callable, Dict
+from typing import Any, Callable, Dict, Mapping, Optional
 
 EXPORT_VERSION = 1
 
@@ -49,6 +49,8 @@ def validate_backup(data: Any) -> dict:
             f"Backup version {version} is newer than this app supports "
             f"(max {EXPORT_VERSION}); update MeManga"
         )
+    if "state" in data and not isinstance(data["state"], dict):
+        raise BackupVersionError("Invalid backup: state must be an object")
 
     while version < EXPORT_VERSION:
         migrate = _MIGRATIONS.get(version)
@@ -60,3 +62,157 @@ def validate_backup(data: Any) -> dict:
         version += 1
 
     return data
+
+
+def _chapter_sort_key(value: Any):
+    try:
+        return (0, float(value), str(value))
+    except (TypeError, ValueError):
+        return (1, str(value).lower())
+
+
+def _merge_unique_chapters(local: Any, imported: Any) -> list:
+    merged = {str(ch) for ch in (local or [])}
+    merged.update(str(ch) for ch in (imported or []))
+    return sorted(merged, key=_chapter_sort_key)
+
+
+def _chapter_record_key(record: Any):
+    if not isinstance(record, dict):
+        return repr(record)
+    return (
+        str(record.get("number", "")),
+        str(record.get("source_url") or record.get("url") or ""),
+        str(record.get("source", "")),
+        bool(record.get("is_backup", False)),
+    )
+
+
+def _merge_chapter_records(local: Any, imported: Any) -> list:
+    merged = []
+    seen = set()
+    for record in list(local or []) + list(imported or []):
+        key = _chapter_record_key(record)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(record)
+    return merged
+
+
+def _newer_progress(local: Any, imported: Any) -> dict:
+    if not isinstance(local, dict):
+        return imported if isinstance(imported, dict) else {}
+    if not isinstance(imported, dict):
+        return local
+
+    local_time = local.get("last_read")
+    imported_time = imported.get("last_read")
+    if imported_time and (not local_time or str(imported_time) > str(local_time)):
+        return {**local, **imported}
+    return {**imported, **local}
+
+
+def _max_value(local: Any, imported: Any):
+    if local in (None, ""):
+        return imported
+    if imported in (None, ""):
+        return local
+    return max(local, imported)
+
+
+def _max_chapter(local: Any, imported: Any):
+    if local in (None, ""):
+        return imported
+    if imported in (None, ""):
+        return local
+    return max((local, imported), key=_chapter_sort_key)
+
+
+def merge_manga_state(local: Dict[str, Any], imported: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge one manga's imported backup state into local state.
+
+    The policy is intentionally conservative: never replace the whole
+    local record, union list-like chapter state, merge per-chapter maps
+    without overwriting local entries, and only take imported scalar
+    metadata when the local record is missing it.
+    """
+    if not isinstance(local, dict):
+        local = {}
+    if not isinstance(imported, dict):
+        imported = {}
+
+    merged = {**imported, **local}
+
+    for key in ("downloaded", "read_chapters", "external_chapters"):
+        merged[key] = _merge_unique_chapters(local.get(key), imported.get(key))
+
+    for key in ("available_chapters",):
+        merged[key] = _merge_chapter_records(local.get(key), imported.get(key))
+
+    for key in ("failed_chapters", "pending_backup", "partial_chapters"):
+        imported_map = imported.get(key) if isinstance(imported.get(key), dict) else {}
+        local_map = local.get(key) if isinstance(local.get(key), dict) else {}
+        if imported_map or local_map:
+            merged[key] = {**imported_map, **local_map}
+
+    merged["reading_progress"] = _newer_progress(
+        local.get("reading_progress"),
+        imported.get("reading_progress"),
+    )
+    merged["new_chapters_available"] = _max_value(
+        local.get("new_chapters_available", 0),
+        imported.get("new_chapters_available", 0),
+    ) or 0
+
+    if "last_chapter" in imported or "last_chapter" in local:
+        merged["last_chapter"] = _max_chapter(
+            local.get("last_chapter"),
+            imported.get("last_chapter"),
+        )
+    if "last_updated" in imported or "last_updated" in local:
+        merged["last_updated"] = _max_value(
+            local.get("last_updated"),
+            imported.get("last_updated"),
+        )
+
+    if imported.get("created") and not local.get("created"):
+        merged["created"] = imported["created"]
+
+    return merged
+
+
+def merge_backup_state(
+    local_state: Dict[str, Dict[str, Any]],
+    imported_state: Dict[str, Dict[str, Any]],
+    *,
+    title_aliases: Optional[Mapping[str, str]] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Merge all imported manga state entries into local manga state."""
+    if not isinstance(local_state, dict):
+        local_state = {}
+    if not isinstance(imported_state, dict):
+        imported_state = {}
+    if title_aliases is None:
+        title_aliases = {}
+    casefolded_aliases = {
+        title.casefold(): canonical
+        for title, canonical in title_aliases.items()
+        if isinstance(title, str)
+    }
+
+    merged = dict(local_state)
+    for title, imported_entry in imported_state.items():
+        alias_title = title_aliases.get(title) if isinstance(title, str) else None
+        if alias_title is None and isinstance(title, str):
+            alias_title = casefolded_aliases.get(title.casefold())
+        if alias_title and alias_title != title:
+            merged[alias_title] = merge_manga_state(
+                merged.get(alias_title, {}),
+                imported_entry,
+            )
+        elif title in merged:
+            merged[title] = merge_manga_state(merged[title], imported_entry)
+        else:
+            merged[title] = imported_entry
+    return merged

--- a/memanga/cli.py
+++ b/memanga/cli.py
@@ -19,8 +19,13 @@ from rich.prompt import Prompt, Confirm
 from rich.table import Table
 from rich import box
 
-from .backup import EXPORT_VERSION, BackupVersionError, validate_backup
+from .backup import (
+    EXPORT_VERSION,
+    BackupVersionError,
+    validate_backup,
+)
 from .config import Config, get_app_password, set_app_password
+from .cron import build_cron_line
 from .state import State
 from .downloader import check_for_updates, download_chapter, get_supported_sources, DownloaderError, ChapterWithSource, restart_browsers, _find_chapter_on_backup, _get_sources_from_manga
 from .scrapers import get_scraper
@@ -36,6 +41,26 @@ state = State()
 # ============================================================================
 
 VALID_STATUSES = ["reading", "on-hold", "dropped", "completed"]
+
+
+def _partial_threshold_arg(value):
+    """argparse type for --partial-threshold: a percentage in [0, 100].
+
+    Rejects non-numeric or out-of-range input at parse time so both
+    `config` and `check` give a clear error instead of silently clamping
+    on the command line (issue #86).
+    """
+    try:
+        num = float(value)
+    except (TypeError, ValueError):
+        raise argparse.ArgumentTypeError(
+            f"invalid threshold {value!r}: expected a number"
+        )
+    if not (0.0 <= num <= 100.0):
+        raise argparse.ArgumentTypeError(
+            f"threshold must be between 0 and 100, got {num:g}"
+        )
+    return num
 
 
 def _get_status_display(manga: Dict[str, Any]) -> str:
@@ -356,6 +381,13 @@ def cmd_update(args):
         if old_title in manga_state:
             manga_state[args.title] = manga_state.pop(old_title)
             state.set("manga", manga_state)
+        # Move already-downloaded files so they stay reachable under the
+        # new title (folder + filenames are keyed by title).
+        from .downloader import rename_manga_downloads
+        try:
+            rename_manga_downloads(config.download_dir, old_title, args.title)
+        except Exception:
+            pass
         changes.append(f"Title → {args.title}")
 
     if not changes:
@@ -411,7 +443,19 @@ def cmd_check(args):
     download_dir = config.download_dir
     output_format = getattr(args, 'format', None) or config.output_format
     email_cfg = config.get("email", {})
-    
+    post_processing = config.get("delivery.post_processing")
+
+    # Partial-chapter tolerance (issue #86). Config is the source of truth;
+    # `check` flags can override it for a single run.
+    allow_partial = config.partial_enabled
+    if getattr(args, 'allow_partial', False):
+        allow_partial = True
+    if getattr(args, 'no_partial', False):
+        allow_partial = False
+    partial_threshold = getattr(args, 'partial_threshold', None)
+    if partial_threshold is None:
+        partial_threshold = config.partial_threshold
+
     for manga in manga_list:
         title = manga["title"]
         status = manga.get("status", "reading")
@@ -479,6 +523,71 @@ def cmd_check(args):
                 if not should_download:
                     continue
 
+                max_retries = getattr(args, 'retries', 3)
+
+                # Captures partial-download details from download_chapter so
+                # we can surface which pages are missing without parsing the
+                # log line. Reset per attempt.
+                partial_info = {}
+
+                def _capture_partial(failed_pages, total, _info=partial_info):
+                    _info["failed_pages"] = failed_pages
+                    _info["total"] = total
+
+                def _deliver_email(file_path):
+                    """Send to Kindle if configured (skips image folders)."""
+                    if not (delivery_mode == "email" and email_cfg.get("kindle_email")):
+                        return
+                    if file_path.is_dir():
+                        console.print("     [dim]📧 Skipped email (image folders cannot be emailed)[/dim]")
+                        return
+                    console.print("     [dim]📧 Sending to Kindle...[/dim]")
+                    try:
+                        send_to_kindle(
+                            pdf_path=file_path,
+                            kindle_email=email_cfg["kindle_email"],
+                            sender_email=email_cfg["sender_email"],
+                            smtp_server=email_cfg.get("smtp_server", "smtp.gmail.com"),
+                            smtp_port=email_cfg.get("smtp_port", 587),
+                            app_password=get_app_password(config),
+                        )
+                        console.print("     [green]📬 Sent to Kindle![/green]")
+                        if config.get("delivery.delete_after_send", False):
+                            file_path.unlink()
+                            console.print("     [dim]🗑️  Deleted local copy[/dim]")
+                    except EmailError as email_e:
+                        console.print(f"     [red]📧 Email failed: {email_e}[/red]")
+
+                def _announce_saved(file_path, from_backup, partial, source=None):
+                    """Print the save line and, for partials, warn + log which
+                    pages are missing so headless runs leave a trail."""
+                    label = f"{file_path.parent.name}/{file_path.name}/" if file_path.is_dir() else file_path.name
+                    src = " from backup" if from_backup else ""
+                    if partial:
+                        miss = partial.get("failed_pages", [])
+                        total = partial.get("total", 0)
+                        console.print(
+                            f"     [yellow]⚠️  Saved partial{src}: {label} — "
+                            f"{len(miss)}/{total} page(s) missing (pages {miss})[/yellow]"
+                        )
+                        state.add_notification(
+                            "warn",
+                            f"'{title}' Chapter {ch.number} saved as partial: "
+                            f"{len(miss)}/{total} page(s) missing (pages {miss}).",
+                        )
+                        state.add_partial_chapter(
+                            title,
+                            ch.number,
+                            source=source or "",
+                            failed_pages=miss,
+                            total_pages=total,
+                            path=str(file_path),
+                            from_backup=from_backup,
+                        )
+                    else:
+                        state.clear_partial_chapter(title, ch.number)
+                        console.print(f"     [green]✅ Saved{src}: {label}[/green]")
+
                 try:
                     # Show source info if from backup
                     source_info = ""
@@ -486,39 +595,30 @@ def cmd_check(args):
                         source_info = f" [yellow](from backup: {ch.source})[/yellow]"
 
                     console.print(f"     [dim]⬇️  Downloading {ch_label}...{source_info}[/dim]")
-                    max_retries = getattr(args, 'retries', 3)
-                    file_path = download_chapter(manga, ch, download_dir, output_format, max_retries=max_retries)
-                    is_image_folder = file_path.is_dir()
 
-                    if is_image_folder:
-                        console.print(f"     [green]✅ Saved: {file_path.parent.name}/{file_path.name}/[/green]")
-                    else:
-                        console.print(f"     [green]✅ Saved: {file_path.name}[/green]")
+                    # Only accept a partial straight away when there's no
+                    # backup to try first — otherwise we prefer a complete
+                    # download from the backup (issue #86 direction).
+                    is_from_backup = isinstance(ch, ChapterWithSource) and ch.is_backup
+                    has_backup = (not is_from_backup) and len(_get_sources_from_manga(manga)) > 1
+                    primary_allow_partial = allow_partial and not has_backup
 
-                    # Email if configured (skip for image folders)
-                    if delivery_mode == "email" and email_cfg.get("kindle_email"):
-                        if is_image_folder:
-                            console.print(f"     [dim]📧 Skipped email (image folders cannot be emailed)[/dim]")
-                        else:
-                            console.print(f"     [dim]📧 Sending to Kindle...[/dim]")
-                            try:
-                                send_to_kindle(
-                                    pdf_path=file_path,
-                                    kindle_email=email_cfg["kindle_email"],
-                                    sender_email=email_cfg["sender_email"],
-                                    smtp_server=email_cfg.get("smtp_server", "smtp.gmail.com"),
-                                    smtp_port=email_cfg.get("smtp_port", 587),
-                                    app_password=get_app_password(config),
-                                )
-                                console.print(f"     [green]📬 Sent to Kindle![/green]")
-
-                                # Delete after send if configured
-                                if config.get("delivery.delete_after_send", False):
-                                    file_path.unlink()
-                                    console.print(f"     [dim]🗑️  Deleted local copy[/dim]")
-
-                            except EmailError as e:
-                                console.print(f"     [red]📧 Email failed: {e}[/red]")
+                    partial_info.clear()
+                    file_path = download_chapter(
+                        manga, ch, download_dir, output_format,
+                        max_retries=max_retries,
+                        post_processing=post_processing,
+                        allow_partial=primary_allow_partial,
+                        partial_threshold=partial_threshold,
+                        on_partial=_capture_partial,
+                    )
+                    _announce_saved(
+                        file_path,
+                        from_backup=False,
+                        partial=dict(partial_info),
+                        source=getattr(ch, "source", None) or "unknown",
+                    )
+                    _deliver_email(file_path)
 
                     # Update state
                     state.add_downloaded_chapter(title, ch.number)
@@ -535,39 +635,94 @@ def cmd_check(args):
                     ch_source = ch.source if isinstance(ch, ChapterWithSource) else "unknown"
                     is_from_backup = isinstance(ch, ChapterWithSource) and ch.is_backup
 
-                    # Auto-fallback to backup source when the primary source fails
-                    backup_tried = False
+                    backup_ch = None
                     if not is_from_backup:
                         backup_ch = _find_chapter_on_backup(manga, ch.number)
-                        if backup_ch:
-                            backup_tried = True
-                            console.print(f"     [yellow]⚠️  Primary failed ({e}), trying backup ({backup_ch.source})...[/yellow]")
-                            try:
-                                file_path = download_chapter(manga, backup_ch, download_dir, output_format, max_retries=max_retries)
-                                is_image_folder = file_path.is_dir()
-                                if is_image_folder:
-                                    console.print(f"     [green]✅ Saved from backup: {file_path.parent.name}/{file_path.name}/[/green]")
-                                else:
-                                    console.print(f"     [green]✅ Saved from backup: {file_path.name}[/green]")
-                                state.add_downloaded_chapter(title, ch.number)
-                                state.clear_pending_backup(title, ch.number)
-                                state.clear_failed_chapter(title, ch.number)
-                                total_downloaded += 1
-                            except DownloaderError as backup_e:
-                                console.print(f"     [red]❌ Backup also failed: {backup_e}[/red]")
-                                state.add_failed_chapter(
-                                    title, ch.number,
-                                    f"{ch_source}+{backup_ch.source}",
-                                    f"Primary: {e}; Backup: {backup_e}",
-                                )
-                                total_failed += 1
 
-                    if not backup_tried:
-                        # No backup available (or this chapter was already from backup source)
-                        console.print(f"     [red]❌ Failed: {e}[/red]")
-                        state.add_failed_chapter(title, ch.number, ch_source, str(e))
+                    saved = False
+                    backup_e = None
+
+                    # 1) Try a complete download from the backup source.
+                    if backup_ch:
+                        console.print(f"     [yellow]⚠️  Primary failed ({e}), trying backup ({backup_ch.source})...[/yellow]")
+                        try:
+                            file_path = download_chapter(
+                                manga, backup_ch, download_dir, output_format,
+                                max_retries=max_retries,
+                                post_processing=post_processing,
+                            )
+                            _announce_saved(
+                                file_path,
+                                from_backup=True,
+                                partial=None,
+                                source=getattr(backup_ch, "source", None),
+                            )
+                            _deliver_email(file_path)
+                            state.add_downloaded_chapter(title, ch.number)
+                            state.clear_pending_backup(title, ch.number)
+                            state.clear_failed_chapter(title, ch.number)
+                            total_downloaded += 1
+                            saved = True
+                        except DownloaderError as be:
+                            backup_e = be
+                            console.print(f"     [red]❌ Backup also failed: {be}[/red]")
+
+                    # 2) Both sources failed to deliver a complete chapter.
+                    #    If partial tolerance is on, salvage the best partial
+                    #    (backup first, then primary) within the threshold.
+                    if not saved and allow_partial:
+                        salvage = []
+                        if backup_ch:
+                            salvage.append((backup_ch, True))
+                        # Skip the primary here if we already tried it with
+                        # partial enabled above (no backup case).
+                        if not primary_allow_partial:
+                            salvage.append((ch, False))
+                        for cand, from_backup in salvage:
+                            partial_info.clear()
+                            try:
+                                file_path = download_chapter(
+                                    manga, cand, download_dir, output_format,
+                                    max_retries=max_retries,
+                                    post_processing=post_processing,
+                                    allow_partial=True,
+                                    partial_threshold=partial_threshold,
+                                    on_partial=_capture_partial,
+                                )
+                            except DownloaderError:
+                                continue
+                            _announce_saved(
+                                file_path,
+                                from_backup=from_backup,
+                                partial=dict(partial_info),
+                                source=getattr(cand, "source", None),
+                            )
+                            _deliver_email(file_path)
+                            state.add_downloaded_chapter(title, ch.number)
+                            state.clear_pending_backup(title, ch.number)
+                            state.clear_failed_chapter(title, ch.number)
+                            total_downloaded += 1
+                            saved = True
+                            break
+
+                    # 3) Nothing worked — record the failure.
+                    if not saved:
+                        if backup_ch and backup_e is not None:
+                            console.print(f"     [red]❌ Failed: {e}[/red]")
+                            state.add_failed_chapter(
+                                title, ch.number,
+                                f"{ch_source}+{backup_ch.source}",
+                                f"Primary: {e}; Backup: {backup_e}",
+                                failed_pages=getattr(e, "failed_pages", None),
+                            )
+                        else:
+                            console.print(f"     [red]❌ Failed: {e}[/red]")
+                            state.add_failed_chapter(
+                                title, ch.number, ch_source, str(e),
+                                failed_pages=getattr(e, "failed_pages", None),
+                            )
                         total_failed += 1
-                    
+
         except DownloaderError as e:
             console.print(f"  [red]└─ Error: {e}[/red]")
         except Exception as e:
@@ -613,6 +768,13 @@ def cmd_status(args):
         table.add_row("Kindle email", config.get("email.kindle_email") or "[red]not set[/red]")
         table.add_row("Sender email", config.get("email.sender_email") or "[red]not set[/red]")
     
+    pp_enabled = bool(config.get("delivery.post_processing.enabled"))
+    pp_status = "enabled" if pp_enabled else "disabled"
+    table.add_row(
+        "Post-processing",
+        f"[{'green' if pp_enabled else 'dim'}]{pp_status}[/]",
+    )
+
     cron_status = "enabled" if config.get("cron.enabled") else "disabled"
     cron_time = config.get("cron.time", "06:00")
     table.add_row("Cron", f"[{'green' if cron_status == 'enabled' else 'dim'}]{cron_status}[/] ({cron_time})")
@@ -643,7 +805,27 @@ def cmd_config(args):
         console.print(Panel("[bold]Current Configuration[/bold]", border_style="cyan"))
         console.print(yaml.dump(display, default_flow_style=False))
         return
-    
+
+    # Non-interactive config for partial-chapter tolerance (issue #86).
+    # When any of these flags are given, persist them and return without
+    # dropping into the interactive prompt flow.
+    partial = getattr(args, "partial", None)
+    threshold = getattr(args, "partial_threshold", None)
+    if partial is not None or threshold is not None:
+        if partial is not None:
+            config.set("partial_chapters.enabled", partial == "on")
+        if threshold is not None:
+            # Already validated to [0, 100] by the argparse type.
+            config.set("partial_chapters.threshold_percent", float(threshold))
+        config.save()
+
+        state_str = "enabled" if config.partial_enabled else "disabled"
+        console.print(
+            f"[green]✅ Partial-chapter tolerance {state_str}[/green] "
+            f"[dim](threshold: {config.partial_threshold:g}%)[/dim]"
+        )
+        return
+
     console.print(Panel("[bold]⚙️  Configure MeManga[/bold]", border_style="yellow"))
     console.print()
     
@@ -718,6 +900,69 @@ def cmd_config(args):
     elif fmt_choice == "7":
         config.set("delivery.output_format", "webp")
 
+    # Post-processing hook (optional, disabled by default)
+    pp_enabled = bool(config.get("delivery.post_processing.enabled"))
+    console.print(
+        f"\n[bold]Post-processing[/bold] (current: "
+        f"[cyan]{'enabled' if pp_enabled else 'disabled'}[/cyan])"
+    )
+    console.print(
+        "[dim]Run a command after each chapter is saved. "
+        "Only enable commands you trust.[/dim]"
+    )
+    if Confirm.ask("Enable post-processing command?", default=pp_enabled):
+        console.print(
+            "[dim]Placeholders: {output_path} {title} {chapter} {source} "
+            "{format} {is_dir} (also as MEMANGA_* env vars).[/dim]"
+        )
+        console.print(
+            "[dim]Commands run directly, without a shell. Invoke a shell "
+            "explicitly for pipes, redirects, or globbing. Scripts should "
+            "prefer MEMANGA_* env vars.[/dim]"
+        )
+        pp_command = Prompt.ask(
+            "Command",
+            default=config.get("delivery.post_processing.command", "")
+        )
+        pp_fail = Confirm.ask(
+            "Mark chapter as failed if the command fails?",
+            default=config.get("delivery.post_processing.fail_on_error", False)
+        )
+        config.set("delivery.post_processing.enabled", True)
+        config.set("delivery.post_processing.command", pp_command)
+        config.set("delivery.post_processing.fail_on_error", pp_fail)
+    else:
+        config.set("delivery.post_processing.enabled", False)
+
+    # Partial-chapter tolerance (issue #86)
+    current_partial = config.partial_enabled
+    state_str = "enabled" if current_partial else "disabled"
+    console.print(
+        f"\n[bold]Partial-Chapter Tolerance[/bold] (current: [cyan]{state_str}[/cyan])"
+    )
+    console.print(
+        "[dim]Keep a chapter that is missing a few pages instead of discarding it.[/dim]"
+    )
+    if Confirm.ask("Enable partial-chapter tolerance?", default=current_partial):
+        config.set("partial_chapters.enabled", True)
+        threshold = Prompt.ask(
+            "Max % of pages allowed to fail",
+            default=str(config.partial_threshold),
+        )
+        try:
+            value = float(threshold)
+        except (TypeError, ValueError):
+            console.print("[yellow]⚠️  Invalid number, keeping previous threshold.[/yellow]")
+        else:
+            clamped = max(0.0, min(100.0, value))
+            if clamped != value:
+                console.print(
+                    f"[yellow]⚠️  Threshold must be 0-100; clamped to {clamped:g}%.[/yellow]"
+                )
+            config.set("partial_chapters.threshold_percent", clamped)
+    else:
+        config.set("partial_chapters.enabled", False)
+
     config.save()
     console.print("\n[green]✅ Configuration saved![/green]")
 
@@ -768,8 +1013,7 @@ def _cmd_cron_unix(args):
             console.print("[red]Invalid time format. Use HH:MM[/red]")
             return 1
 
-        cron_cmd = f"cd {project_dir} && {python_path} -m memanga check --auto --quiet"
-        cron_line = f"{minute} {hour} * * * {cron_cmd} >> {project_dir}/memanga.log 2>&1"
+        cron_line = build_cron_line(minute, hour, project_dir, python_path)
 
         result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
         existing = result.stdout if result.returncode == 0 else ""
@@ -1161,48 +1405,41 @@ def cmd_import(args):
     else:
         # Merge mode: skip duplicates, merge chapter lists
         existing_manga = config.get("manga", [])
-        existing_titles = {m["title"].lower() for m in existing_manga}
-        existing_state = state.get("manga", {})
-
+        existing_titles = {
+            m["title"].lower(): m["title"]
+            for m in existing_manga
+        }
+        state_title_aliases = {}
         added = 0
         skipped = 0
         for m in imported_manga:
-            if m["title"].lower() in existing_titles:
+            title = m["title"]
+            title_key = title.lower()
+            existing_title = existing_titles.get(title_key)
+            if existing_title is not None:
+                if title != existing_title:
+                    state_title_aliases[title] = existing_title
                 skipped += 1
                 continue
             existing_manga.append(m)
-            existing_titles.add(m["title"].lower())
+            existing_titles[title_key] = title
             added += 1
-
-        # Merge state (downloaded chapter lists)
-        for title, s in imported_state.items():
-            if title in existing_state:
-                # Merge downloaded lists
-                existing_downloaded = set(existing_state[title].get("downloaded", []))
-                imported_downloaded = set(s.get("downloaded", []))
-                def _sort_key(x):
-                    try:
-                        return float(x)
-                    except (ValueError, TypeError):
-                        return 0.0
-                merged = sorted(
-                    existing_downloaded | imported_downloaded,
-                    key=_sort_key,
-                )
-                existing_state[title]["downloaded"] = merged
-            else:
-                existing_state[title] = s
 
         config.set("manga", existing_manga)
         config.save()
-        state.set("manga", existing_state)
+        state.merge_missing_manga_state(
+            imported_state,
+            merge_existing_downloaded=True,
+            title_aliases=state_title_aliases,
+        )
 
         console.print(f"[green]Imported: {added} added, {skipped} skipped (duplicate)[/green]")
 
 
 def cmd_failed(args):
-    """List and manage chapters that failed to download."""
+    """List and manage chapters that failed or were accepted as partial."""
     all_failed = state.get_all_failed_chapters()
+    all_partials = state.get_all_partial_chapters()
 
     # Filter by title if requested
     if args.title:
@@ -1210,36 +1447,59 @@ def cmd_failed(args):
             t: chapters for t, chapters in all_failed.items()
             if args.title.lower() in t.lower()
         }
+        all_partials = {
+            t: chapters for t, chapters in all_partials.items()
+            if args.title.lower() in t.lower()
+        }
 
-    if not all_failed:
-        console.print("[dim]No failed chapters recorded.[/dim]")
+    retryable = {}
+    for manga_title, chapters in all_failed.items():
+        retryable.setdefault(manga_title, {}).update(chapters)
+    for manga_title, chapters in all_partials.items():
+        bucket = retryable.setdefault(manga_title, {})
+        for chapter_num, info in chapters.items():
+            if chapter_num in bucket:
+                continue
+            bucket[chapter_num] = {
+                **info,
+                "partial": True,
+                "error": "Accepted partial download",
+            }
+
+    if not retryable:
+        console.print("[dim]No failed or partial chapters recorded.[/dim]")
         return
 
     table = Table(
-        title="⚠️  Failed Chapter Downloads",
+        title="⚠️  Retryable Chapter Downloads",
         box=box.ROUNDED,
         show_lines=True,
     )
     table.add_column("Manga", style="cyan bold")
     table.add_column("Chapter", style="yellow", justify="center")
-    table.add_column("Failed At", style="dim")
+    table.add_column("Status", justify="center")
+    table.add_column("Recorded At", style="dim")
     table.add_column("Source", style="green")
-    table.add_column("Pages Failed", justify="center")
+    table.add_column("Pages Missing", justify="center")
     table.add_column("Attempts", justify="center")
-    table.add_column("Error", style="red", no_wrap=False, max_width=40)
+    table.add_column("Reason", style="red", no_wrap=False, max_width=40)
 
-    for manga_title, chapters in sorted(all_failed.items()):
+    for manga_title, chapters in sorted(retryable.items()):
         for chapter_num, info in sorted(chapters.items(), key=lambda x: float(x[0]) if x[0].replace('.', '', 1).isdigit() else 0):
-            failed_at = info.get("failed_at", "")[:16].replace("T", " ")
+            is_partial = bool(info.get("partial")) or "accepted_at" in info
+            recorded_at = (
+                info.get("accepted_at") if is_partial else info.get("failed_at", "")
+            )[:16].replace("T", " ")
             pages = info.get("failed_pages", [])
             pages_str = str(pages) if pages else "—"
             table.add_row(
                 manga_title,
                 chapter_num,
-                failed_at,
+                "partial" if is_partial else "failed",
+                recorded_at,
                 info.get("source", "?"),
                 pages_str,
-                str(info.get("attempts", 1)),
+                "—" if is_partial else str(info.get("attempts", 1)),
                 info.get("error", ""),
             )
 
@@ -1250,7 +1510,10 @@ def cmd_failed(args):
         for manga_title, chapters in all_failed.items():
             for chapter_num in list(chapters):
                 state.clear_failed_chapter(manga_title, chapter_num)
-        console.print("[green]✅ Cleared all failure records.[/green]")
+        for manga_title, chapters in all_partials.items():
+            for chapter_num in list(chapters):
+                state.clear_partial_chapter(manga_title, chapter_num)
+        console.print("[green]✅ Cleared all failure and partial records.[/green]")
         return
 
     if args.retry:
@@ -1260,10 +1523,11 @@ def cmd_failed(args):
         download_dir = config.download_dir
         output_format = config.output_format
         email_cfg = config.get("email", {})
+        post_processing = config.get("delivery.post_processing")
         retried = 0
         succeeded = 0
 
-        for manga_title, chapters in all_failed.items():
+        for manga_title, chapters in retryable.items():
             manga = manga_by_title.get(manga_title)
             if not manga:
                 console.print(f"  [yellow]⚠️  Manga not found in config: {manga_title}[/yellow]")
@@ -1297,7 +1561,7 @@ def cmd_failed(args):
                 console.print(f"  [dim]⬇️  Retrying {manga_title} Chapter {chapter_num}...[/dim]")
                 retried += 1
                 try:
-                    file_path = download_chapter(manga, ch_obj, download_dir, output_format)
+                    file_path = download_chapter(manga, ch_obj, download_dir, output_format, post_processing=post_processing)
                     is_image_folder = file_path.is_dir()
                     if is_image_folder:
                         console.print(f"  [green]✅ Saved: {file_path.parent.name}/{file_path.name}/[/green]")
@@ -1320,6 +1584,7 @@ def cmd_failed(args):
 
                     state.add_downloaded_chapter(manga_title, chapter_num)
                     state.clear_failed_chapter(manga_title, chapter_num)
+                    state.clear_partial_chapter(manga_title, chapter_num)
                     succeeded += 1
                 except DownloaderError as retry_e:
                     # Try backup if available
@@ -1327,9 +1592,10 @@ def cmd_failed(args):
                     if backup_ch:
                         console.print(f"  [yellow]⚠️  Primary failed, trying backup ({backup_ch.source})...[/yellow]")
                         try:
-                            file_path = download_chapter(manga, backup_ch, download_dir, output_format)
+                            file_path = download_chapter(manga, backup_ch, download_dir, output_format, post_processing=post_processing)
                             state.add_downloaded_chapter(manga_title, chapter_num)
                             state.clear_failed_chapter(manga_title, chapter_num)
+                            state.clear_partial_chapter(manga_title, chapter_num)
                             label = f"{file_path.parent.name}/{file_path.name}/" if file_path.is_dir() else file_path.name
                             console.print(f"  [green]✅ Saved from backup: {label}[/green]")
                             succeeded += 1
@@ -1488,10 +1754,7 @@ def cmd_tui(args):
 # ============================================================================
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="📖 MeManga - Automatic manga downloader",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog="""
+    _epilog = """
 Examples:
   memanga list                          # Show tracked manga
   memanga add -i                        # Add manga interactively
@@ -1501,7 +1764,18 @@ Examples:
   memanga check --auto                  # Auto-download new chapters
   memanga cron install                  # Set up daily checks
   memanga config                        # Configure settings
-        """,
+"""
+
+    parser = argparse.ArgumentParser(
+        description="📖 MeManga - Automatic manga downloader",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_epilog,
+    )
+    # GUI is not part of this CLI build; hide the flag and reject it clearly.
+    parser.add_argument(
+        "--gui",
+        action="store_true",
+        help=argparse.SUPPRESS,
     )
 
     subparsers = parser.add_subparsers(dest="command", title="commands")
@@ -1552,6 +1826,12 @@ Examples:
     p_check.add_argument("--force-suspicious", action="store_true", help="Accept a chapter batch even if it was flagged as suspicious")
     p_check.add_argument("--format", choices=["pdf", "epub", "cbz", "zip", "jpg", "png", "webp"], help="Output format (overrides config)")
     p_check.add_argument("--retries", type=int, default=3, metavar="N", help="Retry failed page downloads N times (default: 3, 0 to disable)")
+    # Partial-chapter tolerance (issue #86) — config is the source of truth;
+    # these override it for a single run.
+    partial_grp = p_check.add_mutually_exclusive_group()
+    partial_grp.add_argument("--allow-partial", action="store_true", help="Keep a chapter with a few missing pages instead of discarding it (issue #86)")
+    partial_grp.add_argument("--no-partial", action="store_true", help="Force-discard any chapter with missing pages, even if partial tolerance is enabled in config")
+    p_check.add_argument("--partial-threshold", type=_partial_threshold_arg, metavar="PCT", help="Max %% of pages allowed to fail before a partial is refused, 0-100 (default: config value)")
     p_check.set_defaults(func=cmd_check)
     
     # status
@@ -1561,6 +1841,16 @@ Examples:
     # config
     p_config = subparsers.add_parser("config", help="Configure settings")
     p_config.add_argument("--show", action="store_true", help="Show current config")
+    # Non-interactive partial-chapter tolerance controls (issue #86). When
+    # omitted, `config` stays interactive.
+    p_config.add_argument(
+        "--partial", choices=["on", "off"],
+        help="Enable/disable partial-chapter tolerance without prompting",
+    )
+    p_config.add_argument(
+        "--partial-threshold", type=_partial_threshold_arg, metavar="PCT",
+        help="Persist the max %% of pages allowed to fail (0-100)",
+    )
     p_config.set_defaults(func=cmd_config)
     
     # cron
@@ -1607,6 +1897,12 @@ Examples:
     p_tui.set_defaults(func=cmd_tui)
     
     args = parser.parse_args()
+
+    if args.gui:
+        sys.stderr.write(
+            "error: --gui is not available in this installation (CLI build)\n"
+        )
+        sys.exit(1)
 
     if args.command is None:
         # Default to TUI

--- a/memanga/config.py
+++ b/memanga/config.py
@@ -8,6 +8,8 @@ import threading
 import yaml
 from pathlib import Path
 
+from .perf import timed
+
 
 class Config:
     """Manages configuration file.
@@ -32,7 +34,9 @@ class Config:
     def _load(self):
         """Load config from file."""
         if self.config_path.exists():
-            with open(self.config_path, "r") as f:
+            # Explicit UTF-8: titles are arbitrary Unicode and the
+            # platform default encoding may not represent them.
+            with open(self.config_path, "r", encoding="utf-8") as f:
                 data = yaml.safe_load(f) or {}
             # Merge with defaults to ensure new fields exist
             defaults = self._default_config()
@@ -59,6 +63,14 @@ class Config:
                 "delete_after_send": False,  # Delete file after sending to Kindle
                 "output_format": "pdf",  # "pdf", "epub", "cbz", "zip", "jpg", "png", or "webp"
                 "naming_template": "{title} - Chapter {chapter}",  # File naming pattern
+                "post_processing": {
+                    # Optional command run after each chapter's output
+                    # file/folder is created. Disabled by default. See docs
+                    # for available placeholders/env vars.
+                    "enabled": False,
+                    "command": "",
+                    "fail_on_error": False,  # True marks the chapter failed
+                },
             },
             "email": {
                 "kindle_email": "",
@@ -75,6 +87,25 @@ class Config:
                 "sort_by": "title",
                 "auto_check": True,
                 "auto_check_interval": 3600,
+                # Reader prefetch (issue #107). Off by default: while
+                # reading a manual-mode manga, the reader quietly queues
+                # the immediate next available chapter in the background.
+                "reader_prefetch_next": False,
+            },
+            # Built-in reader behaviour (issue #104). Kept separate from
+            # delivery.delete_after_send, which is tied to email delivery —
+            # this is reader-driven local cleanup. Off by default: a chapter
+            # stays on disk after it is read unless the user opts in.
+            "reader": {
+                "remove_after_read": False,
+            },
+            # Partial-chapter tolerance (issue #86). Off by default: any
+            # missing page still aborts the chapter and discards output.
+            # When enabled, a chapter whose failure rate is within
+            # threshold_percent is kept with only the pages that succeeded.
+            "partial_chapters": {
+                "enabled": False,
+                "threshold_percent": 5,  # max % of pages allowed to fail
             },
         }
     
@@ -110,6 +141,7 @@ class Config:
             data = data[k]
         data[keys[-1]] = value
     
+    @timed("config.save")
     def save(self):
         """Save config to file atomically. Thread-safe.
 
@@ -124,7 +156,7 @@ class Config:
 
         fd, tmp_path = tempfile.mkstemp(dir=self.config_dir, suffix=".tmp")
         try:
-            with os.fdopen(fd, "w") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(payload)
             os.replace(tmp_path, self.config_path)
         except Exception:
@@ -171,11 +203,35 @@ class Config:
     
     @property
     def email_enabled(self):
-        return self.delivery_mode == "email" and self.get("email.kindle_email")
+        # bool() matters: `and` would otherwise leak the kindle_email
+        # string, which Qt setters like setChecked() reject (issue #55).
+        return self.delivery_mode == "email" and bool(self.get("email.kindle_email"))
     
     @property
     def output_format(self):
         return self.get("delivery.output_format", "pdf")
+
+    @property
+    def partial_enabled(self):
+        """Whether partial-chapter tolerance is turned on (issue #86)."""
+        return bool(self.get("partial_chapters.enabled", False))
+
+    @property
+    def partial_threshold(self):
+        """Max share of pages allowed to fail before a partial is refused,
+        as a percentage clamped to [0, 100]. Falls back to 5 for garbage or
+        out-of-range values persisted by an older/hand-edited config."""
+        try:
+            value = float(self.get("partial_chapters.threshold_percent", 5))
+        except (TypeError, ValueError):
+            return 5.0
+        return max(0.0, min(100.0, value))
+
+    @property
+    def reader_prefetch_enabled(self):
+        """Whether the reader prefetches the next manual-mode chapter
+        while reading (issue #107)."""
+        return bool(self.get("gui.reader_prefetch_next", False))
 
 
 _KEYRING_SERVICE = "memanga"

--- a/memanga/cron.py
+++ b/memanga/cron.py
@@ -1,0 +1,29 @@
+"""
+Crontab helpers for shell-safe construction of the Unix cron entry shared
+by the CLI (`memanga cron install`) and the GUI Settings page.
+"""
+
+import shlex
+from pathlib import Path, PurePosixPath
+
+
+def quote_cron_path(path) -> str:
+    """Quote a filesystem path for use inside a crontab command.
+
+    ``shlex.quote()`` guards against spaces and shell metacharacters;
+    crontab(5) additionally turns an unescaped ``%`` into a newline, so
+    those are backslash-escaped on top of the shell quoting.
+    """
+    return shlex.quote(str(path)).replace("%", r"\%")
+
+
+def build_cron_line(minute, hour, project_dir, python_path) -> str:
+    """Build the daily auto-check crontab entry with shell-safe paths."""
+    project_dir = PurePosixPath(Path(project_dir).as_posix())
+    python_path = Path(python_path).as_posix()
+    command = (
+        f"cd {quote_cron_path(project_dir)} && "
+        f"{quote_cron_path(python_path)} -m memanga check --auto --quiet"
+    )
+    log_path = quote_cron_path(project_dir / "memanga.log")
+    return f"{minute} {hour} * * * {command} >> {log_path} 2>&1"

--- a/memanga/downloader.py
+++ b/memanga/downloader.py
@@ -10,8 +10,13 @@ Handles:
 """
 
 import io
+import os
+import re
+import signal
+import shlex
 import time
 import atexit
+import subprocess
 import tempfile
 import shutil
 import uuid
@@ -57,10 +62,23 @@ OutputFormat = Literal["pdf", "epub", "cbz", "zip", "jpg", "png", "webp"]
 # Default days to wait before falling back to backup source
 DEFAULT_FALLBACK_DELAY_DAYS = 2
 
+# How long a post-processing command may run before it's killed (seconds).
+POST_PROCESSING_TIMEOUT = 600
+
 
 class DownloaderError(Exception):
-    """Base exception for downloader errors."""
-    pass
+    """Base exception for downloader errors.
+
+    Incomplete-download failures carry structured detail so callers can
+    record/act on them without parsing the message string:
+    ``failed_pages`` (1-indexed page numbers) and ``total_pages``.
+    Both are ``None`` for errors unrelated to per-page failures.
+    """
+
+    def __init__(self, message, failed_pages=None, total_pages=None):
+        super().__init__(message)
+        self.failed_pages = failed_pages
+        self.total_pages = total_pages
 
 
 class ChapterWithSource(Chapter):
@@ -118,6 +136,31 @@ def _get_sources_from_manga(manga: Dict[str, Any]) -> List[Dict[str, str]]:
         "source": manga.get("source", ""),
         "url": manga.get("url", ""),
     }]
+
+
+def _max_cached_chapter(cached: List[Dict[str, Any]]) -> float:
+    """Highest numeric chapter number in a cached available-chapters list.
+
+    Used to bootstrap the catalogue baseline for manga that predate the
+    stored ``catalogue_baseline`` field (#102). Entries are the dicts the
+    GUI persists via ``set_available_chapters`` (``{"number": ...}``).
+    Returns 0.0 when nothing usable is present.
+    """
+    best = 0.0
+    for entry in cached or []:
+        if not isinstance(entry, dict):
+            continue
+        num = entry.get("number")
+        if num is None:
+            continue
+        try:
+            best = max(best, float(num))
+        except (TypeError, ValueError):
+            # Fall back to the leading number in strings like "12 Part 1".
+            match = re.search(r"\d+\.?\d*", str(num))
+            if match:
+                best = max(best, float(match.group()))
+    return best
 
 
 def check_for_updates(
@@ -258,55 +301,124 @@ def check_for_updates(
             f"All sources failed for '{title}': " + "; ".join(source_errors)
         )
 
-    # Suspicious-batch guard. Only meaningful when we have a baseline (a
-    # previously tracked chapter) and the user isn't explicitly
-    # bulk-downloading with from_chapter.
-    if from_chapter is None and last_num > 0 and primary_checked:
-        from .suspicion import evaluate_new_chapters
+    # Suspicious-batch guard.
+    #
+    # The batch is scored against the source's *catalogue baseline* — the
+    # highest chapter the source has legitimately exposed before — not the
+    # last downloaded chapter. Scoring against the last download makes a
+    # manual-mode backlog (only an early chapter grabbed from an
+    # already-large catalogue) look like a giant source jump on every check
+    # (#102). Only chapters that appear beyond the known catalogue are
+    # candidates for suspicion; anything at or below it is an existing,
+    # still-undownloaded backlog and stays freely downloadable.
+    if primary_checked:
+        primary_high = max((ch.numeric for ch in primary_all), default=0.0)
 
-        suspicion = evaluate_new_chapters(
-            state, title,
-            [ch.numeric for ch in primary_chapters.values()],
-            last_num,
+        get_suspicious_batch = getattr(state, "get_suspicious_batch", None)
+        active_suspicious = (
+            get_suspicious_batch(title)
+            if callable(get_suspicious_batch)
+            else None
         )
-        if suspicion.suspicious and not force_suspicious:
-            suspect = sorted(primary_chapters.values())
-            suspect_numbers = [round(ch.numeric, 3) for ch in suspect]
+        get_catalogue_baseline = getattr(state, "get_catalogue_baseline", None)
+        baseline = (
+            get_catalogue_baseline(title)
+            if callable(get_catalogue_baseline)
+            else None
+        )
+        if baseline is None and not active_suspicious:
+            # No trusted snapshot yet (manga predates this field, or was
+            # never checked). Bootstrap from the last cached catalogue so an
+            # existing large backlog isn't mistaken for a jump.
+            get_available_chapters = getattr(state, "get_available_chapters", None)
+            cached = (
+                get_available_chapters(title)
+                if callable(get_available_chapters)
+                else []
+            )
+            baseline = _max_cached_chapter(cached)
+        if baseline is None:
+            baseline = 0.0
+        bootstrapped_manual_baseline = False
+        if baseline <= 0 and manga.get("mode") == "manual" and from_chapter is None:
+            # First manual-mode check after adding/importing a manga. Manual
+            # mode only surfaces Download buttons, so this snapshot is not an
+            # auto-delivery risk; use it as the initial catalogue baseline
+            # instead of scoring the whole undownloaded backlog against the
+            # user's last downloaded/read chapter (#102).
+            baseline = primary_high
+            bootstrapped_manual_baseline = True
 
-            # Verify against backup sources before withholding anything.
-            confirmed = sum(1 for n in suspect_numbers if n in backup_all_numbers)
-            if backup_sources_checked and confirmed / len(suspect_numbers) >= 0.5:
-                # Backup largely agrees with the primary, so accept the batch.
-                state.clear_suspicious_batch(title)
-            else:
-                if backup_sources_checked:
-                    backup_status = (
-                        f"backup confirmed only {confirmed}/{len(suspect_numbers)} chapters"
-                    )
-                else:
-                    backup_status = "no backup source available to verify"
-                state.set_suspicious_batch(title, {
-                    "detected_at": datetime.now().isoformat(),
-                    "chapters": [ch.number for ch in suspect],
-                    "count": len(suspect),
-                    "last_chapter": last_num,
-                    "highest": max(suspect_numbers),
-                    "score": suspicion.score,
-                    "reasons": suspicion.reasons,
-                    "backup_status": backup_status,
-                })
-                state.add_notification(
-                    "warn",
-                    f"Suspicious chapter batch for '{title}': "
-                    f"{len(suspect)} chapter(s) up to {max(suspect_numbers):g} "
-                    f"({backup_status}). Skipped auto-delivery.",
+        catalogue_trusted = True
+        # Only score when we have a download baseline and the user isn't
+        # explicitly bulk-downloading with from_chapter.
+        if from_chapter is None and last_num > 0:
+            from .suspicion import evaluate_new_chapters
+
+            guard_from = max(last_num, baseline)
+            scored = {
+                num: ch for num, ch in primary_chapters.items()
+                if ch.numeric > guard_from
+            }
+            suspicion = (
+                evaluate_new_chapters(
+                    state, title,
+                    [ch.numeric for ch in scored.values()],
+                    guard_from,
                 )
-                # Withhold the whole primary batch from download/delivery.
-                primary_chapters = {}
-        else:
-            # Batch is normal, forced, or backup-confirmed. Drop any
-            # stale suspicious record so warnings don't linger.
-            state.clear_suspicious_batch(title)
+                if scored else None
+            )
+            if suspicion is not None and suspicion.suspicious and not force_suspicious:
+                suspect = sorted(scored.values())
+                suspect_numbers = [round(ch.numeric, 3) for ch in suspect]
+
+                # Verify against backup sources before withholding anything.
+                confirmed = sum(1 for n in suspect_numbers if n in backup_all_numbers)
+                if backup_sources_checked and confirmed / len(suspect_numbers) >= 0.5:
+                    # Backup largely agrees with the primary, so accept the batch.
+                    state.clear_suspicious_batch(title)
+                else:
+                    if backup_sources_checked:
+                        backup_status = (
+                            f"backup confirmed only {confirmed}/{len(suspect_numbers)} chapters"
+                        )
+                    else:
+                        backup_status = "no backup source available to verify"
+                    state.set_suspicious_batch(title, {
+                        "detected_at": datetime.now().isoformat(),
+                        "chapters": [ch.number for ch in suspect],
+                        "count": len(suspect),
+                        "last_chapter": guard_from,
+                        "highest": max(suspect_numbers),
+                        "score": suspicion.score,
+                        "reasons": suspicion.reasons,
+                        "backup_status": backup_status,
+                    })
+                    state.add_notification(
+                        "warn",
+                        f"Suspicious chapter batch for '{title}': "
+                        f"{len(suspect)} chapter(s) up to {max(suspect_numbers):g} "
+                        f"({backup_status}). Skipped auto-delivery.",
+                    )
+                    # Withhold only the suspicious newly-appeared chapters;
+                    # the known backlog stays downloadable. Don't advance the
+                    # trusted baseline past an unverified jump.
+                    for num in scored:
+                        primary_chapters.pop(num, None)
+                    catalogue_trusted = False
+            else:
+                # Batch is normal, forced, or backup-confirmed. Drop any
+                # stale suspicious record so warnings don't linger.
+                state.clear_suspicious_batch(title)
+
+        # Advance the trusted catalogue high-water mark unless we just held
+        # back an unverified jump. Recording it even when the guard didn't
+        # run (fresh manga, explicit from_chapter) gives later checks a
+        # baseline so a big existing backlog is never re-scored as a jump.
+        if catalogue_trusted and (primary_high > baseline or bootstrapped_manual_baseline):
+            set_catalogue_baseline = getattr(state, "set_catalogue_baseline", None)
+            if callable(set_catalogue_baseline):
+                set_catalogue_baseline(title, primary_high)
 
     # Process primary chapters first (always download these)
     for ch_num, ch in primary_chapters.items():
@@ -387,6 +499,10 @@ def download_chapter(
     naming_template: Optional[str] = None,
     cancel_event=None,
     max_retries: int = 3,
+    post_processing: Optional[Dict[str, Any]] = None,
+    allow_partial: bool = False,
+    partial_threshold: float = 0.0,
+    on_partial=None,
 ) -> Optional[Path]:
     """
     Download a chapter and convert to PDF or EPUB.
@@ -402,11 +518,39 @@ def download_chapter(
             InterruptedError before/during page fetching to abort the download.
         max_retries: Number of times to retry failed page downloads
             (with exponential back-off). 0 to disable.
+        post_processing: Optional ``delivery.post_processing`` config dict
+            ({"enabled", "command", "fail_on_error"}). When enabled, the
+            command is run after the output file/folder is created. If
+            ``fail_on_error`` is set, a command failure raises
+            :class:`DownloaderError` so normal failed-chapter handling applies;
+            otherwise it only prints a warning.
+        allow_partial: When True, a chapter that still has missing pages
+            after retries is kept as a *partial* download (only the pages
+            that succeeded, in order) instead of raising — provided the
+            failure rate is within ``partial_threshold``. Off by default,
+            so the historical "any failure aborts the chapter" behavior is
+            unchanged unless a caller opts in (issue #86).
+        partial_threshold: Maximum share of pages allowed to fail, as a
+            percentage (0-100). A partial is kept only when
+            ``failed_pages / total_pages * 100 <= partial_threshold`` and
+            at least one page downloaded. With the default 0, any failure
+            still aborts.
+        on_partial: Optional callable(failed_page_nums, total_pages) invoked
+            when a partial download is accepted, so callers can log/surface
+            it and record which pages are missing.
 
     Returns:
         Path to downloaded file, or None if failed
     """
     title = manga["title"]
+
+    # Defensive: keep the tolerance within [0, 100] even if a caller passes
+    # something out of range directly (issue #86). The CLI/config already
+    # clamp, but download_chapter is a public entry point.
+    try:
+        partial_threshold = max(0.0, min(100.0, float(partial_threshold)))
+    except (TypeError, ValueError):
+        partial_threshold = 0.0
 
     def _check_cancel():
         if cancel_event is not None and cancel_event.is_set():
@@ -517,10 +661,36 @@ def download_chapter(
         still_failed = [idx for idx, _, _ in download_tasks if idx not in results]
         if still_failed:
             failed_page_nums = [i + 1 for i in still_failed]
-            raise DownloaderError(
-                f"Incomplete download: {len(still_failed)}/{len(page_urls)} "
-                f"pages failed (pages {failed_page_nums})"
+            failed_pct = len(still_failed) / total_pages * 100
+
+            # Partial-chapter tolerance (issue #86): when enabled and the
+            # failure rate is within the configured threshold, keep the
+            # pages we did get instead of discarding the whole chapter.
+            # At least one page must have downloaded — a chapter with zero
+            # usable pages is a hard failure regardless of the threshold.
+            partial_ok = (
+                allow_partial
+                and results
+                and failed_pct <= partial_threshold
             )
+            if not partial_ok:
+                raise DownloaderError(
+                    f"Incomplete download: {len(still_failed)}/{len(page_urls)} "
+                    f"pages failed (pages {failed_page_nums})",
+                    failed_pages=failed_page_nums,
+                    total_pages=total_pages,
+                )
+
+            print(
+                f"  Partial chapter kept: {len(still_failed)}/{total_pages} "
+                f"page(s) missing ({failed_pct:.0f}% <= "
+                f"{partial_threshold:g}% tolerance), pages {failed_page_nums}"
+            )
+            if on_partial is not None:
+                try:
+                    on_partial(failed_page_nums, total_pages)
+                except Exception:
+                    pass
 
         # Preserve page order
         image_paths = [results[i] for i in sorted(results)]
@@ -577,7 +747,8 @@ def download_chapter(
         elif output_format == "cbz":
             output_path = manga_dir / f"{base_name}.cbz"
             try:
-                _images_to_cbz(image_paths, output_path)
+                comicinfo_xml = _build_comicinfo_xml(manga, chapter, len(image_paths))
+                _images_to_cbz(image_paths, output_path, comicinfo_xml)
             except Exception as e:
                 raise DownloaderError(f"Failed to create CBZ: {e}")
         elif output_format == "zip":
@@ -599,8 +770,274 @@ def download_chapter(
                 _images_to_pdf(image_paths, output_path)
             except Exception as e:
                 raise DownloaderError(f"Failed to create PDF: {e}")
-        
+
+        # Run the user's post-processing hook (if configured) after the
+        # output exists but before the caller records the chapter as
+        # downloaded, so a fail_on_error failure surfaces normally.
+        _run_post_processing(
+            post_processing,
+            output_path=output_path,
+            title=title,
+            chapter_num=chapter.number,
+            source=source,
+            output_format=output_format,
+        )
+
         return output_path
+
+
+def _run_post_processing(
+    post_processing: Optional[Dict[str, Any]],
+    output_path: Path,
+    title: str,
+    chapter_num: str,
+    source: str,
+    output_format: str,
+):
+    """Run the optional user post-processing command for a finished chapter.
+
+    The command is split into argv and run directly, not through a shell.
+    Useful values are passed both as ``{placeholder}`` substitutions in command
+    arguments and as ``MEMANGA_*`` environment variables:
+
+    - ``{output_path}`` / ``MEMANGA_OUTPUT_PATH`` - final file or folder path
+    - ``{title}`` / ``MEMANGA_MANGA_TITLE`` - manga title
+    - ``{chapter}`` / ``MEMANGA_CHAPTER`` - chapter number
+    - ``{source}`` / ``MEMANGA_SOURCE`` - source the chapter came from
+    - ``{format}`` / ``MEMANGA_OUTPUT_FORMAT`` - output format
+    - ``{is_dir}`` / ``MEMANGA_IS_DIR`` - "1" if output is a folder, else "0"
+
+    Placeholder values are substituted after argv parsing, so metadata cannot
+    become shell syntax. For shell features such as pipes or redirects, invoke
+    a shell explicitly and prefer the ``MEMANGA_*`` environment variables.
+
+    A non-zero exit, timeout, or launch error is treated as failure: if
+    ``fail_on_error`` is set the failure is re-raised as
+    :class:`DownloaderError`; otherwise a warning is printed and the download
+    stays successful.
+    """
+    if not post_processing or not post_processing.get("enabled"):
+        return
+
+    command = (post_processing.get("command") or "").strip()
+    if not command:
+        return
+
+    fail_on_error = bool(post_processing.get("fail_on_error"))
+    is_dir = "1" if output_path.is_dir() else "0"
+    output_path_str = str(output_path)
+    title = str(title)
+    chapter_num = str(chapter_num)
+    source = str(source)
+    output_format = str(output_format)
+
+    replacements = {
+        "output_path": output_path_str,
+        "title": title,
+        "chapter": chapter_num,
+        "source": source,
+        "format": output_format,
+        "is_dir": is_dir,
+    }
+
+    def _fail(message: str):
+        if fail_on_error:
+            raise DownloaderError(message)
+        print(f"  [Warning] {message}")
+
+    try:
+        command_args = _split_post_processing_command(command)
+    except ValueError as e:
+        _fail(f"Post-processing command could not be parsed: {e}")
+        return
+    if not command_args:
+        return
+
+    resolved_args = [
+        _substitute_post_processing_placeholders(arg, replacements)
+        for arg in command_args
+    ]
+
+    env = os.environ.copy()
+    env.update({
+        "MEMANGA_OUTPUT_PATH": output_path_str,
+        "MEMANGA_MANGA_TITLE": title,
+        "MEMANGA_CHAPTER": chapter_num,
+        "MEMANGA_SOURCE": source,
+        "MEMANGA_OUTPUT_FORMAT": output_format,
+        "MEMANGA_IS_DIR": is_dir,
+    })
+
+    try:
+        result = _run_post_processing_command(
+            resolved_args,
+            env=env,
+            timeout=POST_PROCESSING_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        _fail(
+            f"Post-processing command timed out after "
+            f"{POST_PROCESSING_TIMEOUT}s"
+        )
+        return
+    except Exception as e:
+        _fail(f"Post-processing command failed to start: {e}")
+        return
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        message = f"Post-processing command exited with code {result.returncode}"
+        if detail:
+            message += f": {detail}"
+        _fail(message)
+
+
+def _run_post_processing_command(
+    args: List[str],
+    env: Dict[str, str],
+    timeout: int,
+) -> subprocess.CompletedProcess:
+    """Run a post-processing command and terminate its process tree on timeout."""
+    kwargs: Dict[str, Any] = {}
+    if os.name == "nt":
+        kwargs["creationflags"] = (
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            | getattr(subprocess, "CREATE_NO_WINDOW", 0x08000000)
+        )
+    else:
+        kwargs["start_new_session"] = True
+
+    process = subprocess.Popen(
+        args,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        **kwargs,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        # The process tree is killed first, then we drain the pipes with a
+        # bounded wait. If a surviving grandchild still holds the pipe handles
+        # open, communicate() would block forever, so every drain here has its
+        # own timeout and we ultimately abandon the output rather than hang.
+        _terminate_process_tree(process)
+        stdout, stderr = _drain_after_timeout(process)
+        exc.output = stdout
+        exc.stderr = stderr
+        raise exc
+
+    return subprocess.CompletedProcess(args, process.returncode, stdout, stderr)
+
+
+def _drain_after_timeout(
+    process: subprocess.Popen,
+    drain_timeout: int = 5,
+) -> tuple:
+    """Read remaining output from a killed process without ever blocking.
+
+    Returns ``(stdout, stderr)``. If the pipes cannot be drained even after a
+    second kill, they are force-closed and ``(None, None)`` is returned so the
+    caller never waits on a wedged child that inherited the handles.
+    """
+    try:
+        return process.communicate(timeout=drain_timeout)
+    except subprocess.TimeoutExpired:
+        pass
+
+    process.kill()
+    try:
+        return process.communicate(timeout=drain_timeout)
+    except subprocess.TimeoutExpired:
+        pass
+
+    for stream in (process.stdout, process.stderr):
+        if stream is not None:
+            try:
+                stream.close()
+            except Exception:
+                pass
+    return None, None
+
+
+_POST_PROCESSING_PLACEHOLDER_RE = re.compile(
+    r"\{(output_path|title|chapter|source|format|is_dir)\}"
+)
+
+
+def _substitute_post_processing_placeholders(
+    arg: str,
+    replacements: Dict[str, str],
+) -> str:
+    """Replace placeholders once, without expanding placeholder text in values."""
+    return _POST_PROCESSING_PLACEHOLDER_RE.sub(
+        lambda match: replacements[match.group(1)],
+        arg,
+    )
+
+
+def _split_post_processing_command(command: str) -> List[str]:
+    """Split a command string into argv without damaging Windows paths."""
+    if os.name != "nt":
+        return shlex.split(command)
+
+    args: List[str] = []
+    current: List[str] = []
+    in_quotes = False
+    quote_char = ""
+
+    for ch in command:
+        if ch in ("'", '"'):
+            if in_quotes and ch == quote_char:
+                in_quotes = False
+                quote_char = ""
+            elif not in_quotes:
+                in_quotes = True
+                quote_char = ch
+            else:
+                current.append(ch)
+        elif ch.isspace() and not in_quotes:
+            if current:
+                args.append("".join(current))
+                current = []
+        else:
+            current.append(ch)
+
+    if in_quotes:
+        raise ValueError("No closing quotation")
+    if current:
+        args.append("".join(current))
+    return args
+
+
+def _terminate_process_tree(process: subprocess.Popen) -> bool:
+    """Terminate a process and its children where the platform supports it."""
+    if process.poll() is not None:
+        return True
+    if os.name == "nt":
+        try:
+            result = subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(process.pid)],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            if result.returncode == 0:
+                return True
+        except Exception:
+            pass
+    else:
+        try:
+            os.killpg(os.getpgid(process.pid), signal.SIGKILL)
+            return True
+        except Exception:
+            pass
+    try:
+        process.kill()
+        return True
+    except Exception:
+        return False
 
 
 def _image_to_jpeg_bytes(img_path: Path) -> tuple:
@@ -762,11 +1199,103 @@ def _images_to_pdf(image_paths: List[Path], output_path: Path):
     output_path.write_bytes(pdf_bytes)
 
 
-def _images_to_cbz(image_paths: List[Path], output_path: Path):
+def _parse_comicinfo_date(date_str: Optional[str]) -> Optional[Tuple[int, int, int]]:
+    """Best-effort parse of a chapter/source date into (year, month, day).
+
+    Chapter dates arrive in many shapes across scrapers (ISO 8601 from API
+    sources like ``publishAt``, free-form text elsewhere). Returns ``None``
+    when nothing usable can be extracted so the caller simply omits the
+    Year/Month/Day fields.
+    """
+    if not date_str:
+        return None
+    text = str(date_str).strip()
+    if not text:
+        return None
+
+    # ISO 8601 first (covers the trailing "...Z" suffix common to API sources).
+    try:
+        iso_text = text[:-1] + "+00:00" if text.endswith("Z") else text
+        dt = datetime.fromisoformat(iso_text)
+        return dt.year, dt.month, dt.day
+    except ValueError:
+        pass
+
+    for fmt in (
+        "%Y-%m-%d", "%Y/%m/%d", "%d-%m-%Y", "%m/%d/%Y",
+        "%B %d, %Y", "%b %d, %Y", "%d %B %Y", "%d %b %Y",
+    ):
+        try:
+            dt = datetime.strptime(text, fmt)
+            return dt.year, dt.month, dt.day
+        except ValueError:
+            continue
+    return None
+
+
+def _build_comicinfo_xml(
+    manga: Dict[str, Any],
+    chapter: Chapter,
+    page_count: int,
+) -> bytes:
+    """Build a ComicInfo.xml document from already-known metadata.
+
+    Only fields MeManga already has on hand (the tracked manga config and
+    the ``Chapter`` object) are written; no extra network requests are
+    made. Optional fields with no data are omitted entirely. Serialization
+    and XML escaping are handled by ElementTree.
+    """
+    from xml.etree.ElementTree import Element, SubElement, tostring
+
+    root = Element("ComicInfo", {
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xmlns:xsd": "http://www.w3.org/2001/XMLSchema",
+    })
+
+    def add(tag: str, value: Any):
+        if value is None:
+            return
+        text = str(value).strip()
+        if not text:
+            return
+        SubElement(root, tag).text = text
+
+    chapter_title = getattr(chapter, "title", None)
+    add("Title", chapter_title or f"Chapter {chapter.number}")
+    add("Series", manga.get("title"))
+    add("Number", chapter.number)
+
+    add("Summary", manga.get("description"))
+
+    parsed = _parse_comicinfo_date(getattr(chapter, "date", None))
+    if parsed:
+        year, month, day = parsed
+        add("Year", year)
+        add("Month", month)
+        add("Day", day)
+
+    add("Writer", manga.get("author"))
+
+    # Web: prefer the specific chapter URL, fall back to the manga URL.
+    add("Web", getattr(chapter, "url", "") or manga.get("url", ""))
+    add("PageCount", page_count)
+
+    return tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def _images_to_cbz(
+    image_paths: List[Path],
+    output_path: Path,
+    comicinfo_xml: Optional[bytes] = None,
+):
     """Convert a list of images to a CBZ (Comic Book ZIP) archive.
 
     Images are stored as-is (no re-encoding) with sequential names
     for correct reading order.
+
+    When ``comicinfo_xml`` is provided it is written to the archive root as
+    ``ComicInfo.xml`` so offline libraries and e-readers can read chapter
+    metadata. Page names and order are unaffected.
     """
     import zipfile
 
@@ -777,6 +1306,8 @@ def _images_to_cbz(image_paths: List[Path], output_path: Path):
         for i, img_path in enumerate(image_paths):
             ext = img_path.suffix.lower() or '.jpg'
             cbz.write(img_path, f"page_{i:03d}{ext}")
+        if comicinfo_xml is not None:
+            cbz.writestr("ComicInfo.xml", comicinfo_xml)
 
 
 def _images_to_folder(image_paths: List[Path], output_dir: Path, img_format: str):
@@ -843,7 +1374,70 @@ def _sanitize_filename(name: str) -> str:
     invalid_chars = '<>:"/\\|?*'
     for char in invalid_chars:
         name = name.replace(char, '')
-    return name.strip()[:100]  # Limit length
+    name = name.strip()[:100]  # Limit length
+    # Windows trims trailing dots/spaces from path components, so remove
+    # them explicitly after truncation to keep generated paths stable.
+    name = name.rstrip(". ")
+    # Never yield a dot-only ('.', '..') or empty result; those are
+    # directory references, not usable path components.
+    if not name.strip('.'):
+        return 'untitled'
+    return name
+
+
+def rename_manga_downloads(download_dir, old_title: str, new_title: str) -> bool:
+    """Move a manga's downloaded files when the manga is renamed.
+
+    Downloads live under ``<download_dir>/<sanitized title>/`` and the
+    default naming template embeds the title in each file
+    (``{title} - Chapter N``). The reader derives both the folder and the
+    file name from the manga's current title, so a rename leaves the old
+    files unreachable — the chapter shows as downloaded but "Read" finds
+    nothing.
+
+    This moves the per-manga folder to the new title and rewrites the
+    title prefix on any contained file or folder name so the reader's
+    lookup matches again. Existing files at the destination are left
+    untouched rather than overwritten.
+
+    Returns ``True`` if anything was moved, ``False`` if there was nothing
+    to migrate (no prior downloads, or the sanitized title is unchanged).
+    """
+    old_safe = _sanitize_filename(old_title)
+    new_safe = _sanitize_filename(new_title)
+    if not old_safe or not new_safe or old_safe == new_safe:
+        return False
+
+    base = Path(download_dir)
+    old_dir = base / old_safe
+    if not old_dir.is_dir():
+        return False
+
+    new_dir = base / new_safe
+    new_dir.mkdir(parents=True, exist_ok=True)
+
+    moved = False
+    for entry in list(old_dir.iterdir()):
+        name = entry.name
+        # Swap the leading title prefix (e.g. "Old - Chapter 5.cbz" ->
+        # "New - Chapter 5.cbz"). Names that don't start with the title
+        # (e.g. image-format "Chapter 5" folders) are moved as-is.
+        if name.startswith(old_safe):
+            name = new_safe + name[len(old_safe):]
+        target = new_dir / name
+        if target.exists():
+            continue
+        shutil.move(str(entry), str(target))
+        moved = True
+
+    # Drop the old folder if it's now empty; leave it if collisions
+    # forced some files to stay behind.
+    try:
+        old_dir.rmdir()
+    except OSError:
+        pass
+
+    return moved
 
 
 def _format_chapter_number(chapter_num: str) -> str:

--- a/memanga/emailer.py
+++ b/memanga/emailer.py
@@ -6,6 +6,7 @@ Automatically splits large PDFs that exceed Gmail's 25MB limit.
 
 import shutil
 import smtplib
+import ssl
 import tempfile
 from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
@@ -22,8 +23,15 @@ class EmailError(Exception):
     pass
 
 
-# Gmail limit is 25MB, use 23MB to be safe (base64 encoding adds ~33% overhead)
-MAX_ATTACHMENT_SIZE = 18 * 1024 * 1024  # 18MB raw (~24MB after base64, under Gmail's 25MB limit)
+# Gmail's attachment cap is 25MB after email encoding. Base64 adds roughly
+# 33%, so keep raw files lower to stay under the encoded cap.
+EMAIL_ATTACHMENT_LIMIT = 25 * 1024 * 1024
+MAX_ATTACHMENT_SIZE = 18 * 1024 * 1024  # 18MB raw (~24MB after base64)
+
+
+def _format_mb(size: int) -> str:
+    """Format a byte count as MiB for user-facing messages."""
+    return f"{size / (1024 * 1024):.1f}MB"
 
 
 def split_pdf(pdf_path: Path, max_size: int = MAX_ATTACHMENT_SIZE) -> List[Path]:
@@ -139,8 +147,13 @@ def send_to_kindle(
         if file_size > MAX_ATTACHMENT_SIZE:
             fmt = suffix.lstrip('.').upper()
             raise EmailError(
-                f"{fmt} file is {file_size / (1024*1024):.1f}MB, exceeding the 25MB email limit. "
-                f"{fmt} files cannot be split. Use PDF format instead (set in 'memanga config')."
+                f"{fmt} file is {_format_mb(file_size)}, exceeding MeManga's "
+                f"{_format_mb(MAX_ATTACHMENT_SIZE)} safe raw attachment limit. "
+                f"Email attachments are base64 encoded, so the raw file must "
+                f"stay below this limit to fit under the "
+                f"{_format_mb(EMAIL_ATTACHMENT_LIMIT)} encoded email cap. "
+                f"{fmt} files cannot be split. Use PDF format instead "
+                f"(set in 'memanga config')."
             )
         parts = [pdf_path]
         is_split = False
@@ -150,7 +163,11 @@ def send_to_kindle(
         is_split = len(parts) > 1
         
         if is_split:
-            print(f"     📎 Split into {len(parts)} parts (exceeded 25MB limit)")
+            print(
+                f"     📎 Split into {len(parts)} parts (exceeded "
+                f"{_format_mb(MAX_ATTACHMENT_SIZE)} safe raw attachment limit; "
+                f"encoded email cap is {_format_mb(EMAIL_ATTACHMENT_LIMIT)})"
+            )
     
     # Send each part
     for i, part_path in enumerate(parts):
@@ -217,8 +234,9 @@ def _send_single_email(
     
     # Send
     try:
+        context = ssl.create_default_context()
         with smtplib.SMTP(smtp_server, smtp_port) as server:
-            server.starttls()
+            server.starttls(context=context)
             server.login(sender_email, app_password)
             server.send_message(msg)
         return True
@@ -244,8 +262,9 @@ def test_email_config(
         True if connection successful
     """
     try:
+        context = ssl.create_default_context()
         with smtplib.SMTP(smtp_server, smtp_port) as server:
-            server.starttls()
+            server.starttls(context=context)
             server.login(sender_email, app_password)
         return True
     except Exception:

--- a/memanga/perf.py
+++ b/memanga/perf.py
@@ -1,0 +1,85 @@
+"""
+Lightweight opt-in timing instrumentation shared by the GUI and CLI.
+
+Disabled by default so production runs stay quiet. Enable with the
+``MEMANGA_PERF`` environment variable (``1``/``true``/``yes``/``on``)
+or programmatically via :func:`set_enabled` (used by tests).
+
+When enabled, each timed block logs its duration at DEBUG level on the
+``memanga.perf`` logger and appends a ``(name, duration_ms)`` sample to
+a bounded in-memory buffer readable via :func:`recent_samples`. When
+disabled, :func:`timed` costs a single boolean check per call.
+
+Usage::
+
+    from .perf import timed
+
+    @timed("state.save")          # as a decorator
+    def save(self): ...
+
+    with timed("gui.library.refresh"):   # or as a context manager
+        rebuild()
+"""
+
+import logging
+import os
+import threading
+import time
+from collections import deque
+from contextlib import contextmanager
+from typing import Deque, List, Optional, Tuple
+
+logger = logging.getLogger("memanga.perf")
+
+# Bounded so a long session can't grow memory. Samples arrive from worker
+# threads, so append/clear/snapshot share a lock: iterating a deque while
+# another thread appends raises "deque mutated during iteration".
+_MAX_SAMPLES = 200
+_samples: Deque[Tuple[str, float]] = deque(maxlen=_MAX_SAMPLES)
+_samples_lock = threading.Lock()
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# None means "not resolved yet - read the environment on first use".
+_enabled: Optional[bool] = None
+
+
+def is_enabled() -> bool:
+    """Whether timing collection is active."""
+    global _enabled
+    if _enabled is None:
+        _enabled = os.environ.get("MEMANGA_PERF", "").strip().lower() in _TRUTHY
+    return _enabled
+
+
+def set_enabled(value: Optional[bool]):
+    """Force collection on/off; ``None`` re-reads the environment."""
+    global _enabled
+    _enabled = value
+
+
+def clear_samples():
+    with _samples_lock:
+        _samples.clear()
+
+
+def recent_samples() -> List[Tuple[str, float]]:
+    """Snapshot of the most recent ``(name, duration_ms)`` samples."""
+    with _samples_lock:
+        return list(_samples)
+
+
+@contextmanager
+def timed(name: str):
+    """Time a block (or, used as a decorator, a call) under ``name``."""
+    if not is_enabled():
+        yield
+        return
+    start = time.perf_counter()
+    try:
+        yield
+    finally:
+        duration_ms = (time.perf_counter() - start) * 1000.0
+        with _samples_lock:
+            _samples.append((name, duration_ms))
+        logger.debug("%s took %.1f ms", name, duration_ms)

--- a/memanga/scrapers/mangafire.py
+++ b/memanga/scrapers/mangafire.py
@@ -8,7 +8,7 @@ endpoints to an SPA under /title/hid-slug backed by a JSON API:
 - GET /api/titles/{hid}/chapters?language=en&limit=100&page=N  (chapter list)
 - GET /api/chapters/{chapter_id}                               (page image URLs)
 
-All work with plain HTTP (no browser handshake needed).
+All work with plain HTTP (no VRF token or browser needed).
 
 Image descrambling based on:
 - https://github.com/f4rh4d-4hmed/MangaFire-API
@@ -182,7 +182,18 @@ class VRFGenerator:
         self._initialized = True
 
     def _ensure_browser_in_thread(self):
-        """Ensure the thread-local Firefox is running. Executor-thread only."""
+        """Ensure the thread-local Firefox is running. Executor-thread only.
+
+        Atomic, mirroring ``PlaywrightScraper._get_browser_in_thread``: a
+        failed ``firefox.launch()`` must not leave ``_vrf_thread_local``
+        with ``playwright`` set but no ``page``. The old code set
+        ``_vrf_thread_local.playwright`` first, so a launch failure left a
+        half-initialised thread-local — and the next call skipped the init
+        block and raised ``AttributeError`` on ``_vrf_thread_local.page``,
+        masking the real launch error (this is the "'thread_local'"
+        download failure in the frozen build). Build everything in locals,
+        roll the Playwright start back on failure, and commit at once.
+        """
         if not PLAYWRIGHT_AVAILABLE:
             raise RuntimeError("Playwright not available")
 
@@ -192,6 +203,8 @@ class VRFGenerator:
                 and hasattr(_vrf_thread_local, 'page')):
             return _vrf_thread_local.page
 
+        # Drop any half-initialised state from a previous failed attempt
+        # so sync_playwright().start() doesn't raise "already started".
         self._close_in_thread()
 
         print("[MangaFire] Starting Firefox browser (bypasses bot detection)...")
@@ -204,6 +217,8 @@ class VRFGenerator:
             )
             page = context.new_page()
         except Exception:
+            # Roll back so the next call retries cleanly and surfaces the
+            # real error instead of a masking AttributeError.
             try:
                 pw.stop()
             except Exception:

--- a/memanga/state.py
+++ b/memanga/state.py
@@ -2,13 +2,44 @@
 State management for MeManga - tracks downloaded chapters and check history
 """
 
+import copy
 import json
 import os
+import re
 import tempfile
 import threading
+from contextlib import contextmanager
 from pathlib import Path
 from datetime import datetime
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Mapping
+
+from .backup import merge_backup_state
+from .perf import timed
+
+
+_CHAPTER_NUMBER_RE = re.compile(r"(\d+(?:\.\d+)?)")
+
+
+def _chapter_number(label: Any) -> Optional[float]:
+    """Return the first numeric chapter value embedded in a label."""
+    match = _CHAPTER_NUMBER_RE.search(str(label))
+    if not match:
+        return None
+    return float(match.group(1))
+
+
+def _chapter_sort_key(chapter) -> float:
+    """Numeric sort key for a chapter identifier.
+
+    Mirrors Chapter.numeric (scrapers/base.py): plain numbers sort by
+    value and labelled numbers like "2 Part 1" or "Chapter 10" by their
+    first embedded number, so labelled chapters land after their plain
+    predecessors and the reader's Next controls can reach a prefetched
+    "2 Part 1" from chapter "1" (issue #107). Fully non-numeric labels
+    keep the old float()-only fallback of 0.0.
+    """
+    num = _chapter_number(chapter)
+    return num if num is not None else 0.0
 
 
 class State:
@@ -16,7 +47,21 @@ class State:
 
     Uses a dirty flag and thread lock to batch saves and prevent corruption.
     Call flush() explicitly when you need the file written immediately.
+
+    Issue #110: the GUI mutates state from background workers (checks,
+    downloads, source-health probes) while the main thread flushes it
+    periodically and on close. Every public method therefore takes the
+    same reentrant lock via ``_locked()``. Getters return deep snapshots
+    (nested containers included) and container-accepting setters store
+    snapshots, so no caller ever holds a live alias into ``_data``.
     """
+
+    # Latency above which a successful probe is flagged "warning" instead
+    # of "ok". Healthy sites on an ordinary connection routinely answer in
+    # 500-2000 ms, so a lower bound paints almost every source yellow. This
+    # threshold reserves the warning tier for responses that are genuinely
+    # sluggish.
+    SLOW_LATENCY_MS = 2500
 
     def __init__(self, config_dir: Optional[Path] = None):
         if config_dir:
@@ -26,10 +71,12 @@ class State:
 
         self.state_path = self.config_dir / "state.json"
         self.config_dir.mkdir(parents=True, exist_ok=True)
-        self._lock = threading.Lock()
+        # Reentrant so mutators that persist immediately can call save()
+        # (and nested public getters) while already holding the lock.
+        self._lock = threading.RLock()
         self._dirty = False
         self._data = self._load()
-    
+
     def _load(self) -> Dict[str, Any]:
         """Load state from file."""
         if self.state_path.exists():
@@ -39,7 +86,7 @@ class State:
             except (json.JSONDecodeError, IOError):
                 return self._default_state()
         return self._default_state()
-    
+
     def _default_state(self) -> Dict[str, Any]:
         """Return default state structure."""
         return {
@@ -50,24 +97,63 @@ class State:
             "download_history": [],
             "source_health": {},
         }
-    
+
+    @contextmanager
+    def _locked(self):
+        """Hold the state lock around a read or nested update of ``_data``.
+
+        Issue #110: every public method accesses ``_data`` through this so
+        background workers can't interleave with the main thread's periodic
+        flush/save. Yields ``_data`` so method bodies stay readable.
+        """
+        with self._lock:
+            yield self._data
+
+    @staticmethod
+    def _snapshot(value):
+        """Deep-copy container values so nothing a caller receives (or
+        passes in) aliases ``_data`` — shallow copies still leaked the
+        dicts nested inside returned lists, e.g. editing a row from
+        get_available_chapters() changed stored state. Everything in
+        ``_data`` is plain JSON types, so deepcopy stays cheap relative
+        to the GUI work that consumes these snapshots.
+        """
+        return copy.deepcopy(value) if isinstance(value, (dict, list)) else value
+
+    @classmethod
+    def _copy_entry(cls, entry: Dict[str, Any]) -> Dict[str, Any]:
+        """Snapshot a manga entry, deep-copying its container values."""
+        return {k: cls._snapshot(v) for k, v in entry.items()}
+
+    def _entry_value(self, manga_title: str, key: str, default=None):
+        """Read one field of a manga entry under the lock.
+
+        Containers come back as deep snapshots (see _snapshot). Cheaper
+        than get_manga_state() for the per-chapter getters the GUI calls
+        in row-rendering loops, since it doesn't snapshot the whole entry
+        (notably the available_chapters cache).
+        """
+        with self._locked() as data:
+            value = data.get("manga", {}).get(manga_title, {}).get(key, default)
+            return self._snapshot(value)
+
+    @timed("state.save")
     def save(self):
         """Save state to file atomically. Thread-safe."""
         with self._lock:
-            self._dirty = False
             data_snapshot = json.dumps(self._data, indent=None, default=str)
-
-        fd, tmp_path = tempfile.mkstemp(dir=self.config_dir, suffix=".tmp")
-        try:
-            with os.fdopen(fd, "w") as f:
-                f.write(data_snapshot)
-            os.replace(tmp_path, self.state_path)
-        except Exception:
+            fd, tmp_path = tempfile.mkstemp(dir=self.config_dir, suffix=".tmp")
             try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-            raise
+                with os.fdopen(fd, "w") as f:
+                    f.write(data_snapshot)
+                os.replace(tmp_path, self.state_path)
+                self._dirty = False
+            except Exception:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
 
     def _mark_dirty(self):
         """Mark state as modified. Use flush() to write to disk."""
@@ -75,31 +161,71 @@ class State:
 
     def flush(self):
         """Write to disk only if state has been modified."""
-        if self._dirty:
-            self.save()
+        with self._lock:
+            if self._dirty:
+                self.save()
 
     def get(self, key: str, default=None):
-        """Get a state value."""
-        return self._data.get(key, default)
+        """Get a state value. Containers come back as deep copies so the
+        caller can't race concurrent mutators; write changes back with
+        set()."""
+        with self._locked() as data:
+            return self._snapshot(data.get(key, default))
 
     def set(self, key: str, value):
-        """Set a state value and save immediately."""
-        self._data[key] = value
-        self.save()
-    
+        """Set a state value and save immediately. Containers are stored
+        as snapshots so later mutation by the caller can't reach ``_data``."""
+        with self._locked() as data:
+            data[key] = self._snapshot(value)
+            self.save()
+
+    def merge_missing_manga_state(
+        self,
+        imported_state: Dict[str, Any],
+        *,
+        merge_existing_downloaded: bool = False,
+        title_aliases: Optional[Mapping[str, str]] = None,
+    ):
+        """Merge imported manga state entries without replacing local state.
+
+        Issue #110: Settings backup import used to build a snapshot with
+        get("manga"), mutate it, then set("manga") wholesale. A worker update
+        between those calls could be overwritten. Keep the read/merge/save under
+        the State lock so local worker mutations serialize with import.
+        """
+        if imported_state is None:
+            imported_state = {}
+        if not isinstance(imported_state, dict):
+            raise TypeError("imported_state must be a dict")
+        with self._locked() as data:
+            manga = data.setdefault("manga", {})
+            if merge_existing_downloaded:
+                data["manga"] = self._snapshot(
+                    merge_backup_state(
+                        manga,
+                        imported_state,
+                        title_aliases=title_aliases,
+                    )
+                )
+            else:
+                for title, state_data in imported_state.items():
+                    if not manga.get(title):
+                        manga[title] = self._snapshot(state_data)
+            self.save()
+
     # ========================================================================
     # Manga State
     # ========================================================================
-    
+
     def get_manga_state(self, manga_title: str) -> Dict[str, Any]:
-        """Get full state for a manga."""
-        return self._data.get("manga", {}).get(manga_title, {})
-    
+        """Get full state for a manga (a snapshot, not the live entry)."""
+        with self._locked() as data:
+            return self._copy_entry(data.get("manga", {}).get(manga_title, {}))
+
     def get_last_chapter(self, manga_title: str) -> Optional[str]:
         """Get the last downloaded chapter number for a manga."""
-        manga_state = self.get_manga_state(manga_title)
-        return manga_state.get("last_chapter")
-    
+        return self._entry_value(manga_title, "last_chapter")
+
     def set_last_chapter(self, manga_title: str, chapter: str):
         """Set the last downloaded chapter for a manga.
 
@@ -107,88 +233,107 @@ class State:
         closeEvent flush cover durability without thrashing disk on
         every per-chapter update.
         """
-        self._ensure_manga_entry(manga_title)
-        self._data["manga"][manga_title]["last_chapter"] = chapter
-        self._data["manga"][manga_title]["last_updated"] = datetime.now().isoformat()
-        self._mark_dirty()
-    
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            data["manga"][manga_title]["last_chapter"] = chapter
+            data["manga"][manga_title]["last_updated"] = datetime.now().isoformat()
+            self._mark_dirty()
+
     def get_downloaded_chapters(self, manga_title: str) -> List[str]:
         """Get list of all downloaded chapter numbers for a manga."""
-        manga_state = self.get_manga_state(manga_title)
-        return manga_state.get("downloaded", [])
-    
+        return self._entry_value(manga_title, "downloaded", [])
+
     def add_downloaded_chapter(self, manga_title: str, chapter: str):
         """Mark a chapter as downloaded."""
-        self._ensure_manga_entry(manga_title)
-        
-        if "downloaded" not in self._data["manga"][manga_title]:
-            self._data["manga"][manga_title]["downloaded"] = []
-        
-        chapter_str = str(chapter)
-        if chapter_str not in self._data["manga"][manga_title]["downloaded"]:
-            self._data["manga"][manga_title]["downloaded"].append(chapter_str)
-            def _sort_key(x):
-                try:
-                    return float(x)
-                except (ValueError, TypeError):
-                    return 0.0
-            self._data["manga"][manga_title]["downloaded"].sort(key=_sort_key)
-        
-        self._data["manga"][manga_title]["last_chapter"] = chapter_str
-        self._data["manga"][manga_title]["last_updated"] = datetime.now().isoformat()
-        self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+
+            if "downloaded" not in entry:
+                entry["downloaded"] = []
+
+            chapter_str = str(chapter)
+            if chapter_str not in entry["downloaded"]:
+                entry["downloaded"].append(chapter_str)
+                entry["downloaded"].sort(key=_chapter_sort_key)
+
+            entry["last_chapter"] = chapter_str
+            entry["last_updated"] = datetime.now().isoformat()
+            self._mark_dirty()
 
     def is_chapter_downloaded(self, manga_title: str, chapter: str) -> bool:
         """Check if a chapter has been downloaded."""
         return str(chapter) in self.get_downloaded_chapters(manga_title)
-    
+
+    def remove_downloaded_chapter(self, manga_title: str, chapter: str) -> bool:
+        """Drop a single chapter from the downloaded list (issue #104).
+
+        Deliberately narrow: it touches only ``downloaded`` and leaves
+        ``read_chapters`` alone, so removing a chapter's local file after
+        it is read returns the Detail row to the Download state without
+        losing read progress. Returns True if the chapter was present.
+        No-op for unknown manga or chapters not marked downloaded.
+        """
+        with self._locked() as data:
+            manga_state = data.get("manga", {}).get(manga_title)
+            if not manga_state:
+                return False
+            downloaded = manga_state.get("downloaded", [])
+            chapter_str = str(chapter)
+            if chapter_str not in downloaded:
+                return False
+            downloaded.remove(chapter_str)
+            self._mark_dirty()
+            return True
+
     # ========================================================================
     # Backup Source Tracking
     # ========================================================================
-    
+
     def get_pending_backup(self, manga_title: str, chapter: str) -> Optional[Dict[str, Any]]:
         """Get pending backup info for a chapter (if waiting for primary to catch up)."""
-        manga_state = self.get_manga_state(manga_title)
-        pending = manga_state.get("pending_backup", {})
+        pending = self._entry_value(manga_title, "pending_backup", {})
         return pending.get(str(chapter))
-    
+
     def set_pending_backup(self, manga_title: str, chapter: str, backup_source: str, backup_url: str):
         """Mark a chapter as seen on backup source, start the waiting period."""
-        self._ensure_manga_entry(manga_title)
-        
-        if "pending_backup" not in self._data["manga"][manga_title]:
-            self._data["manga"][manga_title]["pending_backup"] = {}
-        
-        chapter_str = str(chapter)
-        if chapter_str not in self._data["manga"][manga_title]["pending_backup"]:
-            self._data["manga"][manga_title]["pending_backup"][chapter_str] = {
-                "first_seen": datetime.now().isoformat(),
-                "backup_source": backup_source,
-                "backup_url": backup_url,
-            }
-            self.save()
-    
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+
+            if "pending_backup" not in entry:
+                entry["pending_backup"] = {}
+
+            chapter_str = str(chapter)
+            if chapter_str not in entry["pending_backup"]:
+                entry["pending_backup"][chapter_str] = {
+                    "first_seen": datetime.now().isoformat(),
+                    "backup_source": backup_source,
+                    "backup_url": backup_url,
+                }
+                self.save()
+
     def clear_pending_backup(self, manga_title: str, chapter: str):
         """Clear pending backup for a chapter (downloaded from primary or backup)."""
-        manga_state = self.get_manga_state(manga_title)
-        pending = manga_state.get("pending_backup", {})
-        
-        chapter_str = str(chapter)
-        if chapter_str in pending:
-            del self._data["manga"][manga_title]["pending_backup"][chapter_str]
-            self.save()
-    
+        with self._locked() as data:
+            pending = data.get("manga", {}).get(manga_title, {}).get("pending_backup", {})
+
+            chapter_str = str(chapter)
+            if chapter_str in pending:
+                del pending[chapter_str]
+                self.save()
+
     def clear_all_pending_backups(self, manga_title: str):
         """Clear all pending backups for a manga."""
-        if manga_title in self._data.get("manga", {}):
-            self._data["manga"][manga_title]["pending_backup"] = {}
-            self.save()
-    
+        with self._locked() as data:
+            if manga_title in data.get("manga", {}):
+                data["manga"][manga_title]["pending_backup"] = {}
+                self.save()
+
     def get_all_pending_backups(self, manga_title: str) -> Dict[str, Dict[str, Any]]:
         """Get all pending backup chapters for a manga."""
-        manga_state = self.get_manga_state(manga_title)
-        return manga_state.get("pending_backup", {})
-    
+        return self._entry_value(manga_title, "pending_backup", {})
+
     # ========================================================================
     # Suspicious Batch Tracking
     # ========================================================================
@@ -197,20 +342,22 @@ class State:
         """Record a suspicious chapter batch that was held back from
         download/delivery. ``info`` should describe the batch (chapters,
         score, reasons, backup verification status, detected_at)."""
-        self._ensure_manga_entry(manga_title)
-        self._data["manga"][manga_title]["suspicious_batch"] = info
-        self.save()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            data["manga"][manga_title]["suspicious_batch"] = self._snapshot(info)
+            self.save()
 
     def get_suspicious_batch(self, manga_title: str) -> Optional[Dict[str, Any]]:
         """Get the held-back suspicious batch for a manga, if any."""
-        return self.get_manga_state(manga_title).get("suspicious_batch")
+        return self._entry_value(manga_title, "suspicious_batch")
 
     def clear_suspicious_batch(self, manga_title: str):
         """Clear the suspicious batch record (accepted, confirmed, or stale)."""
-        manga_state = self._data.get("manga", {}).get(manga_title, {})
-        if "suspicious_batch" in manga_state:
-            del manga_state["suspicious_batch"]
-            self.save()
+        with self._locked() as data:
+            manga_state = data.get("manga", {}).get(manga_title, {})
+            if "suspicious_batch" in manga_state:
+                del manga_state["suspicious_batch"]
+                self.save()
 
     # ========================================================================
     # Failed Chapter Tracking
@@ -225,46 +372,105 @@ class State:
         failed_pages: Optional[List[int]] = None,
     ):
         """Record a chapter download failure."""
-        self._ensure_manga_entry(manga_title)
-        chapter_str = str(chapter)
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            chapter_str = str(chapter)
+            entry = data["manga"][manga_title]
 
-        if "failed_chapters" not in self._data["manga"][manga_title]:
-            self._data["manga"][manga_title]["failed_chapters"] = {}
+            if "failed_chapters" not in entry:
+                entry["failed_chapters"] = {}
 
-        existing = self._data["manga"][manga_title]["failed_chapters"].get(chapter_str, {})
-        self._data["manga"][manga_title]["failed_chapters"][chapter_str] = {
-            "failed_at": datetime.now().isoformat(),
-            "source": source,
-            "error": error[:300],
-            "failed_pages": failed_pages or [],
-            "attempts": existing.get("attempts", 0) + 1,
-        }
-        self.save()
+            existing = entry["failed_chapters"].get(chapter_str, {})
+            entry["failed_chapters"][chapter_str] = {
+                "failed_at": datetime.now().isoformat(),
+                "source": source,
+                "error": error[:300],
+                "failed_pages": self._snapshot(failed_pages or []),
+                "attempts": existing.get("attempts", 0) + 1,
+            }
+            self.save()
 
     def get_failed_chapters(self, manga_title: str) -> Dict[str, Any]:
         """Get all failed chapter records for a manga."""
-        manga_state = self.get_manga_state(manga_title)
-        return manga_state.get("failed_chapters", {})
+        return self._entry_value(manga_title, "failed_chapters", {})
 
     def get_all_failed_chapters(self) -> Dict[str, Dict[str, Any]]:
         """Get failed chapters for all manga that have failures."""
-        result = {}
-        for title, manga_state in self._data.get("manga", {}).items():
-            failed = manga_state.get("failed_chapters", {})
-            if failed:
-                result[title] = failed
-        return result
+        with self._locked() as data:
+            result = {}
+            for title, manga_state in data.get("manga", {}).items():
+                failed = manga_state.get("failed_chapters", {})
+                if failed:
+                    result[title] = copy.deepcopy(failed)
+            return result
 
     def clear_failed_chapter(self, manga_title: str, chapter: str):
         """Remove a failed chapter record after successful re-download."""
-        chapter_str = str(chapter)
-        failed = self._data.get("manga", {}).get(manga_title, {}).get("failed_chapters", {})
-        if chapter_str in failed:
-            del self._data["manga"][manga_title]["failed_chapters"][chapter_str]
+        with self._locked() as data:
+            chapter_str = str(chapter)
+            failed = data.get("manga", {}).get(manga_title, {}).get("failed_chapters", {})
+            if chapter_str in failed:
+                del failed[chapter_str]
+                self.save()
+
+    # ========================================================================
+    # Accepted Partial Chapter Tracking
+    # ========================================================================
+
+    def add_partial_chapter(
+        self,
+        manga_title: str,
+        chapter: str,
+        source: str = "",
+        failed_pages: Optional[List[int]] = None,
+        total_pages: int = 0,
+        path: str = "",
+        from_backup: bool = False,
+    ):
+        """Record an accepted partial chapter so it remains retryable."""
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            chapter_str = str(chapter)
+            entry = data["manga"][manga_title]
+            entry.setdefault("partial_chapters", {})[chapter_str] = {
+                "accepted_at": datetime.now().isoformat(),
+                "source": source,
+                "failed_pages": self._snapshot(failed_pages or []),
+                "total_pages": int(total_pages or 0),
+                "path": path,
+                "from_backup": bool(from_backup),
+            }
             self.save()
 
+    def get_partial_chapters(self, manga_title: str) -> Dict[str, Any]:
+        """Get accepted partial chapter records for a manga."""
+        return self._entry_value(manga_title, "partial_chapters", {})
+
+    def get_partial_chapter(self, manga_title: str, chapter: str) -> Optional[Dict[str, Any]]:
+        """Get one accepted partial chapter record."""
+        partials = self.get_partial_chapters(manga_title)
+        return partials.get(str(chapter))
+
+    def get_all_partial_chapters(self) -> Dict[str, Dict[str, Any]]:
+        """Get accepted partial chapters for all manga."""
+        with self._locked() as data:
+            return {
+                title: self._snapshot(partials)
+                for title, manga_state in data.get("manga", {}).items()
+                if (partials := manga_state.get("partial_chapters", {}))
+            }
+
+    def clear_partial_chapter(self, manga_title: str, chapter: str):
+        """Remove an accepted partial record after a complete re-download."""
+        with self._locked() as data:
+            chapter_str = str(chapter)
+            partials = data.get("manga", {}).get(manga_title, {}).get("partial_chapters", {})
+            if chapter_str in partials:
+                del partials[chapter_str]
+                self.save()
+
     def _ensure_manga_entry(self, manga_title: str):
-        """Ensure manga entry exists in state."""
+        """Ensure manga entry exists in state. Caller must hold ``_lock``."""
         if "manga" not in self._data:
             self._data["manga"] = {}
         if manga_title not in self._data["manga"]:
@@ -277,88 +483,132 @@ class State:
                 "new_chapters_available": 0,
                 "available_chapters": [],
                 "external_chapters": [],
+                "partial_chapters": {},
             }
 
     # ========================================================================
     # Check History
     # ========================================================================
-    
+
     def update_last_check(self, new_chapters: int = 0, downloaded: int = 0):
         """Update the last check timestamp and optionally log to history."""
-        now = datetime.now().isoformat()
-        self._data["last_check"] = now
-        
-        # Add to history (keep last 50)
-        if "check_history" not in self._data:
-            self._data["check_history"] = []
-        
-        self._data["check_history"].append({
-            "timestamp": now,
-            "new_chapters": new_chapters,
-            "downloaded": downloaded,
-        })
-        
-        # Trim history
-        self._data["check_history"] = self._data["check_history"][-50:]
-        
-        self.save()
-    
+        with self._locked() as data:
+            now = datetime.now().isoformat()
+            data["last_check"] = now
+
+            # Add to history (keep last 50)
+            if "check_history" not in data:
+                data["check_history"] = []
+
+            data["check_history"].append({
+                "timestamp": now,
+                "new_chapters": new_chapters,
+                "downloaded": downloaded,
+            })
+
+            # Trim history
+            data["check_history"] = data["check_history"][-50:]
+
+            self.save()
+
     def get_check_history(self, limit: int = 10) -> List[Dict[str, Any]]:
         """Get recent check history."""
-        history = self._data.get("check_history", [])
-        return history[-limit:]
-    
+        with self._locked() as data:
+            return self._snapshot(data.get("check_history", [])[-limit:])
+
     # ========================================================================
     # Statistics
     # ========================================================================
-    
+
     def get_stats(self) -> Dict[str, Any]:
         """Get overall statistics."""
-        manga_data = self._data.get("manga", {})
-        
-        total_manga = len(manga_data)
-        total_chapters = sum(
-            len(m.get("downloaded", []))
-            for m in manga_data.values()
-        )
-        
-        return {
-            "total_manga": total_manga,
-            "total_chapters": total_chapters,
-            "last_check": self._data.get("last_check"),
-            "checks_logged": len(self._data.get("check_history", [])),
-        }
-    
+        with self._locked() as data:
+            manga_data = data.get("manga", {})
+
+            total_manga = len(manga_data)
+            total_chapters = sum(
+                len(m.get("downloaded", []))
+                for m in manga_data.values()
+            )
+
+            return {
+                "total_manga": total_manga,
+                "total_chapters": total_chapters,
+                "last_check": data.get("last_check"),
+                "checks_logged": len(data.get("check_history", [])),
+            }
+
     # ========================================================================
     # Reading Progress
     # ========================================================================
 
     def set_reading_progress(self, manga_title: str, chapter: str):
         """Update the last-read chapter for a manga."""
-        self._ensure_manga_entry(manga_title)
-        entry = self._data["manga"][manga_title]
-        if "reading_progress" not in entry:
-            entry["reading_progress"] = {}
-        entry["reading_progress"]["last_chapter"] = str(chapter)
-        entry["reading_progress"]["last_read"] = datetime.now().isoformat()
-        self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+            if "reading_progress" not in entry:
+                entry["reading_progress"] = {}
+            entry["reading_progress"]["last_chapter"] = str(chapter)
+            entry["reading_progress"]["last_read"] = datetime.now().isoformat()
+            self._mark_dirty()
 
     def get_reading_progress(self, manga_title: str) -> Dict[str, Any]:
         """Get reading progress for a manga."""
-        return self.get_manga_state(manga_title).get("reading_progress", {})
+        return self._entry_value(manga_title, "reading_progress", {})
 
     def get_continue_reading(self) -> Optional[Dict[str, Any]]:
         """Get the most recently read manga for 'Continue Reading' widget."""
-        best = None
-        best_time = None
-        for title, data in self._data.get("manga", {}).items():
-            progress = data.get("reading_progress", {})
-            last_read = progress.get("last_read")
-            if last_read and progress.get("last_chapter"):
-                if best_time is None or last_read > best_time:
-                    best_time = last_read
-                    best = {"title": title, **progress}
-        return best
+        with self._locked() as data:
+            best = None
+            best_time = None
+            for title, entry in data.get("manga", {}).items():
+                progress = entry.get("reading_progress", {})
+                last_read = progress.get("last_read")
+                if last_read and progress.get("last_chapter"):
+                    if best_time is None or last_read > best_time:
+                        best_time = last_read
+                        best = {"title": title, **progress}
+            return self._snapshot(best)
+
+    # ── Reader resume position (issue #106) ────────────────────────────
+    # Separate from `reading_progress.last_chapter` (the cursor) and
+    # `read_chapters` (the read set): this stores *where inside a chapter*
+    # the reader left off, so reopening a chapter can restore the exact
+    # page (paged mode) or scroll offset (webtoon/strip mode).
+
+    def set_reader_position(self, manga_title: str, chapter, mode: str,
+                            page_index: Optional[int] = None,
+                            scroll_ratio: Optional[float] = None):
+        """Save the in-chapter resume position for a manga/chapter."""
+        if chapter is None or str(chapter).strip() == "":
+            return
+        self._ensure_manga_entry(manga_title)
+        entry = self._data["manga"][manga_title]
+        positions = entry.setdefault("reader_positions", {})
+        pos: Dict[str, Any] = {
+            "mode": mode,
+            "updated_at": datetime.now().isoformat(),
+        }
+        if page_index is not None:
+            pos["page_index"] = max(0, int(page_index))
+        if scroll_ratio is not None:
+            pos["scroll_ratio"] = min(1.0, max(0.0, float(scroll_ratio)))
+        positions[str(chapter)] = pos
+        self._mark_dirty()
+
+    def get_reader_position(self, manga_title: str, chapter) -> Optional[Dict[str, Any]]:
+        """Get the saved resume position, or None if never saved."""
+        positions = self.get_manga_state(manga_title).get("reader_positions", {})
+        return positions.get(str(chapter))
+
+    def clear_reader_position(self, manga_title: str, chapter):
+        """Drop the saved resume position (e.g. chapter finished)."""
+        positions = self._data.get("manga", {}).get(manga_title, {}).get("reader_positions", {})
+        ch = str(chapter)
+        if ch in positions:
+            del positions[ch]
+            self._mark_dirty()
 
     # ── Per-chapter read tracking (issue #18) ──────────────────────────
     # `reading_progress.last_chapter` only tracks the cursor (the most-
@@ -370,32 +620,43 @@ class State:
         """Add `chapter` to the per-manga read set (idempotent)."""
         if chapter is None or str(chapter).strip() == "":
             return
-        self._ensure_manga_entry(manga_title)
-        entry = self._data["manga"][manga_title]
-        read_list = entry.setdefault("read_chapters", [])
-        ch = str(chapter)
-        if ch not in read_list:
-            read_list.append(ch)
-            self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+            read_list = entry.setdefault("read_chapters", [])
+            ch = str(chapter)
+            if ch not in read_list:
+                read_list.append(ch)
+                self._mark_dirty()
 
     def unmark_chapter_read(self, manga_title: str, chapter):
-        entry = self._data.get("manga", {}).get(manga_title)
-        if not entry:
-            return
-        read_list = entry.get("read_chapters", [])
-        ch = str(chapter)
-        if ch in read_list:
-            read_list.remove(ch)
-            self._mark_dirty()
+        with self._locked() as data:
+            entry = data.get("manga", {}).get(manga_title)
+            if not entry:
+                return
+            read_list = entry.get("read_chapters", [])
+            ch = str(chapter)
+            if ch in read_list:
+                read_list.remove(ch)
+                self._mark_dirty()
 
     def is_chapter_read(self, manga_title: str, chapter) -> bool:
         return str(chapter) in self.get_read_chapters(manga_title)
 
     def get_read_chapters(self, manga_title: str) -> List[str]:
-        return list(self.get_manga_state(manga_title).get("read_chapters", []) or [])
+        return self._entry_value(manga_title, "read_chapters", []) or []
 
     def get_read_count(self, manga_title: str) -> int:
-        return len(self.get_manga_state(manga_title).get("read_chapters", []) or [])
+        """Number of chapters read, without snapshotting the read list.
+
+        The Library page calls this per manga on every refresh (grid
+        cards + the header's read total), so it counts under the lock
+        instead of paying get_read_chapters()'s deep copy each time.
+        """
+        with self._locked() as data:
+            return len(
+                data.get("manga", {}).get(manga_title, {}).get("read_chapters", []) or []
+            )
 
     # ========================================================================
     # New Chapter Badges
@@ -403,28 +664,31 @@ class State:
 
     def set_new_chapters(self, manga_title: str, count: int):
         """Set the number of new chapters available for a manga."""
-        self._ensure_manga_entry(manga_title)
-        self._data["manga"][manga_title]["new_chapters_available"] = count
-        self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            data["manga"][manga_title]["new_chapters_available"] = count
+            self._mark_dirty()
 
     def get_new_chapters(self, manga_title: str) -> int:
         """Get the number of new chapters available."""
-        return self.get_manga_state(manga_title).get("new_chapters_available", 0)
+        return self._entry_value(manga_title, "new_chapters_available", 0)
 
     def clear_new_chapters(self, manga_title: str):
         """Clear the new chapters badge (e.g. after downloading)."""
-        state = self.get_manga_state(manga_title)
-        if state and state.get("new_chapters_available", 0) > 0:
-            self._data["manga"][manga_title]["new_chapters_available"] = 0
-            self._mark_dirty()
+        with self._locked() as data:
+            entry = data.get("manga", {}).get(manga_title, {})
+            if entry.get("new_chapters_available", 0) > 0:
+                entry["new_chapters_available"] = 0
+                self._mark_dirty()
 
     def decrement_new_chapters(self, manga_title: str):
         """Decrement the new chapters badge by 1 (used by manual single downloads)."""
-        state = self.get_manga_state(manga_title)
-        current = state.get("new_chapters_available", 0) if state else 0
-        if current > 0:
-            self._data["manga"][manga_title]["new_chapters_available"] = current - 1
-            self._mark_dirty()
+        with self._locked() as data:
+            entry = data.get("manga", {}).get(manga_title, {})
+            current = entry.get("new_chapters_available", 0)
+            if current > 0:
+                entry["new_chapters_available"] = current - 1
+                self._mark_dirty()
 
     # ========================================================================
     # Available Chapters Cache
@@ -437,13 +701,56 @@ class State:
         Used by the Detail page to show every chapter as 'Read' (downloaded) or
         'Download' (available) without re-scraping.
         """
-        self._ensure_manga_entry(manga_title)
-        self._data["manga"][manga_title]["available_chapters"] = chapters
-        self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            data["manga"][manga_title]["available_chapters"] = self._snapshot(list(chapters))
+            self._mark_dirty()
 
     def get_available_chapters(self, manga_title: str) -> List[Dict[str, Any]]:
         """Get the cached chapter list for a manga (empty list if never checked)."""
-        return self.get_manga_state(manga_title).get("available_chapters", [])
+        return self._entry_value(manga_title, "available_chapters", [])
+
+    def get_available_chapter_count(self, manga_title: str) -> int:
+        """Number of cached available chapters, without snapshotting them.
+
+        Callers that only need the total (Library cards' "Read X/N"
+        line) would otherwise deep-copy the whole cached list - per
+        card, per refresh - just to call len() on it.
+        """
+        with self._locked() as data:
+            return len(
+                data.get("manga", {}).get(manga_title, {}).get("available_chapters", []) or []
+            )
+
+    def get_catalogue_baseline(self, manga_title: str) -> Optional[float]:
+        """Highest chapter number the source has legitimately exposed so far.
+
+        This "last seen available chapter" high-water mark lets the
+        suspicious-batch guard tell an existing-but-undownloaded backlog
+        apart from a genuine source jump (#102). Returns ``None`` when no
+        trusted snapshot has been recorded yet.
+        """
+        value = self.get_manga_state(manga_title).get("catalogue_baseline")
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    def set_catalogue_baseline(self, manga_title: str, highest: float):
+        """Record the trusted catalogue high-water mark for a manga (#102).
+
+        Only ever called with a value the source has actually shown and that
+        the guard did not hold back, so it never advances past an unverified
+        suspicious jump.
+        """
+        self._ensure_manga_entry(manga_title)
+        try:
+            self._data["manga"][manga_title]["catalogue_baseline"] = float(highest)
+        except (TypeError, ValueError):
+            return
+        self._mark_dirty()
 
     # ========================================================================
     # External Chapters (already read outside the app)
@@ -455,26 +762,20 @@ class State:
         Stored separately from `downloaded` so the app never lies about what's
         on disk; the Detail page renders these as "Read elsewhere" rows.
         """
-        self._ensure_manga_entry(manga_title)
-        entry = self._data["manga"][manga_title]
-        if "external_chapters" not in entry:
-            entry["external_chapters"] = []
-        ch_str = str(chapter)
-        if ch_str not in entry["external_chapters"]:
-            entry["external_chapters"].append(ch_str)
-
-            def _sort_key(x):
-                try:
-                    return float(x)
-                except (ValueError, TypeError):
-                    return 0.0
-
-            entry["external_chapters"].sort(key=_sort_key)
-            self._mark_dirty()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+            if "external_chapters" not in entry:
+                entry["external_chapters"] = []
+            ch_str = str(chapter)
+            if ch_str not in entry["external_chapters"]:
+                entry["external_chapters"].append(ch_str)
+                entry["external_chapters"].sort(key=_chapter_sort_key)
+                self._mark_dirty()
 
     def get_external_chapters(self, manga_title: str) -> List[str]:
         """Get the chapters the user marked as already read elsewhere."""
-        return self.get_manga_state(manga_title).get("external_chapters", [])
+        return self._entry_value(manga_title, "external_chapters", [])
 
     def is_external_chapter(self, manga_title: str, chapter: str) -> bool:
         """Whether a chapter was previously marked as read-elsewhere."""
@@ -486,35 +787,42 @@ class State:
 
     def add_notification(self, ntype: str, message: str):
         """Add a notification to the log."""
-        if "notifications" not in self._data:
-            self._data["notifications"] = []
-        self._data["notifications"].append({
-            "type": ntype,
-            "message": message,
-            "timestamp": datetime.now().isoformat(),
-            "read": False,
-        })
-        self._data["notifications"] = self._data["notifications"][-100:]
-        self._mark_dirty()
+        with self._locked() as data:
+            if "notifications" not in data:
+                data["notifications"] = []
+            data["notifications"].append({
+                "type": ntype,
+                "message": message,
+                "timestamp": datetime.now().isoformat(),
+                "read": False,
+            })
+            data["notifications"] = data["notifications"][-100:]
+            self._mark_dirty()
 
     def get_notifications(self, limit: int = 20) -> List[Dict[str, Any]]:
-        """Get recent notifications."""
-        return list(reversed(self._data.get("notifications", [])[-limit:]))
+        """Get recent notifications. Items are copies — mark_notifications_read
+        mutates the stored dicts in place, so live references would race."""
+        with self._locked() as data:
+            return self._snapshot(
+                list(reversed(data.get("notifications", [])[-limit:])))
 
     def get_unread_count(self) -> int:
         """Count unread notifications."""
-        return sum(1 for n in self._data.get("notifications", []) if not n.get("read"))
+        with self._locked() as data:
+            return sum(1 for n in data.get("notifications", []) if not n.get("read"))
 
     def mark_notifications_read(self):
         """Mark all notifications as read."""
-        for n in self._data.get("notifications", []):
-            n["read"] = True
-        self._mark_dirty()
+        with self._locked() as data:
+            for n in data.get("notifications", []):
+                n["read"] = True
+            self._mark_dirty()
 
     def clear_notifications(self):
         """Wipe all notifications. Used by the GUI's 'Clear all' button."""
-        self._data["notifications"] = []
-        self._mark_dirty()
+        with self._locked() as data:
+            data["notifications"] = []
+            self._mark_dirty()
 
     def filter_notifications(self, kind: str, limit: int = 100) -> List[Dict[str, Any]]:
         """Return notifications filtered by category.
@@ -526,7 +834,9 @@ class State:
             downloads — download-complete / kindle-sent events
             system    — errors, warnings, generic system events
         """
-        all_notifs = list(reversed(self._data.get("notifications", [])[-limit:]))
+        with self._locked() as data:
+            all_notifs = self._snapshot(
+                list(reversed(data.get("notifications", [])[-limit:])))
         if kind == "all":
             return all_notifs
         bucket_map = {
@@ -546,19 +856,22 @@ class State:
         if not query or not query.strip():
             return
         q = query.strip()
-        history = self._data.get("search_history", []) or []
-        # Dedupe by case-insensitive match, then prepend.
-        history = [h for h in history if h.lower() != q.lower()]
-        history.insert(0, q)
-        self._data["search_history"] = history[:limit]
-        self._mark_dirty()
+        with self._locked() as data:
+            history = data.get("search_history", []) or []
+            # Dedupe by case-insensitive match, then prepend.
+            history = [h for h in history if h.lower() != q.lower()]
+            history.insert(0, q)
+            data["search_history"] = history[:limit]
+            self._mark_dirty()
 
     def get_recent_searches(self, limit: int = 8) -> List[str]:
-        return list(self._data.get("search_history", []) or [])[:limit]
+        with self._locked() as data:
+            return list(data.get("search_history", []) or [])[:limit]
 
     def clear_search_history(self):
-        self._data["search_history"] = []
-        self._mark_dirty()
+        with self._locked() as data:
+            data["search_history"] = []
+            self._mark_dirty()
 
     # ========================================================================
     # Download History
@@ -567,23 +880,26 @@ class State:
     def add_download_history(self, title: str, chapter: str, fmt: str,
                              path: str = "", size_mb: float = 0, kindle_sent: bool = False):
         """Log a completed download."""
-        if "download_history" not in self._data:
-            self._data["download_history"] = []
-        self._data["download_history"].append({
-            "title": title,
-            "chapter": chapter,
-            "format": fmt,
-            "path": path,
-            "size_mb": round(size_mb, 2),
-            "kindle_sent": kindle_sent,
-            "timestamp": datetime.now().isoformat(),
-        })
-        self._data["download_history"] = self._data["download_history"][-200:]
-        self._mark_dirty()
+        with self._locked() as data:
+            if "download_history" not in data:
+                data["download_history"] = []
+            data["download_history"].append({
+                "title": title,
+                "chapter": chapter,
+                "format": fmt,
+                "path": path,
+                "size_mb": round(size_mb, 2),
+                "kindle_sent": kindle_sent,
+                "timestamp": datetime.now().isoformat(),
+            })
+            data["download_history"] = data["download_history"][-200:]
+            self._mark_dirty()
 
     def get_download_history(self, limit: int = 50) -> List[Dict[str, Any]]:
         """Get recent download history."""
-        return list(reversed(self._data.get("download_history", [])[-limit:]))
+        with self._locked() as data:
+            return self._snapshot(
+                list(reversed(data.get("download_history", [])[-limit:])))
 
     # ========================================================================
     # Source Health
@@ -597,69 +913,103 @@ class State:
         probe that produced this status update. Drives the "Xms" badge
         in the Sources screen.
         """
-        if "source_health" not in self._data:
-            self._data["source_health"] = {}
-        now = datetime.now().isoformat()
-        health = self._data["source_health"].get(domain, {"error_count": 0})
-        if success:
-            health["last_success"] = now
-            health["error_count"] = 0
-            # "slow" badge if response was sluggish (>500ms is plenty).
-            if latency_ms is not None and latency_ms > 500:
-                health["status"] = "warning"
+        with self._locked() as data:
+            if "source_health" not in data:
+                data["source_health"] = {}
+            now = datetime.now().isoformat()
+            health = data["source_health"].get(domain, {"error_count": 0})
+            if success:
+                health["last_success"] = now
+                health["error_count"] = 0
+                # Flag only genuinely slow responses; see SLOW_LATENCY_MS.
+                if latency_ms is not None and latency_ms > self.SLOW_LATENCY_MS:
+                    health["status"] = "warning"
+                else:
+                    health["status"] = "ok"
             else:
-                health["status"] = "ok"
-        else:
-            health["last_error"] = now
-            health["last_error_msg"] = error_msg[:100]
-            health["error_count"] = health.get("error_count", 0) + 1
-            health["status"] = "warning" if health["error_count"] < 3 else "error"
-        if latency_ms is not None:
-            health["latency_ms"] = int(latency_ms)
-        self._data["source_health"][domain] = health
-        self._mark_dirty()
+                health["last_error"] = now
+                health["last_error_msg"] = error_msg[:100]
+                health["error_count"] = health.get("error_count", 0) + 1
+                health["status"] = "warning" if health["error_count"] < 3 else "error"
+            if latency_ms is not None:
+                health["latency_ms"] = int(latency_ms)
+            data["source_health"][domain] = health
+            self._mark_dirty()
 
     def get_source_health(self, domain: str) -> Dict[str, Any]:
         """Get health info for a source."""
-        return self._data.get("source_health", {}).get(domain, {})
+        with self._locked() as data:
+            return self._snapshot(data.get("source_health", {}).get(domain, {}))
 
     def get_all_source_health(self) -> Dict[str, Dict[str, Any]]:
-        """Get health info for all sources."""
-        return self._data.get("source_health", {})
+        """Get health info for all sources. Entries are copies — probes
+        update the stored dicts in place."""
+        with self._locked() as data:
+            return self._snapshot(data.get("source_health", {}))
 
     def reset_manga_progress(self, manga_title: str, from_chapter: float = 0):
         """Reset a manga's download progress to re-download from a specific chapter.
         If from_chapter is 0, clears everything for a full re-download.
         If from_chapter is N, keeps chapters < N downloaded and re-downloads N onwards.
         """
-        self._ensure_manga_entry(manga_title)
-        entry = self._data["manga"][manga_title]
-        if from_chapter == 0:
-            entry["last_chapter"] = None
-            entry["downloaded"] = []
-        else:
-            # Keep only chapters before from_chapter, remove the rest
-            entry["downloaded"] = [
-                ch for ch in entry.get("downloaded", [])
-                if float(ch) < from_chapter
-            ]
-            entry["last_chapter"] = None
-        entry["last_updated"] = datetime.now().isoformat()
-        self.save()
+        with self._locked() as data:
+            self._ensure_manga_entry(manga_title)
+            entry = data["manga"][manga_title]
+            if from_chapter == 0:
+                entry["last_chapter"] = None
+                entry["downloaded"] = []
+                entry["partial_chapters"] = {}
+            else:
+                # Keep only chapters before from_chapter, remove the rest.
+                # Labelled chapters (e.g. "Chapter 3" or "3 Part 1") compare
+                # by their embedded chapter number. Labels with no number are preserved
+                # because they cannot be ordered safely against the threshold.
+                def _keep_downloaded(ch):
+                    num = _chapter_number(ch)
+                    return num is None or num < from_chapter
+
+                entry["downloaded"] = [
+                    ch for ch in entry.get("downloaded", [])
+                    if _keep_downloaded(ch)
+                ]
+                entry["partial_chapters"] = {
+                    ch: info
+                    for ch, info in entry.get("partial_chapters", {}).items()
+                    if _keep_downloaded(ch)
+                }
+                entry["last_chapter"] = None
+            entry["last_updated"] = datetime.now().isoformat()
+            self.save()
 
     # ========================================================================
     # Cleanup
     # ========================================================================
-    
-    def remove_manga(self, manga_title: str) -> bool:
-        """Remove a manga from state."""
-        if manga_title in self._data.get("manga", {}):
-            del self._data["manga"][manga_title]
+
+    def rename_manga(self, old_title: str, new_title: str) -> bool:
+        """Move a manga's state entry to a new title (edit/rename flows).
+
+        Issue #110: replaces the GUI's direct ``_data`` pokes so renames go
+        through the lock like every other mutation.
+        """
+        with self._locked() as data:
+            manga = data.get("manga", {})
+            if old_title not in manga:
+                return False
+            manga[new_title] = manga.pop(old_title)
             self.save()
             return True
-        return False
-    
+
+    def remove_manga(self, manga_title: str) -> bool:
+        """Remove a manga from state."""
+        with self._locked() as data:
+            if manga_title in data.get("manga", {}):
+                del data["manga"][manga_title]
+                self.save()
+                return True
+            return False
+
     def clear_all(self):
         """Clear all state (fresh start)."""
-        self._data = self._default_state()
-        self.save()
+        with self._lock:
+            self._data = self._default_state()
+            self.save()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.3.3"
+version = "0.4.0"
 description = "Automatic manga downloader with Kindle support (CLI)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,6 +8,9 @@
 #     pytest tests/unit/test_state.py
 #     pytest tests/unit/cli/
 #     pytest tests/unit/scrapers/
+#
+# Skip the slow integration suite during dev:
+#     pytest -m "not integration"
 
 testpaths = tests
 python_files = test_*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,10 @@ pikepdf>=8.0.0
 # Secure credential storage
 keyring>=24.0.0
 # Backs keyring's Windows Credential Manager backend. keyring declares
-# this as a conditional dep already; pinning it explicitly shields
-# against version drift dropping it silently.
+# this as a conditional dep already but we pin it explicitly so the
+# Windows build machine doesn't silently drop it on a version bump,
+# which would leave the frozen exe using keyring's Null backend
+# (silently throwing away saved email passwords).
 pywin32-ctypes>=0.2.0; sys_platform == "win32"
 
 # Stealth mode for Playwright scrapers

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,6 +8,7 @@ pytest                          # full suite
 pytest -x                       # stop on first failure
 pytest -k state                 # only tests with "state" in the name
 pytest tests/unit/              # only unit tests
+pytest tests/integration/       # only integration
 pytest --cov=memanga --cov-report=html   # HTML coverage report
 ```
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,11 +29,15 @@ if str(_REPO_ROOT) not in sys.path:
 
 @pytest.fixture
 def isolated_home(monkeypatch, tmp_path) -> Path:
-    """Redirect HOME (and APPDATA / XDG_CONFIG_HOME) to a tmp dir so
-    no test ever writes to the real config. Returns the new home
-    path so tests can poke at created files.
+    """Redirect HOME (and APPDATA/XDG_CONFIG_HOME) to a tmp dir so the
+    test never writes to the developer's real config.
+    Returns the new home path so tests can poke at created files.
     """
     monkeypatch.setenv("HOME", str(tmp_path))
+    # Path.home() on Windows resolves USERPROFILE and ignores HOME
+    # (Python 3.8+), so without this the suite reads and writes the
+    # developer's real config/state and download directories.
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     monkeypatch.setenv("APPDATA", str(tmp_path))
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
     (tmp_path / ".config" / "memanga").mkdir(parents=True, exist_ok=True)
@@ -56,8 +60,8 @@ def state(isolated_home):
 def config(isolated_home, monkeypatch):
     """Fresh Config instance pointed at the isolated home."""
     from memanga import config as cfg_mod
-    # Config infers its path from $HOME — isolated_home already
-    # redirected that, so this just wraps it.
+    # Some Config implementations infer the path from $HOME, so the
+    # isolated_home fixture already did the work.
     return cfg_mod.Config()
 
 
@@ -97,7 +101,7 @@ def sample_manga_with_backup():
 
 class MockScraper:
     """Minimal scraper that returns a deterministic chapter list.
-    Use as a drop-in for any real scraper in downloader tests.
+    Use as a drop-in for any real scraper in `downloader` tests.
     """
 
     name = "mock"
@@ -143,7 +147,7 @@ def mock_scraper():
 
 @pytest.fixture
 def patch_get_scraper(monkeypatch, mock_scraper):
-    """Make ``memanga.scrapers.get_scraper(...)`` always return the mock."""
+    """Make `memanga.scrapers.get_scraper(...)` always return the mock."""
     import memanga.scrapers as scrapers_pkg
     import memanga.downloader as dl
     monkeypatch.setattr(scrapers_pkg, "get_scraper", lambda d: mock_scraper)

--- a/tests/scrapers/live/test_live_parsing.py
+++ b/tests/scrapers/live/test_live_parsing.py
@@ -120,11 +120,11 @@ def test_scraper_pipeline_live(domain, spec, health_recorder):
     reach = probe_url(f"https://{domain}")
     stages = [StageResult(STAGE_REACHABILITY, reach.status, reach.detail,
                             reach.elapsed_ms)]
-    if reach.status not in (STATUS_OK, STATUS_PROTECTED):
+    if reach.status == STATUS_DEAD:
         health_recorder(HealthResult(
-            domain, reach.status, STAGE_REACHABILITY, reach.detail,
+            domain, STATUS_DEAD, STAGE_REACHABILITY, reach.detail,
             reach.elapsed_ms, extra={"stages": [asdict(s) for s in stages]}))
-        pytest.fail(f"[{reach.status}:reachability] {domain}: {reach.detail}")
+        pytest.fail(f"[DEAD:reachability] {domain}: {reach.detail}")
     # PROTECTED is not fatal — the real scraper bypasses Cloudflare,
     # so still run the pipeline and let its stages decide.
 

--- a/tests/unit/cli/test_cli_commands.py
+++ b/tests/unit/cli/test_cli_commands.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import pytest
 import sys
+import types
 from unittest.mock import patch, MagicMock
 
 
@@ -196,6 +197,28 @@ class TestCheckCommand:
         rc = run_cli("check")
         assert rc == 0  # nothing to do — should exit cleanly
 
+    def test_partial_flags_are_accepted(self, run_cli, config):
+        # Issue #86: the partial-tolerance override flags must parse.
+        # With no manga, check exits cleanly regardless.
+        rc = run_cli("check", "--allow-partial", "--partial-threshold", "10")
+        assert rc == 0
+
+    def test_check_out_of_range_threshold_rejected(self, run_cli, config):
+        # Issue #86: out-of-range threshold is rejected consistently with
+        # `config` (argparse type error).
+        rc = run_cli("check", "--partial-threshold", "150")
+        assert rc != 0
+
+    def test_allow_and_no_partial_are_mutually_exclusive(self, run_cli, config):
+        rc = run_cli("check", "--allow-partial", "--no-partial")
+        assert rc != 0  # argparse rejects the conflicting pair
+
+    def test_partial_flags_listed_in_help(self, run_cli, capsys):
+        run_cli("check", "--help")
+        out = capsys.readouterr().out.lower()
+        assert "--allow-partial" in out
+        assert "--partial-threshold" in out
+
     def test_check_with_one_manga(self, run_cli, config, patch_get_scraper,
                                     monkeypatch):
         config.set("manga", [{
@@ -208,6 +231,216 @@ class TestCheckCommand:
         rc = run_cli("check")
         # Either returns 0 (success) or a small int — should not crash.
         assert rc in (0, 1)
+
+    def test_backup_success_in_email_mode_sends_before_marking_downloaded(
+            self, run_cli, config, monkeypatch, tmp_path):
+        """Issue #86 regression: backup recovery must still run Kindle
+        delivery before the chapter is marked downloaded."""
+        from memanga import cli
+        from memanga.downloader import DownloaderError
+        from memanga.state import State
+
+        config.set("delivery.mode", "email")
+        config.set("email.kindle_email", "reader@example.com")
+        config.set("email.sender_email", "sender@example.com")
+        config.set("manga", [{
+            "title": "Vinland Saga",
+            "status": "reading",
+            "sources": [
+                {"source": "primary.test", "url": "https://primary.test/vs"},
+                {"source": "backup.test", "url": "https://backup.test/vs"},
+            ],
+        }])
+        config.save()
+
+        cli.state = State()
+        primary_ch = types.SimpleNamespace(
+            number="71", title="", url="https://primary.test/c/71",
+            source="primary.test", is_backup=False)
+        backup_ch = types.SimpleNamespace(
+            number="71", title="", url="https://backup.test/c/71",
+            source="backup.test", is_backup=True)
+        backup_path = tmp_path / "backup.pdf"
+        sent = []
+
+        monkeypatch.setattr(cli, "check_for_updates",
+                            lambda *a, **k: [primary_ch])
+        monkeypatch.setattr(cli, "_find_chapter_on_backup",
+                            lambda *a, **k: backup_ch)
+
+        def fake_download(manga, chapter, *args, **kwargs):
+            if getattr(chapter, "is_backup", False):
+                return backup_path
+            raise DownloaderError("primary incomplete",
+                                  failed_pages=[13], total_pages=40)
+
+        def fake_send_to_kindle(**kwargs):
+            sent.append(kwargs["pdf_path"])
+            assert not cli.state.is_chapter_downloaded("Vinland Saga", "71")
+
+        monkeypatch.setattr(cli, "download_chapter", fake_download)
+        monkeypatch.setattr(cli, "send_to_kindle", fake_send_to_kindle)
+        monkeypatch.setattr(cli, "get_app_password", lambda cfg: "pw")
+
+        rc = run_cli("check", "--auto", "--quiet")
+
+        assert rc == 0
+        assert sent == [backup_path]
+        assert cli.state.is_chapter_downloaded("Vinland Saga", "71")
+
+    def test_backup_partial_in_email_mode_sends_and_warns(
+            self, run_cli, config, monkeypatch, tmp_path):
+        """When both sources fail complete downloads, an accepted backup
+        partial must be delivered and logged before state is advanced."""
+        from memanga import cli
+        from memanga.downloader import DownloaderError
+        from memanga.state import State
+
+        config.set("delivery.mode", "email")
+        config.set("email.kindle_email", "reader@example.com")
+        config.set("email.sender_email", "sender@example.com")
+        config.set("partial_chapters.enabled", True)
+        config.set("partial_chapters.threshold_percent", 10)
+        config.set("manga", [{
+            "title": "Vinland Saga",
+            "status": "reading",
+            "sources": [
+                {"source": "primary.test", "url": "https://primary.test/vs"},
+                {"source": "backup.test", "url": "https://backup.test/vs"},
+            ],
+        }])
+        config.save()
+
+        cli.state = State()
+        primary_ch = types.SimpleNamespace(
+            number="71", title="", url="https://primary.test/c/71",
+            source="primary.test", is_backup=False)
+        backup_ch = types.SimpleNamespace(
+            number="71", title="", url="https://backup.test/c/71",
+            source="backup.test", is_backup=True)
+        partial_path = tmp_path / "backup-partial.pdf"
+        sent = []
+
+        monkeypatch.setattr(cli, "check_for_updates",
+                            lambda *a, **k: [primary_ch])
+        monkeypatch.setattr(cli, "_find_chapter_on_backup",
+                            lambda *a, **k: backup_ch)
+
+        def fake_download(manga, chapter, *args, **kwargs):
+            if not getattr(chapter, "is_backup", False):
+                raise DownloaderError("primary incomplete",
+                                      failed_pages=[13], total_pages=40)
+            if not kwargs.get("allow_partial", False):
+                raise DownloaderError("backup incomplete",
+                                      failed_pages=[7], total_pages=40)
+            kwargs["on_partial"]([7], 40)
+            return partial_path
+
+        def fake_send_to_kindle(**kwargs):
+            sent.append(kwargs["pdf_path"])
+            assert not cli.state.is_chapter_downloaded("Vinland Saga", "71")
+
+        monkeypatch.setattr(cli, "download_chapter", fake_download)
+        monkeypatch.setattr(cli, "send_to_kindle", fake_send_to_kindle)
+        monkeypatch.setattr(cli, "get_app_password", lambda cfg: "pw")
+
+        rc = run_cli("check", "--auto", "--quiet")
+
+        assert rc == 0
+        assert sent == [partial_path]
+        assert cli.state.is_chapter_downloaded("Vinland Saga", "71")
+        assert cli.state.get_partial_chapter("Vinland Saga", "71")["failed_pages"] == [7]
+        notifications = cli.state.get("notifications", [])
+        assert any("saved as partial" in n["message"] for n in notifications)
+
+    def test_over_threshold_backup_failure_records_failure_not_downloaded(
+            self, run_cli, config, monkeypatch):
+        """If neither complete nor partial recovery is acceptable, the
+        chapter stays failed and is not marked downloaded."""
+        from memanga import cli
+        from memanga.downloader import DownloaderError
+        from memanga.state import State
+
+        config.set("partial_chapters.enabled", True)
+        config.set("partial_chapters.threshold_percent", 1)
+        config.set("manga", [{
+            "title": "Vinland Saga",
+            "status": "reading",
+            "sources": [
+                {"source": "primary.test", "url": "https://primary.test/vs"},
+                {"source": "backup.test", "url": "https://backup.test/vs"},
+            ],
+        }])
+        config.save()
+
+        cli.state = State()
+        primary_ch = types.SimpleNamespace(
+            number="71", title="", url="https://primary.test/c/71",
+            source="primary.test", is_backup=False)
+        backup_ch = types.SimpleNamespace(
+            number="71", title="", url="https://backup.test/c/71",
+            source="backup.test", is_backup=True)
+
+        monkeypatch.setattr(cli, "check_for_updates",
+                            lambda *a, **k: [primary_ch])
+        monkeypatch.setattr(cli, "_find_chapter_on_backup",
+                            lambda *a, **k: backup_ch)
+        monkeypatch.setattr(
+            cli, "download_chapter",
+            lambda *a, **k: (_ for _ in ()).throw(
+                DownloaderError("incomplete", failed_pages=[1], total_pages=10)
+            ),
+        )
+
+        rc = run_cli("check", "--auto", "--quiet")
+
+        assert rc == 0
+        assert not cli.state.is_chapter_downloaded("Vinland Saga", "71")
+        failed = cli.state.get_failed_chapters("Vinland Saga")
+        assert "71" in failed
+
+    def test_failed_retry_includes_accepted_partials(
+            self, run_cli, config, monkeypatch, tmp_path):
+        from memanga import cli
+        from memanga.scrapers.base import Chapter
+        from memanga.state import State
+
+        config.set("manga", [{
+            "title": "Vinland Saga",
+            "status": "reading",
+            "source": "primary.test",
+            "url": "https://primary.test/vs",
+        }])
+        config.save()
+
+        cli.state = State()
+        cli.state.add_downloaded_chapter("Vinland Saga", "71")
+        cli.state.add_partial_chapter(
+            "Vinland Saga",
+            "71",
+            source="primary.test",
+            failed_pages=[7],
+            total_pages=40,
+        )
+        fixed_path = tmp_path / "fixed.pdf"
+        fixed_path.write_bytes(b"%PDF")
+
+        primary_ch = Chapter(
+            number="71", title="", url="https://primary.test/c/71", date=None,
+        )
+
+        class FakeScraper:
+            def get_chapters(self, url):
+                return [primary_ch]
+
+        monkeypatch.setattr(cli, "get_scraper", lambda source: FakeScraper())
+        monkeypatch.setattr(cli, "download_chapter", lambda *a, **k: fixed_path)
+
+        rc = run_cli("failed", "--retry")
+
+        assert rc == 0
+        assert cli.state.is_chapter_downloaded("Vinland Saga", "71")
+        assert cli.state.get_partial_chapter("Vinland Saga", "71") is None
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -241,6 +474,46 @@ class TestConfigCommand:
             # Reload config from disk
             from memanga.config import Config
             assert Config().get("delivery.output_format") == "epub"
+
+    # ── Non-interactive partial-chapter tolerance (issue #86) ──
+
+    def test_config_partial_on_persists(self, run_cli, config):
+        rc = run_cli("config", "--partial", "on", "--partial-threshold", "5")
+        assert rc == 0
+        assert config.get("partial_chapters.enabled") is True
+        assert float(config.get("partial_chapters.threshold_percent")) == 5.0
+
+    def test_config_partial_off_persists(self, run_cli, config):
+        run_cli("config", "--partial", "on")
+        rc = run_cli("config", "--partial", "off")
+        assert rc == 0
+        assert config.get("partial_chapters.enabled") is False
+
+    def test_config_threshold_only_keeps_enabled_state(self, run_cli, config):
+        # Turn tolerance on, then change only the threshold — enabled
+        # state must be preserved.
+        run_cli("config", "--partial", "on", "--partial-threshold", "5")
+        rc = run_cli("config", "--partial-threshold", "10")
+        assert rc == 0
+        assert config.get("partial_chapters.enabled") is True
+        assert float(config.get("partial_chapters.threshold_percent")) == 10.0
+
+    def test_config_out_of_range_threshold_rejected(self, run_cli, config):
+        rc = run_cli("config", "--partial-threshold", "150")
+        assert rc != 0  # argparse rejects it, nothing persisted
+        assert config.get("partial_chapters.threshold_percent") != 150
+
+    def test_config_non_numeric_threshold_rejected(self, run_cli, config):
+        rc = run_cli("config", "--partial-threshold", "lots")
+        assert rc != 0
+
+    def test_config_show_does_not_prompt(self, run_cli, config, monkeypatch):
+        # --show must return without touching stdin.
+        def _boom(*a, **k):
+            raise AssertionError("config --show should not prompt")
+        monkeypatch.setattr("builtins.input", _boom)
+        rc = run_cli("config", "--show")
+        assert rc == 0
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -295,6 +568,106 @@ class TestExportImport:
             titles = [m["title"] for m in config.get("manga", []) or []]
             assert "FromImport" in titles
 
+    def test_import_merge_preserves_existing_manga_state(
+            self, run_cli, config, isolated_home, tmp_path):
+        from memanga import cli
+        from memanga.state import State
+
+        config.set("manga", [{"title": "Stateful", "url": "local",
+                              "source": "mangadex.org",
+                              "status": "reading"}])
+        config.save()
+        cli.state = State(config_dir=isolated_home / ".config" / "memanga")
+        cli.state.set("manga", {
+            "Stateful": {
+                "downloaded": ["1"],
+                "read_chapters": ["1"],
+                "failed_chapters": {
+                    "4": {"error": "local", "attempts": 2},
+                },
+                "reading_progress": {
+                    "last_chapter": "1",
+                    "last_read": "2026-07-17T09:00:00",
+                },
+            }
+        })
+        backup = tmp_path / "state.json"
+        backup.write_text(json.dumps({
+            "version": 1,
+            "manga": [{"title": "stateful", "url": "imported",
+                       "source": "mangadex.org", "status": "reading"}],
+            "state": {
+                "stateful": {
+                    "downloaded": ["2"],
+                    "read_chapters": ["2"],
+                    "external_chapters": ["3"],
+                    "failed_chapters": {
+                        "4": {"error": "imported", "attempts": 1},
+                        "5": {"error": "backup", "attempts": 1},
+                    },
+                    "reading_progress": {
+                        "last_chapter": "2",
+                        "last_read": "2026-07-17T10:00:00",
+                    },
+                }
+            },
+        }))
+
+        assert run_cli("import", str(backup)) == 0
+
+        titles = [m["title"] for m in config.get("manga", []) or []]
+        assert titles == ["Stateful"]
+        manga_state = cli.state.get("manga", {})
+        assert list(manga_state) == ["Stateful"]
+        assert "stateful" not in manga_state
+        merged = manga_state["Stateful"]
+        assert merged["downloaded"] == ["1", "2"]
+        assert merged["read_chapters"] == ["1", "2"]
+        assert merged["external_chapters"] == ["3"]
+        assert merged["failed_chapters"]["4"]["error"] == "local"
+        assert merged["failed_chapters"]["5"]["error"] == "backup"
+        assert merged["reading_progress"]["last_chapter"] == "2"
+
+    def test_import_merge_keeps_added_title_state_apart_from_orphan(
+            self, run_cli, config, isolated_home, tmp_path):
+        from memanga import cli
+        from memanga.state import State
+
+        config.set("manga", [])
+        config.save()
+        cli.state = State(config_dir=isolated_home / ".config" / "memanga")
+        cli.state.set("manga", {
+            "Stateful": {
+                "downloaded": ["1"],
+                "failed_chapters": {
+                    "4": {"error": "local", "attempts": 2},
+                },
+            }
+        })
+        backup = tmp_path / "orphan-state.json"
+        backup.write_text(json.dumps({
+            "version": 1,
+            "manga": [{"title": "stateful", "url": "imported",
+                       "source": "mangadex.org", "status": "reading"}],
+            "state": {
+                "stateful": {
+                    "downloaded": ["2"],
+                    "failed_chapters": {
+                        "5": {"error": "backup", "attempts": 1},
+                    },
+                }
+            },
+        }))
+
+        assert run_cli("import", str(backup)) == 0
+
+        titles = [m["title"] for m in config.get("manga", []) or []]
+        assert titles == ["stateful"]
+        manga_state = cli.state.get("manga", {})
+        assert manga_state["Stateful"]["downloaded"] == ["1"]
+        assert manga_state["stateful"]["downloaded"] == ["2"]
+        assert manga_state["stateful"]["failed_chapters"]["5"]["error"] == "backup"
+
     def test_import_roundtrip(self, run_cli, config, tmp_path):
         """An export produced by the CLI must import cleanly (issue #42)."""
         config.set("manga", [{"title": "RoundTrip", "url": "u",
@@ -307,6 +680,32 @@ class TestExportImport:
         assert run_cli("import", str(backup)) == 0
         titles = [m["title"] for m in config.get("manga", []) or []]
         assert "RoundTrip" in titles
+
+    def test_import_merge_unions_downloaded_state(self, run_cli, config,
+                                                  isolated_home, monkeypatch,
+                                                  tmp_path):
+        from memanga import cli as cli_mod
+        from memanga.state import State
+
+        config.set("manga", [{"title": "Existing", "url": "u",
+                              "source": "mangadex.org", "status": "reading"}])
+        config.save()
+        state = State(config_dir=isolated_home / ".config" / "memanga")
+        monkeypatch.setattr(cli_mod, "state", state)
+        state.add_downloaded_chapter("Existing", "1")
+
+        backup = tmp_path / "merge-state.json"
+        backup.write_text(json.dumps({
+            "version": 1,
+            "manga": [{"title": "Existing", "url": "u",
+                       "source": "mangadex.org", "status": "reading"}],
+            "state": {"Existing": {"downloaded": ["2", "10"]}},
+        }))
+
+        assert run_cli("import", str(backup)) == 0
+
+        reloaded = State(config_dir=isolated_home / ".config" / "memanga")
+        assert reloaded.get_downloaded_chapters("Existing") == ["1", "2", "10"]
 
     def test_import_missing_version_rejected(self, run_cli, config, tmp_path,
                                              capsys):
@@ -525,6 +924,44 @@ class TestCronCommand:
         # Status should never write anything system-wide
         rc = run_cli("cron", "status")
         assert rc in (0, 1, 2)
+
+    def test_cron_install_submits_quoted_line(self, run_cli, monkeypatch):
+        """#109: `cron install` must submit the shell-safe crontab line
+        from build_cron_line() so paths with spaces survive."""
+        from pathlib import Path
+
+        from memanga import cli
+        from memanga.cron import build_cron_line
+
+        monkeypatch.setattr(cli.platform, "system", lambda: "Linux")
+
+        submitted = {}
+
+        class _FakePopen:
+            returncode = 0
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def communicate(self, input=None):
+                submitted["crontab"] = input
+                return ("", "")
+
+        monkeypatch.setattr(
+            cli.subprocess, "run",
+            lambda *a, **k: types.SimpleNamespace(returncode=1, stdout="",
+                                                  stderr=""))
+        monkeypatch.setattr(cli.subprocess, "Popen", _FakePopen)
+
+        rc = run_cli("cron", "install", "--time", "06:00")
+        assert rc == 0
+
+        project_dir = Path(cli.__file__).resolve().parent.parent
+        python_path = project_dir / "venv" / "bin" / "python3"
+        if not python_path.exists():
+            python_path = Path(sys.executable)
+        expected = build_cron_line(0, 6, project_dir, python_path)
+        assert expected in submitted["crontab"].splitlines()
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/unit/cli/test_cli_docker.py
+++ b/tests/unit/cli/test_cli_docker.py
@@ -1,0 +1,104 @@
+"""Tests that --gui is unconditionally hidden and rejected on the CLI branch.
+
+The CLI branch has no memanga.gui package.  These behaviours must hold
+regardless of the MEMANGA_CLI_ONLY environment variable:
+
+  1. --help output never shows --gui or the epilog example line.
+  2. Passing --gui exits 1 with a clear message to stderr.
+
+MEMANGA_CLI_ONLY is still set in Docker images; the same checks confirm
+that Docker containers behave identically (the env var no longer changes
+anything on this branch).
+"""
+from __future__ import annotations
+
+import sys
+import pytest
+
+
+@pytest.fixture
+def invoke(monkeypatch, isolated_home):
+    """Call cli.main() with patched argv; return exit code."""
+    def _call(*argv):
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        monkeypatch.setattr(sys, "argv", ["memanga"] + list(argv))
+        try:
+            cli.main()
+            return 0
+        except SystemExit as exc:
+            return exc.code
+    return _call
+
+
+class TestGuiAlwaysHidden:
+    """--gui must be absent from help on all CLI installs (with or without Docker env)."""
+
+    def test_help_hides_gui_flag(self, monkeypatch, isolated_home, capsys):
+        monkeypatch.delenv("MEMANGA_CLI_ONLY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["memanga", "--help"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--gui" not in out
+        assert "graphical" not in out.lower()
+
+    def test_help_hides_epilog_gui_line(self, monkeypatch, isolated_home, capsys):
+        monkeypatch.delenv("MEMANGA_CLI_ONLY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["memanga", "--help"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "memanga --gui" not in out
+
+    def test_gui_flag_rejected_exit_1(self, monkeypatch, isolated_home, capsys):
+        monkeypatch.delenv("MEMANGA_CLI_ONLY", raising=False)
+        monkeypatch.setattr(sys, "argv", ["memanga", "--gui"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "--gui" in err
+        assert "not available" in err
+
+
+class TestDockerCliOnlyEnvVar:
+    """MEMANGA_CLI_ONLY=1 (Docker) produces the same --gui behaviour as a plain CLI install."""
+
+    def test_help_hides_gui_flag_docker(self, monkeypatch, isolated_home, capsys):
+        monkeypatch.setenv("MEMANGA_CLI_ONLY", "1")
+        monkeypatch.setattr(sys, "argv", ["memanga", "--help"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 0
+        out = capsys.readouterr().out
+        assert "--gui" not in out
+        assert "memanga --gui" not in out
+
+    def test_gui_flag_rejected_exit_1_docker(self, monkeypatch, isolated_home, capsys):
+        monkeypatch.setenv("MEMANGA_CLI_ONLY", "1")
+        monkeypatch.setattr(sys, "argv", ["memanga", "--gui"])
+        import memanga.cli as cli
+        from memanga.config import Config
+        cli.config = Config()
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "--gui" in err
+        assert "not available" in err

--- a/tests/unit/test_backup.py
+++ b/tests/unit/test_backup.py
@@ -15,6 +15,8 @@ import pytest
 from memanga.backup import (
     EXPORT_VERSION,
     BackupVersionError,
+    merge_backup_state,
+    merge_manga_state,
     validate_backup,
     _MIGRATIONS,
 )
@@ -43,6 +45,10 @@ class TestValidateBackup:
         with pytest.raises(BackupVersionError, match="Invalid backup version"):
             validate_backup({"version": bad, "manga": []})
 
+    def test_non_dict_state_rejected(self):
+        with pytest.raises(BackupVersionError, match="state must be an object"):
+            validate_backup({"version": EXPORT_VERSION, "manga": [], "state": []})
+
     def test_newer_version_rejected_with_update_hint(self):
         with pytest.raises(BackupVersionError, match="newer.*update MeManga"):
             validate_backup({"version": EXPORT_VERSION + 1, "manga": []})
@@ -60,3 +66,130 @@ class TestValidateBackup:
         )
         out = validate_backup({"version": 0, "manga": []})
         assert out["migrated"] is True
+
+
+class TestMergeMangaState:
+    def test_partial_chapters_preserve_imported_records_and_local_conflicts(self):
+        local = {
+            "partial_chapters": {
+                "4": {"pages": ["local-1.jpg"], "error": "local"},
+            }
+        }
+        imported = {
+            "partial_chapters": {
+                "4": {"pages": ["imported-1.jpg"], "error": "imported"},
+                "5": {"pages": ["imported-2.jpg"], "error": "backup"},
+            }
+        }
+
+        merged = merge_manga_state(local, imported)
+
+        assert merged["partial_chapters"]["4"] == local["partial_chapters"]["4"]
+        assert merged["partial_chapters"]["5"] == imported["partial_chapters"]["5"]
+
+    def test_preserves_local_and_imported_progress_fields(self):
+        local = {
+            "downloaded": ["1", "3"],
+            "read_chapters": ["1"],
+            "external_chapters": ["7"],
+            "failed_chapters": {
+                "4": {"error": "local", "attempts": 2},
+            },
+            "available_chapters": [
+                {"number": "1", "source": "local", "source_url": "local/1"},
+            ],
+            "reading_progress": {
+                "last_chapter": "3",
+                "last_read": "2026-07-17T09:00:00",
+            },
+            "new_chapters_available": 1,
+        }
+        imported = {
+            "downloaded": ["2", "3"],
+            "read_chapters": ["2"],
+            "external_chapters": ["8"],
+            "failed_chapters": {
+                "4": {"error": "imported", "attempts": 1},
+                "5": {"error": "backup", "attempts": 1},
+            },
+            "available_chapters": [
+                {"number": "1", "source": "local", "source_url": "local/1"},
+                {"number": "2", "source": "backup", "source_url": "backup/2"},
+            ],
+            "reading_progress": {
+                "last_chapter": "5",
+                "last_read": "2026-07-17T10:00:00",
+            },
+            "new_chapters_available": 4,
+        }
+
+        merged = merge_manga_state(local, imported)
+
+        assert merged["downloaded"] == ["1", "2", "3"]
+        assert merged["read_chapters"] == ["1", "2"]
+        assert merged["external_chapters"] == ["7", "8"]
+        assert merged["failed_chapters"]["4"]["error"] == "local"
+        assert merged["failed_chapters"]["5"]["error"] == "backup"
+        assert merged["available_chapters"] == [
+            {"number": "1", "source": "local", "source_url": "local/1"},
+            {"number": "2", "source": "backup", "source_url": "backup/2"},
+        ]
+        assert merged["reading_progress"]["last_chapter"] == "5"
+        assert merged["new_chapters_available"] == 4
+
+    def test_merge_backup_state_adds_new_titles(self):
+        merged = merge_backup_state(
+            {"Local": {"downloaded": ["1"]}},
+            {
+                "Local": {"downloaded": ["2"]},
+                "Imported": {"read_chapters": ["9"]},
+            },
+        )
+
+        assert merged["Local"]["downloaded"] == ["1", "2"]
+        assert merged["Imported"]["read_chapters"] == ["9"]
+
+    def test_merge_backup_state_alias_preserves_local_key_casing(self):
+        merged = merge_backup_state(
+            {
+                "Stateful": {
+                    "downloaded": ["1"],
+                    "failed_chapters": {
+                        "4": {"error": "local", "attempts": 2},
+                    },
+                }
+            },
+            {
+                "stateful": {
+                    "downloaded": ["2"],
+                    "failed_chapters": {
+                        "4": {"error": "imported", "attempts": 1},
+                        "5": {"error": "backup", "attempts": 1},
+                    },
+                }
+            },
+            title_aliases={"stateful": "Stateful"},
+        )
+
+        assert list(merged) == ["Stateful"]
+        assert merged["Stateful"]["downloaded"] == ["1", "2"]
+        assert merged["Stateful"]["failed_chapters"]["4"]["error"] == "local"
+        assert merged["Stateful"]["failed_chapters"]["5"]["error"] == "backup"
+        assert "stateful" not in merged
+
+    def test_merge_backup_state_keeps_new_import_casing_without_alias(self):
+        merged = merge_backup_state(
+            {"Stateful": {"downloaded": ["1"]}},
+            {"stateful": {"downloaded": ["2"]}},
+        )
+
+        assert merged["Stateful"]["downloaded"] == ["1"]
+        assert merged["stateful"]["downloaded"] == ["2"]
+
+    def test_last_chapter_uses_chapter_order_not_string_order(self):
+        merged = merge_manga_state(
+            {"last_chapter": "9"},
+            {"last_chapter": "10"},
+        )
+
+        assert merged["last_chapter"] == "10"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -22,6 +22,33 @@ class TestConfigBasics:
         assert a == {"b": {"c": 42}}
 
 
+class TestPartialChapterConfig:
+    """Partial-chapter tolerance settings (issue #86)."""
+
+    def test_disabled_by_default(self, config):
+        assert config.partial_enabled is False
+        # Default threshold is exposed as a float for the downloader.
+        assert config.partial_threshold == 5.0
+
+    def test_enable_and_set_threshold(self, config):
+        config.set("partial_chapters.enabled", True)
+        config.set("partial_chapters.threshold_percent", 10)
+        assert config.partial_enabled is True
+        assert config.partial_threshold == 10.0
+
+    def test_threshold_falls_back_on_garbage(self, config):
+        config.set("partial_chapters.threshold_percent", "not-a-number")
+        assert config.partial_threshold == 5.0
+
+    def test_threshold_clamps_above_100(self, config):
+        config.set("partial_chapters.threshold_percent", 150)
+        assert config.partial_threshold == 100.0
+
+    def test_threshold_clamps_below_0(self, config):
+        config.set("partial_chapters.threshold_percent", -20)
+        assert config.partial_threshold == 0.0
+
+
 class TestConfigPersistence:
     def test_save_then_reload(self, isolated_home):
         from memanga.config import Config

--- a/tests/unit/test_cron.py
+++ b/tests/unit/test_cron.py
@@ -1,0 +1,47 @@
+"""Tests for memanga.cron shell-safe crontab line construction (#109)."""
+
+import shlex
+
+from memanga.cron import build_cron_line, quote_cron_path
+
+
+class TestQuoteCronPath:
+    def test_plain_path_unchanged(self):
+        assert quote_cron_path("/opt/memanga") == "/opt/memanga"
+
+    def test_path_with_spaces_is_quoted(self):
+        assert quote_cron_path("/opt/My Manga") == "'/opt/My Manga'"
+
+    def test_shell_metacharacters_neutralized(self):
+        evil = "/tmp/$(touch pwned); echo"
+        assert shlex.split(quote_cron_path(evil)) == [evil]
+
+    def test_percent_escaped_for_cron(self):
+        # crontab(5) turns an unescaped % into a newline.
+        assert quote_cron_path("/opt/100%manga") == r"/opt/100\%manga"
+
+
+class TestBuildCronLine:
+    def test_plain_paths(self):
+        line = build_cron_line(0, 6, "/opt/memanga", "/usr/bin/python3")
+        assert line == (
+            "0 6 * * * cd /opt/memanga && /usr/bin/python3 "
+            "-m memanga check --auto --quiet >> /opt/memanga/memanga.log 2>&1"
+        )
+
+    def test_paths_with_spaces(self):
+        line = build_cron_line(30, 7, "/opt/My Manga",
+                               "/opt/My Manga/venv/bin/python3")
+        assert line == (
+            "30 7 * * * cd '/opt/My Manga' && "
+            "'/opt/My Manga/venv/bin/python3' "
+            "-m memanga check --auto --quiet "
+            ">> '/opt/My Manga/memanga.log' 2>&1"
+        )
+
+    def test_metacharacter_paths_stay_single_words(self):
+        evil = "/tmp/x; touch pwned"
+        line = build_cron_line(0, 6, evil, "/usr/bin/python3")
+        command = line.split("* * * ", 1)[1]
+        # The shell must see the whole path as one word, not extra commands.
+        assert evil in shlex.split(command)

--- a/tests/unit/test_downloader.py
+++ b/tests/unit/test_downloader.py
@@ -4,6 +4,9 @@ sanitization, format conversion, fallback delay logic."""
 from __future__ import annotations
 
 import types
+import sys
+import time
+import shutil
 from pathlib import Path
 
 import pytest
@@ -29,6 +32,28 @@ class TestSanitizeFilename:
     def test_preserves_safe_text(self):
         from memanga.downloader import _sanitize_filename
         assert _sanitize_filename("Chainsaw Man") == "Chainsaw Man"
+
+    def test_dot_components_fall_back(self):
+        from memanga.downloader import _sanitize_filename
+        assert _sanitize_filename(".") == "untitled"
+        assert _sanitize_filename("..") == "untitled"
+        # "../" loses its slash and would otherwise collapse to ".."
+        assert _sanitize_filename("../") == "untitled"
+
+    def test_empty_and_whitespace_fall_back(self):
+        from memanga.downloader import _sanitize_filename
+        assert _sanitize_filename("") == "untitled"
+        assert _sanitize_filename("   ") == "untitled"
+
+    def test_all_invalid_chars_fall_back(self):
+        from memanga.downloader import _sanitize_filename
+        assert _sanitize_filename('<>:"/\\|?*') == "untitled"
+
+    def test_truncation_never_leaves_trailing_dot_or_space(self):
+        from memanga.downloader import _sanitize_filename
+        assert _sanitize_filename("a" * 99 + " b") == "a" * 99
+        assert _sanitize_filename("a" * 99 + ".b") == "a" * 99
+        assert _sanitize_filename("Vol. 2.") == "Vol. 2"
 
 
 class TestFormatChapterNumber:
@@ -123,6 +148,22 @@ class TestDownloadChapterPath:
             f"format {fmt!r} produced {rel} — not under Bleach/"
         )
 
+    def test_invalid_title_uses_safe_folder(self, tmp_path,
+                                            patch_get_scraper, fake_state):
+        """Invalid stored titles should use a safe manga folder."""
+        from memanga.downloader import download_chapter
+        out = tmp_path / "downloads"
+        manga = {"title": "../", "url": "https://mock.test/m",
+                 "source": "mock.test"}
+        chapter = types.SimpleNamespace(
+            number="1", title="", url="https://mock.test/c/1",
+            source="mock.test", source_url="https://mock.test/c/1",
+            is_backup=False,
+        )
+        path = download_chapter(manga, chapter, out, "cbz", fake_state)
+        rel = Path(path).resolve().relative_to(out.resolve())
+        assert rel.parts[0] == "untitled"
+
 
 class TestNamingTemplate:
     def test_template_variables_substituted(self, tmp_path,
@@ -148,6 +189,306 @@ class TestNamingTemplate:
             naming_template="{title}__ch{chapter}",
         )
         assert "MyManga__ch1" in Path(path).stem
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# download_chapter — issue #89: optional post-processing hook
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestPostProcessing:
+    """Verify the configurable post-download command hook."""
+
+    @pytest.fixture
+    def fake_state(self):
+        class S:
+            def add_downloaded_chapter(self, *a, **k): pass
+            def is_chapter_downloaded(self, *a, **k): return False
+            def get_pending_backup(self, *a, **k): return None
+            def set_pending_backup(self, *a, **k): pass
+            def clear_pending_backup(self, *a, **k): pass
+        return S()
+
+    def _manga_and_chapter(self):
+        manga = {"title": "PPManga", "url": "https://mock.test/m",
+                 "source": "mock.test"}
+        chapter = types.SimpleNamespace(
+            number="3", title="", url="https://mock.test/c/3",
+            source="mock.test", source_url="https://mock.test/c/3",
+            is_backup=False,
+        )
+        return manga, chapter
+
+    def test_disabled_by_default_does_not_run(self, tmp_path,
+                                              patch_get_scraper, fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "ran.txt"
+        pp = {"enabled": False, "command": f'touch "{marker}"',
+              "fail_on_error": False}
+        download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                         post_processing=pp)
+        assert not marker.exists()
+
+    def test_none_config_is_noop(self, tmp_path, patch_get_scraper, fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        # Simply must not raise when no config is passed.
+        path = download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                                post_processing=None)
+        assert path is not None
+
+    def test_successful_command_runs(self, tmp_path, patch_get_scraper,
+                                     fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "ran.txt"
+        pp = {
+            "enabled": True,
+            "command": (
+                f'"{sys.executable}" -c '
+                f'"from pathlib import Path; Path({str(marker)!r}).touch()"'
+            ),
+            "fail_on_error": True,
+        }
+        download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                         post_processing=pp)
+        assert marker.exists()
+
+    def test_placeholders_and_env_vars(self, tmp_path, patch_get_scraper,
+                                       fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        out_marker = tmp_path / "placeholders.txt"
+        env_marker = tmp_path / "env.txt"
+        script = tmp_path / "record_post_processing.py"
+        script.write_text(
+            "import os, sys\n"
+            "from pathlib import Path\n"
+            "Path(sys.argv[1]).write_text('|'.join(sys.argv[3:]))\n"
+            "Path(sys.argv[2]).write_text('|'.join([\n"
+            "    os.environ['MEMANGA_MANGA_TITLE'],\n"
+            "    os.environ['MEMANGA_CHAPTER'],\n"
+            "    os.environ['MEMANGA_OUTPUT_FORMAT'],\n"
+            "    os.environ['MEMANGA_IS_DIR'],\n"
+            "]))\n"
+            "assert Path(os.environ['MEMANGA_OUTPUT_PATH']).exists()\n"
+        )
+        command = (
+            f'"{sys.executable}" "{script}" "{out_marker}" "{env_marker}" '
+            "{title} {chapter} {source} {format} {is_dir}"
+        )
+        pp = {"enabled": True, "command": command, "fail_on_error": True}
+        download_chapter(manga, chapter, tmp_path, "cbz", fake_state,
+                         post_processing=pp)
+        assert out_marker.read_text().strip() == "PPManga|3|mock.test|cbz|0"
+        assert env_marker.read_text().strip() == "PPManga|3|cbz|0"
+
+    def test_image_folder_output_is_dir_flag(self, tmp_path, patch_get_scraper,
+                                             fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "isdir.txt"
+        script = tmp_path / "check_dir.py"
+        script.write_text(
+            "import os\n"
+            "from pathlib import Path\n"
+            "Path(os.environ['MEMANGA_OUTPUT_PATH']).is_dir() or exit(1)\n"
+            f"Path({str(marker)!r}).write_text(os.environ['MEMANGA_IS_DIR'])\n"
+        )
+        # For an image folder, is_dir should be "1" and the path a directory.
+        command = f'"{sys.executable}" "{script}"'
+        pp = {"enabled": True, "command": command, "fail_on_error": True}
+        path = download_chapter(manga, chapter, tmp_path, "jpg", fake_state,
+                                post_processing=pp)
+        assert Path(path).is_dir()
+        assert marker.read_text().strip() == "1"
+
+    def test_fail_on_error_false_only_warns(self, tmp_path, patch_get_scraper,
+                                            fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        pp = {
+            "enabled": True,
+            "command": f'"{sys.executable}" -c "import sys; sys.exit(1)"',
+            "fail_on_error": False,
+        }
+        # Should NOT raise — download stays successful.
+        path = download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                                post_processing=pp)
+        assert path is not None and Path(path).exists()
+
+    def test_fail_on_error_true_raises(self, tmp_path, patch_get_scraper,
+                                       fake_state):
+        from memanga.downloader import download_chapter, DownloaderError
+        manga, chapter = self._manga_and_chapter()
+        pp = {
+            "enabled": True,
+            "command": f'"{sys.executable}" -c "import sys; sys.exit(3)"',
+            "fail_on_error": True,
+        }
+        with pytest.raises(DownloaderError):
+            download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                             post_processing=pp)
+
+    def test_empty_command_is_noop(self, tmp_path, patch_get_scraper,
+                                   fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        pp = {"enabled": True, "command": "   ", "fail_on_error": True}
+        path = download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                                post_processing=pp)
+        assert path is not None
+
+    def test_placeholder_values_are_not_shell_evaluated(self, tmp_path,
+                                                        patch_get_scraper,
+                                                        fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "placeholder.txt"
+        injected = tmp_path / "injected.txt"
+        manga["title"] = f"PPManga; touch {injected}"
+        script = tmp_path / "write_arg.py"
+        script.write_text(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "Path(sys.argv[1]).write_text(sys.argv[2])\n"
+        )
+
+        pp = {
+            "enabled": True,
+            "command": f'"{sys.executable}" "{script}" "{marker}" {{title}}',
+            "fail_on_error": True,
+        }
+
+        download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                         post_processing=pp, naming_template="{chapter}")
+
+        assert marker.read_text() == manga["title"]
+        assert not injected.exists()
+
+    def test_placeholder_values_are_not_reexpanded(self, tmp_path,
+                                                   patch_get_scraper,
+                                                   fake_state):
+        from memanga.downloader import download_chapter
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "placeholder.txt"
+        script = tmp_path / "write_arg.py"
+        script.write_text(
+            "import sys\n"
+            "from pathlib import Path\n"
+            "Path(sys.argv[1]).write_text(sys.argv[2])\n"
+        )
+        manga["title"] = "Title {source}"
+
+        pp = {
+            "enabled": True,
+            "command": f'"{sys.executable}" "{script}" "{marker}" {{title}}',
+            "fail_on_error": True,
+        }
+
+        download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                         post_processing=pp)
+
+        assert marker.read_text() == "Title {source}"
+
+    def test_timeout_stops_explicit_shell_children(self, tmp_path,
+                                                   patch_get_scraper,
+                                                   fake_state,
+                                                   monkeypatch):
+        sh = shutil.which("sh")
+        if not sh:
+            pytest.skip("requires POSIX sh")
+
+        import memanga.downloader as dl
+        from memanga.downloader import download_chapter, DownloaderError
+
+        manga, chapter = self._manga_and_chapter()
+        marker = tmp_path / "late.txt"
+        monkeypatch.setattr(dl, "POST_PROCESSING_TIMEOUT", 1)
+
+        pp = {
+            "enabled": True,
+            "command": f'"{sh}" -c "sleep 3; touch {marker}"',
+            "fail_on_error": True,
+        }
+
+        with pytest.raises(DownloaderError, match="timed out"):
+            download_chapter(manga, chapter, tmp_path, "pdf", fake_state,
+                             post_processing=pp)
+
+        time.sleep(3.5)
+        assert not marker.exists()
+
+
+class TestPostProcessingCommandSplit:
+    def test_windows_paths_keep_backslashes(self, monkeypatch):
+        import memanga.downloader as dl
+
+        monkeypatch.setattr(dl.os, "name", "nt")
+
+        assert dl._split_post_processing_command(
+            r'python C:\Tools\after_download.py {output_path}'
+        ) == ["python", r"C:\Tools\after_download.py", "{output_path}"]
+        assert dl._split_post_processing_command(
+            r'"C:\Program Files\Tool\hook.exe" "{output_path}"'
+        ) == [r"C:\Program Files\Tool\hook.exe", "{output_path}"]
+        assert dl._split_post_processing_command(
+            r'python --input="C:\Program Files\x" --out="{output_path}"'
+        ) == ["python", r"--input=C:\Program Files\x", "--out={output_path}"]
+
+
+class TestPostProcessingDrainAfterTimeout:
+    """The timeout cleanup must stay bounded even if draining keeps blocking."""
+
+    class _FakeStream:
+        def __init__(self):
+            self.closed = False
+
+        def close(self):
+            self.closed = True
+
+    class _WedgedProcess:
+        """A process whose pipes never reach EOF, mimicking a stuck grandchild."""
+
+        def __init__(self):
+            import subprocess as sp
+            self._sp = sp
+            self.communicate_calls = 0
+            self.kill_calls = 0
+            self.stdout = TestPostProcessingDrainAfterTimeout._FakeStream()
+            self.stderr = TestPostProcessingDrainAfterTimeout._FakeStream()
+
+        def communicate(self, timeout=None):
+            self.communicate_calls += 1
+            raise self._sp.TimeoutExpired(cmd="hook", timeout=timeout)
+
+        def kill(self):
+            self.kill_calls += 1
+
+    def test_gives_up_and_closes_pipes_instead_of_hanging(self):
+        import memanga.downloader as dl
+
+        proc = self._WedgedProcess()
+        stdout, stderr = dl._drain_after_timeout(proc, drain_timeout=0)
+
+        assert (stdout, stderr) == (None, None)
+        assert proc.kill_calls == 1
+        assert proc.communicate_calls == 2
+        assert proc.stdout.closed and proc.stderr.closed
+
+    def test_returns_output_when_drain_succeeds(self):
+        import memanga.downloader as dl
+
+        class _CleanProcess:
+            def communicate(self, timeout=None):
+                return "out", "err"
+
+            def kill(self):  # pragma: no cover - should not be called
+                raise AssertionError("kill should not run on a clean drain")
+
+        stdout, stderr = dl._drain_after_timeout(_CleanProcess(), drain_timeout=5)
+        assert (stdout, stderr) == ("out", "err")
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/unit/test_downloader_pipeline.py
+++ b/tests/unit/test_downloader_pipeline.py
@@ -244,6 +244,114 @@ class TestImagesToCbz:
         except Exception:
             pass
 
+    def test_embeds_comicinfo_at_root_without_disturbing_pages(
+            self, jpg_paths, tmp_path):
+        # ComicInfo.xml must sit at the archive root and must NOT be counted
+        # among the page entries or change their names/order.
+        from memanga.downloader import _images_to_cbz
+        out = tmp_path / "ch.cbz"
+        _images_to_cbz(jpg_paths, out, comicinfo_xml=b"<ComicInfo/>")
+        with zipfile.ZipFile(out) as zf:
+            names = zf.namelist()
+            assert "ComicInfo.xml" in names
+            pages = [n for n in names if n != "ComicInfo.xml"]
+            assert len(pages) == 3
+            assert all(n.startswith("page_") for n in pages)
+            assert pages == sorted(pages)
+            assert zf.read("ComicInfo.xml") == b"<ComicInfo/>"
+
+    def test_no_metadata_keeps_plain_archive(self, jpg_paths, tmp_path):
+        # Omitting metadata must leave the archive exactly as before.
+        from memanga.downloader import _images_to_cbz
+        out = tmp_path / "plain.cbz"
+        _images_to_cbz(jpg_paths, out)
+        with zipfile.ZipFile(out) as zf:
+            assert "ComicInfo.xml" not in zf.namelist()
+
+
+class TestComicInfoXml:
+    """ComicInfo.xml generation from metadata already on hand,
+    with no extra network requests."""
+
+    @staticmethod
+    def _parse(xml_bytes):
+        import xml.etree.ElementTree as ET
+        root = ET.fromstring(xml_bytes)
+        assert root.tag == "ComicInfo"
+        return {child.tag: child.text for child in root}
+
+    def test_basic_fields_always_present(self):
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        manga = {"title": "Berserk"}
+        ch = Chapter(number="5", title=None, url="https://x.test/c/5")
+        fields = self._parse(_build_comicinfo_xml(manga, ch, page_count=12))
+        assert fields["Series"] == "Berserk"
+        # No chapter title: falls back to "Chapter <number>".
+        assert fields["Title"] == "Chapter 5"
+        assert fields["Number"] == "5"
+        assert fields["PageCount"] == "12"
+        assert fields["Web"] == "https://x.test/c/5"
+
+    def test_optional_fields_written_when_available(self):
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        import xml.etree.ElementTree as ET
+        manga = {
+            "title": "Berserk",
+            "description": "A wandering swordsman.",
+            "author": "Kentaro Miura",
+            "url": "https://x.test/manga",
+        }
+        ch = Chapter(number="5", title="The Golden Age",
+                     url="https://x.test/c/5", date="2016-05-06")
+        fields = self._parse(_build_comicinfo_xml(manga, ch, page_count=20))
+        assert fields["Title"] == "The Golden Age"
+        assert fields["Summary"] == "A wandering swordsman."
+        assert fields["Writer"] == "Kentaro Miura"
+        assert fields["Year"] == "2016"
+        assert fields["Month"] == "5"
+        assert fields["Day"] == "6"
+        root = ET.fromstring(_build_comicinfo_xml(manga, ch, page_count=20))
+        assert [child.tag for child in root] == [
+            "Title", "Series", "Number", "Summary", "Year", "Month",
+            "Day", "Writer", "Web", "PageCount",
+        ]
+
+    def test_missing_optional_fields_are_omitted(self):
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        manga = {"title": "Berserk"}
+        ch = Chapter(number="5", url="")
+        fields = self._parse(_build_comicinfo_xml(manga, ch, page_count=1))
+        # No description/author/date/url: those tags simply don't appear.
+        for absent in ("Summary", "Writer", "Year", "Month", "Day", "Web"):
+            assert absent not in fields
+
+    def test_special_characters_are_escaped(self):
+        # Raw XML metacharacters must be escaped by the serializer and
+        # survive a round-trip parse without corrupting the document.
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        manga = {"title": 'Fist of the <North> & "Star"',
+                 "author": "A & B"}
+        ch = Chapter(number="1", title="Ch <1> & more", url="https://x.test/?a=1&b=2")
+        xml_bytes = _build_comicinfo_xml(manga, ch, page_count=3)
+        assert b"&amp;" in xml_bytes  # escaped, not raw
+        fields = self._parse(xml_bytes)  # must still parse cleanly
+        assert fields["Series"] == 'Fist of the <North> & "Star"'
+        assert fields["Title"] == "Ch <1> & more"
+        assert fields["Writer"] == "A & B"
+        assert fields["Web"] == "https://x.test/?a=1&b=2"
+
+    def test_year_omitted_for_unparseable_date(self):
+        from memanga.downloader import _build_comicinfo_xml
+        from memanga.scrapers.base import Chapter
+        manga = {"title": "X"}
+        ch = Chapter(number="1", date="an hour ago")
+        fields = self._parse(_build_comicinfo_xml(manga, ch, page_count=1))
+        assert "Year" not in fields
+
 
 class TestImagesToPdf:
     def test_creates_valid_pdf(self, jpg_paths, tmp_path):
@@ -385,6 +493,111 @@ class TestDownloadChapterErrors:
 
 
 # ─────────────────────────────────────────────────────────────────────────
+# Partial-chapter tolerance (issue #86) — opt-in; a few missing pages are
+# kept instead of discarding the whole chapter when within threshold.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class _PartialScraper:
+    """Fake scraper whose download_image fails a chosen set of page
+    indexes (0-based) and writes a valid JPEG for the rest."""
+
+    def __init__(self, num_pages, fail_indexes):
+        self._num_pages = num_pages
+        self._fail = set(fail_indexes)
+
+    def get_pages(self, url):
+        return [f"https://cdn.test/p{i}.jpg" for i in range(self._num_pages)]
+
+    def download_image(self, url, path):
+        # Index encoded in the filename we asked for: page_%03d.ext
+        idx = int(Path(url).stem[1:])
+        if idx in self._fail:
+            return False
+        Image.new("RGB", (200, 300), (10, 20, 30)).save(path, "JPEG")
+        return True
+
+    def get_cover_url(self, url):
+        return None
+
+
+def _partial_chapter():
+    return types.SimpleNamespace(
+        number="71", title="", url="https://cdn.test/c/71",
+        source="cdn.test", source_url="https://cdn.test/c/71",
+        is_backup=False)
+
+
+class TestPartialChapterTolerance:
+    def _patch(self, monkeypatch, num_pages, fail_indexes):
+        import memanga.downloader as dl
+        monkeypatch.setattr(
+            dl, "get_scraper",
+            lambda d: _PartialScraper(num_pages, fail_indexes))
+
+    def test_disabled_by_default_raises_with_structured_detail(
+            self, tmp_path, fake_state, monkeypatch):
+        """Default behavior unchanged: one missing page discards the
+        chapter, and the error carries structured failure detail."""
+        from memanga.downloader import download_chapter, DownloaderError
+        self._patch(monkeypatch, num_pages=40, fail_indexes={5})
+        manga = {"title": "Vinland Saga", "url": "https://cdn.test/x",
+                 "source": "cdn.test"}
+        with pytest.raises(DownloaderError) as exc:
+            download_chapter(manga, _partial_chapter(), tmp_path, "pdf",
+                             fake_state, max_retries=0)
+        assert exc.value.failed_pages == [6]  # 1-indexed
+        assert exc.value.total_pages == 40
+
+    def test_enabled_under_threshold_keeps_partial(
+            self, tmp_path, fake_state, monkeypatch):
+        """1/40 pages missing (2.5%) is within a 5% threshold — the
+        chapter is kept and on_partial is notified."""
+        from memanga.downloader import download_chapter
+        self._patch(monkeypatch, num_pages=40, fail_indexes={5})
+        manga = {"title": "Vinland Saga", "url": "https://cdn.test/x",
+                 "source": "cdn.test"}
+        seen = {}
+
+        def on_partial(failed, total):
+            seen["failed"] = failed
+            seen["total"] = total
+
+        out = download_chapter(
+            manga, _partial_chapter(), tmp_path, "pdf", fake_state,
+            max_retries=0, allow_partial=True, partial_threshold=5,
+            on_partial=on_partial)
+        assert out is not None and out.exists()
+        assert seen == {"failed": [6], "total": 40}
+
+    def test_enabled_over_threshold_still_raises(
+            self, tmp_path, fake_state, monkeypatch):
+        """5/40 pages missing (12.5%) exceeds a 5% threshold — still a
+        hard failure even with tolerance on."""
+        from memanga.downloader import download_chapter, DownloaderError
+        self._patch(monkeypatch, num_pages=40, fail_indexes={1, 2, 3, 4, 5})
+        manga = {"title": "Vinland Saga", "url": "https://cdn.test/x",
+                 "source": "cdn.test"}
+        with pytest.raises(DownloaderError) as exc:
+            download_chapter(
+                manga, _partial_chapter(), tmp_path, "pdf", fake_state,
+                max_retries=0, allow_partial=True, partial_threshold=5)
+        assert len(exc.value.failed_pages) == 5
+
+    def test_zero_usable_pages_is_hard_failure(
+            self, tmp_path, fake_state, monkeypatch):
+        """Even at 100% threshold, a chapter with no usable pages must
+        not be kept as an empty partial."""
+        from memanga.downloader import download_chapter, DownloaderError
+        self._patch(monkeypatch, num_pages=3, fail_indexes={0, 1, 2})
+        manga = {"title": "X", "url": "https://cdn.test/x", "source": "cdn.test"}
+        with pytest.raises(DownloaderError):
+            download_chapter(
+                manga, _partial_chapter(), tmp_path, "pdf", fake_state,
+                max_retries=0, allow_partial=True, partial_threshold=100)
+
+
+# ─────────────────────────────────────────────────────────────────────────
 # Restart browsers — Playwright pool reset, used by GUI memory-pressure
 # ─────────────────────────────────────────────────────────────────────────
 
@@ -395,3 +608,79 @@ class TestRestartBrowsers:
         live Playwright browsers."""
         from memanga.downloader import restart_browsers
         restart_browsers()  # must not raise
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Rename migration — keep downloaded files reachable after a manga rename
+# (issue #41). The reader derives the folder and file names from the
+# manga's current title, so a rename must move both.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestRenameMangaDownloads:
+    def test_moves_folder_and_rewrites_title_prefix(self, tmp_path):
+        from memanga.downloader import rename_manga_downloads
+        old_dir = tmp_path / "Old Title"
+        old_dir.mkdir()
+        (old_dir / "Old Title - Chapter 1.cbz").write_text("a")
+        (old_dir / "Old Title - Chapter 2.cbz").write_text("b")
+
+        assert rename_manga_downloads(tmp_path, "Old Title", "New Title") is True
+
+        new_dir = tmp_path / "New Title"
+        assert not old_dir.exists()
+        assert (new_dir / "New Title - Chapter 1.cbz").read_text() == "a"
+        assert (new_dir / "New Title - Chapter 2.cbz").read_text() == "b"
+
+    def test_moves_non_title_prefixed_entries_as_is(self, tmp_path):
+        # Image-format downloads use "Chapter N" folders with no title.
+        from memanga.downloader import rename_manga_downloads
+        old_dir = tmp_path / "Old"
+        (old_dir / "Chapter 1").mkdir(parents=True)
+        (old_dir / "Chapter 1" / "001.jpg").write_text("img")
+
+        assert rename_manga_downloads(tmp_path, "Old", "New") is True
+        assert (tmp_path / "New" / "Chapter 1" / "001.jpg").read_text() == "img"
+
+    def test_no_downloads_returns_false(self, tmp_path):
+        from memanga.downloader import rename_manga_downloads
+        assert rename_manga_downloads(tmp_path, "Missing", "New") is False
+
+    def test_unchanged_sanitized_title_is_noop(self, tmp_path):
+        # The sanitizer strips characters like ':' — titles that collapse
+        # to the same safe name must not move anything.
+        from memanga.downloader import rename_manga_downloads
+        d = tmp_path / "Title"
+        d.mkdir()
+        assert rename_manga_downloads(tmp_path, "Title", "Title:") is False
+        assert d.exists()
+
+    def test_does_not_clobber_existing_destination(self, tmp_path):
+        from memanga.downloader import rename_manga_downloads
+        old_dir = tmp_path / "Old"
+        old_dir.mkdir()
+        (old_dir / "Old - Chapter 1.cbz").write_text("new-source")
+        new_dir = tmp_path / "New"
+        new_dir.mkdir()
+        (new_dir / "New - Chapter 1.cbz").write_text("keep-me")
+
+        rename_manga_downloads(tmp_path, "Old", "New")
+
+        # Existing destination file is preserved; the colliding source is
+        # left behind in the old folder rather than overwritten.
+        assert (new_dir / "New - Chapter 1.cbz").read_text() == "keep-me"
+        assert (old_dir / "Old - Chapter 1.cbz").read_text() == "new-source"
+
+    def test_merges_into_existing_new_folder(self, tmp_path):
+        from memanga.downloader import rename_manga_downloads
+        old_dir = tmp_path / "Old"
+        old_dir.mkdir()
+        (old_dir / "Old - Chapter 2.cbz").write_text("two")
+        new_dir = tmp_path / "New"
+        new_dir.mkdir()
+        (new_dir / "New - Chapter 1.cbz").write_text("one")
+
+        assert rename_manga_downloads(tmp_path, "Old", "New") is True
+        assert (new_dir / "New - Chapter 1.cbz").read_text() == "one"
+        assert (new_dir / "New - Chapter 2.cbz").read_text() == "two"
+        assert not old_dir.exists()

--- a/tests/unit/test_emailer.py
+++ b/tests/unit/test_emailer.py
@@ -44,6 +44,21 @@ class TestSendEmail:
         called = mk.call_count + getattr(smtp, "starttls", MagicMock()).call_count
         assert called >= 0
 
+    def test_starttls_uses_ssl_context(self, cfg, tmp_path):
+        import ssl
+        f = tmp_path / "ch.pdf"
+        f.write_bytes(b"%PDF-1.4 fake")
+        smtp = MagicMock()
+        smtp.__enter__ = MagicMock(return_value=smtp)
+        smtp.__exit__ = MagicMock(return_value=False)
+        with patch("smtplib.SMTP", return_value=smtp):
+            _call_send(cfg, f)
+        assert smtp.starttls.call_count == 1
+        ctx = smtp.starttls.call_args.kwargs.get("context")
+        assert isinstance(ctx, ssl.SSLContext)
+        method_names = [call[0] for call in smtp.method_calls]
+        assert method_names.index("starttls") < method_names.index("login")
+
     def test_missing_file_raises_or_returns_false(self, cfg):
         from memanga.emailer import EmailError
         try:
@@ -61,3 +76,19 @@ class TestSendEmail:
             _call_send({}, f)
         except Exception:
             pass  # raising is acceptable
+
+
+class TestEmailConfigCheck:
+    def test_starttls_uses_ssl_context(self):
+        import ssl
+        from memanga.emailer import test_email_config as check_config
+        smtp = MagicMock()
+        smtp.__enter__ = MagicMock(return_value=smtp)
+        smtp.__exit__ = MagicMock(return_value=False)
+        with patch("smtplib.SMTP", return_value=smtp):
+            assert check_config("sender", "smtp.example.test", 587, "abc")
+        assert smtp.starttls.call_count == 1
+        ctx = smtp.starttls.call_args.kwargs.get("context")
+        assert isinstance(ctx, ssl.SSLContext)
+        method_names = [call[0] for call in smtp.method_calls]
+        assert method_names.index("starttls") < method_names.index("login")

--- a/tests/unit/test_emailer_pipeline.py
+++ b/tests/unit/test_emailer_pipeline.py
@@ -111,6 +111,39 @@ class TestSendToKindle:
             with pytest.raises((EmailError, smtplib.SMTPException)):
                 _call_send(good_cfg, tiny_pdf)
 
+    def test_large_single_file_error_explains_raw_and_encoded_limits(
+        self, good_cfg, tmp_path
+    ):
+        from memanga.emailer import EmailError, MAX_ATTACHMENT_SIZE
+        cbz = tmp_path / "large.cbz"
+        cbz.write_bytes(b"0" * (MAX_ATTACHMENT_SIZE + 1024 * 1024))
+
+        with patch("smtplib.SMTP") as smtp:
+            with pytest.raises(EmailError) as exc_info:
+                _call_send(good_cfg, cbz)
+
+        msg = str(exc_info.value)
+        assert "CBZ file is 19.0MB" in msg
+        assert "18.0MB safe raw attachment limit" in msg
+        assert "25.0MB encoded email cap" in msg
+        assert "base64 encoded" in msg
+        assert "exceeding the 25MB email limit" not in msg
+        smtp.assert_not_called()
+
+    def test_pdf_split_message_explains_raw_and_encoded_limits(
+        self, good_cfg, tiny_pdf, capsys
+    ):
+        smtp = _make_smtp_mock()
+        with patch("memanga.emailer.split_pdf", return_value=[tiny_pdf, tiny_pdf]):
+            with patch("smtplib.SMTP", return_value=smtp):
+                _call_send(good_cfg, tiny_pdf)
+
+        msg = capsys.readouterr().out
+        assert "Split into 2 parts" in msg
+        assert "18.0MB safe raw attachment limit" in msg
+        assert "25.0MB" in msg
+        assert "exceeded 25MB limit" not in msg
+
 
 # ─────────────────────────────────────────────────────────────────────
 # split_pdf — chunk huge PDFs under the attachment limit

--- a/tests/unit/test_perf.py
+++ b/tests/unit/test_perf.py
@@ -1,0 +1,166 @@
+"""Tests for memanga.perf - opt-in timing instrumentation.
+
+Covers both usage forms (decorator and context manager), the
+enabled/disabled gate, environment resolution, and the bounded
+sample buffer.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga import perf
+from memanga.perf import timed
+
+
+@pytest.fixture(autouse=True)
+def clean_perf(monkeypatch):
+    """Each test starts disabled with an empty buffer and no env leak."""
+    monkeypatch.delenv("MEMANGA_PERF", raising=False)
+    perf.set_enabled(None)
+    perf.clear_samples()
+    yield
+    perf.set_enabled(None)
+    perf.clear_samples()
+
+
+class TestEnabledGate:
+    def test_disabled_by_default(self):
+        assert not perf.is_enabled()
+
+    @pytest.mark.parametrize("value", ["1", "true", "YES", " on "])
+    def test_truthy_env_values_enable(self, monkeypatch, value):
+        monkeypatch.setenv("MEMANGA_PERF", value)
+        perf.set_enabled(None)
+        assert perf.is_enabled()
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "off", "nope"])
+    def test_other_env_values_stay_disabled(self, monkeypatch, value):
+        monkeypatch.setenv("MEMANGA_PERF", value)
+        perf.set_enabled(None)
+        assert not perf.is_enabled()
+
+    def test_set_enabled_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("MEMANGA_PERF", "1")
+        perf.set_enabled(False)
+        assert not perf.is_enabled()
+        perf.set_enabled(True)
+        assert perf.is_enabled()
+
+    def test_disabled_records_nothing(self):
+        with timed("quiet"):
+            pass
+        assert perf.recent_samples() == []
+
+
+class TestTimedContextManager:
+    def test_records_name_and_duration(self):
+        perf.set_enabled(True)
+        with timed("block"):
+            pass
+        samples = perf.recent_samples()
+        assert len(samples) == 1
+        name, duration_ms = samples[0]
+        assert name == "block"
+        assert duration_ms >= 0
+
+    def test_records_even_when_body_raises(self):
+        perf.set_enabled(True)
+        with pytest.raises(ValueError):
+            with timed("boom"):
+                raise ValueError("bad")
+        assert perf.recent_samples()[0][0] == "boom"
+
+
+class TestTimedDecorator:
+    def test_preserves_return_value_and_name(self):
+        perf.set_enabled(True)
+
+        @timed("fn")
+        def add(a, b=1):
+            return a + b
+
+        assert add(2, b=3) == 5
+        assert add.__name__ == "add"
+        assert perf.recent_samples()[0][0] == "fn"
+
+    def test_reusable_across_calls(self):
+        # A generator-based context manager is single-use; the decorator
+        # form must recreate it per call.
+        perf.set_enabled(True)
+
+        @timed("fn")
+        def noop():
+            pass
+
+        noop()
+        noop()
+        assert [n for n, _ in perf.recent_samples()] == ["fn", "fn"]
+
+    def test_enabled_checked_at_call_time(self):
+        # Decorators are applied at import time, before tests (or the
+        # user) flip the switch - the gate must not be baked in.
+        @timed("late")
+        def noop():
+            pass
+
+        noop()
+        assert perf.recent_samples() == []
+        perf.set_enabled(True)
+        noop()
+        assert [n for n, _ in perf.recent_samples()] == ["late"]
+
+    def test_decorated_state_save_records_sample(self, state):
+        # Integration: State.save carries @timed("state.save").
+        perf.set_enabled(True)
+        state.save()
+        assert "state.save" in [n for n, _ in perf.recent_samples()]
+
+    def test_decorated_config_save_records_sample(self, config):
+        perf.set_enabled(True)
+        config.save()
+        assert "config.save" in [n for n, _ in perf.recent_samples()]
+
+
+class TestSampleBuffer:
+    def test_clear_samples(self):
+        perf.set_enabled(True)
+        with timed("x"):
+            pass
+        perf.clear_samples()
+        assert perf.recent_samples() == []
+
+    def test_buffer_is_bounded(self):
+        perf.set_enabled(True)
+        for i in range(perf._MAX_SAMPLES + 50):
+            with timed(f"s{i}"):
+                pass
+        samples = perf.recent_samples()
+        assert len(samples) == perf._MAX_SAMPLES
+        # Oldest entries were dropped, newest kept.
+        assert samples[-1][0] == f"s{perf._MAX_SAMPLES + 49}"
+
+    def test_snapshot_safe_under_concurrent_appends(self):
+        # Without the lock, list(_samples) can raise "deque mutated
+        # during iteration" while a worker thread appends.
+        import threading
+
+        perf.set_enabled(True)
+        stop = threading.Event()
+
+        def writer():
+            while not stop.is_set():
+                with timed("w"):
+                    pass
+
+        threads = [threading.Thread(target=writer) for _ in range(2)]
+        for t in threads:
+            t.start()
+        try:
+            for _ in range(500):
+                snapshot = perf.recent_samples()
+                assert all(name == "w" for name, _ in snapshot)
+        finally:
+            stop.set()
+            for t in threads:
+                t.join()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -78,6 +78,37 @@ class TestChapterTracking:
         assert not state.is_chapter_downloaded("X", "2")
         assert not state.is_chapter_downloaded("Y", "1")
 
+    def test_downloaded_part_labels_sort_by_leading_chapter(self, state):
+        for chapter in ["10 Part 1", "Extra", "2 Part 1", "3.5 Part 1", "3"]:
+            state.add_downloaded_chapter("X", chapter)
+
+        assert state.get_downloaded_chapters("X") == [
+            "Extra", "2 Part 1", "3", "3.5 Part 1", "10 Part 1"
+        ]
+
+    def test_remove_downloaded_chapter(self, state):
+        # Issue #104: narrow removal drops only the downloaded record.
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "2")
+        assert state.remove_downloaded_chapter("X", "1") is True
+        assert state.get_downloaded_chapters("X") == ["2"]
+        assert not state.is_chapter_downloaded("X", "1")
+
+    def test_remove_downloaded_chapter_keeps_read_state(self, state):
+        # Read progress must survive the local file being removed.
+        state.add_downloaded_chapter("X", "1")
+        state.mark_chapter_read("X", "1")
+        state.remove_downloaded_chapter("X", "1")
+        assert not state.is_chapter_downloaded("X", "1")
+        assert state.is_chapter_read("X", "1")
+
+    def test_remove_downloaded_chapter_noop(self, state):
+        # Unknown manga / chapter must not raise and return False.
+        assert state.remove_downloaded_chapter("never", "1") is False
+        state.add_downloaded_chapter("X", "1")
+        assert state.remove_downloaded_chapter("X", "2") is False
+        assert state.get_downloaded_chapters("X") == ["1"]
+
     def test_set_last_chapter(self, state):
         state.set_last_chapter("X", "10")
         assert state.get_last_chapter("X") == "10"
@@ -95,6 +126,66 @@ class TestChapterTracking:
         st = state.get_manga_state("never-added")
         assert isinstance(st, dict)
 
+    def test_labelled_chapter_sorts_by_embedded_number(self, state):
+        # Issue #107: reader prefetch can download labelled chapters like
+        # "2 Part 1"; they must sort after "1" (by Chapter.numeric-style
+        # extraction) or the reader's Next controls never find them.
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "2 Part 1")
+        assert state.get_downloaded_chapters("X") == ["1", "2 Part 1"]
+
+    def test_labelled_chapters_interleave_with_plain_numbers(self, state):
+        for ch in ["10 Part 1", "Chapter 2", "1", "3"]:
+            state.add_downloaded_chapter("X", ch)
+        assert state.get_downloaded_chapters("X") == [
+            "1", "Chapter 2", "3", "10 Part 1"]
+
+    def test_nonnumeric_chapter_keeps_sort_first_fallback(self, state):
+        # Fully non-numeric labels keep the old 0.0 fallback (sort first).
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "Extra")
+        assert state.get_downloaded_chapters("X") == ["Extra", "1"]
+
+
+class TestPartialChapters:
+    """Accepted partial downloads stay visible and retryable (#117)."""
+
+    def test_add_get_and_clear_partial_chapter(self, state):
+        state.add_partial_chapter(
+            "X",
+            "5",
+            source="mangadex.org",
+            failed_pages=[3, 9],
+            total_pages=40,
+            path="/tmp/x.pdf",
+            from_backup=True,
+        )
+
+        partial = state.get_partial_chapter("X", "5")
+        assert partial["source"] == "mangadex.org"
+        assert partial["failed_pages"] == [3, 9]
+        assert partial["total_pages"] == 40
+        assert partial["path"] == "/tmp/x.pdf"
+        assert partial["from_backup"] is True
+        assert "X" in state.get_all_partial_chapters()
+
+        state.clear_partial_chapter("X", "5")
+
+        assert state.get_partial_chapter("X", "5") is None
+
+    def test_reset_manga_progress_clears_requeued_partial_records(self, state):
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "5")
+        state.add_partial_chapter("X", "1", failed_pages=[2], total_pages=20)
+        state.add_partial_chapter("X", "5", failed_pages=[4], total_pages=20)
+
+        state.reset_manga_progress("X", from_chapter=5)
+
+        assert "1" in state.get_downloaded_chapters("X")
+        assert "5" not in state.get_downloaded_chapters("X")
+        assert "1" in state.get_partial_chapters("X")
+        assert "5" not in state.get_partial_chapters("X")
+
 
 class TestExternalChapters:
     def test_mark_and_check_external(self, state):
@@ -108,11 +199,26 @@ class TestExternalChapters:
         ext = state.get_external_chapters("X")
         assert "1" in ext and "2" in ext
 
+    def test_external_part_labels_sort_by_leading_chapter(self, state):
+        for chapter in ["10 Part 1", "Extra", "2 Part 1", "3.5 Part 1", "3"]:
+            state.mark_external_chapter("X", chapter)
+
+        assert state.get_external_chapters("X") == [
+            "Extra", "2 Part 1", "3", "3.5 Part 1", "10 Part 1"
+        ]
+
     def test_available_chapters_set_and_get(self, state):
         chapters = [{"number": "1", "title": "first"},
                     {"number": "2", "title": "second"}]
         state.set_available_chapters("X", chapters)
         assert state.get_available_chapters("X") == chapters
+
+    def test_available_chapter_count(self, state):
+        state.set_available_chapters("X", [{"number": "1"}, {"number": "2"}])
+        assert state.get_available_chapter_count("X") == 2
+
+    def test_available_chapter_count_unknown_manga_is_zero(self, state):
+        assert state.get_available_chapter_count("never") == 0
 
 
 class TestReadChapters:
@@ -123,6 +229,9 @@ class TestReadChapters:
         state.mark_chapter_read("X", "5")
         assert state.get_read_chapters("X") == ["5"]
         assert state.get_read_count("X") == 1
+
+    def test_read_count_unknown_manga_is_zero(self, state):
+        assert state.get_read_count("never") == 0
 
     def test_unmark_chapter_read(self, state):
         state.mark_chapter_read("X", "5")
@@ -165,6 +274,81 @@ class TestReadingProgress:
 
     def test_get_continue_reading_none_when_empty(self, state):
         assert state.get_continue_reading() is None
+
+
+class TestReaderPosition:
+    """Issue #106 — per-chapter in-reader resume position."""
+
+    def test_set_and_get_paged_position(self, state):
+        state.set_reader_position("X", "7", mode="paged", page_index=12)
+        pos = state.get_reader_position("X", "7")
+        assert pos["mode"] == "paged"
+        assert pos["page_index"] == 12
+        assert "scroll_ratio" not in pos
+        assert pos["updated_at"]  # ISO timestamp string
+
+    def test_set_and_get_scroll_position(self, state):
+        state.set_reader_position("X", "7", mode="webtoon", scroll_ratio=0.42)
+        pos = state.get_reader_position("X", "7")
+        assert pos["mode"] == "webtoon"
+        assert pos["scroll_ratio"] == pytest.approx(0.42)
+        assert "page_index" not in pos
+
+    def test_positions_are_per_chapter(self, state):
+        state.set_reader_position("X", "1", mode="paged", page_index=3)
+        state.set_reader_position("X", "2", mode="paged", page_index=9)
+        assert state.get_reader_position("X", "1")["page_index"] == 3
+        assert state.get_reader_position("X", "2")["page_index"] == 9
+
+    def test_set_overwrites_previous(self, state):
+        state.set_reader_position("X", "1", mode="paged", page_index=3)
+        state.set_reader_position("X", "1", mode="webtoon", scroll_ratio=0.5)
+        pos = state.get_reader_position("X", "1")
+        assert pos["mode"] == "webtoon"
+        assert "page_index" not in pos
+
+    def test_page_index_clamped_nonnegative(self, state):
+        state.set_reader_position("X", "1", mode="paged", page_index=-5)
+        assert state.get_reader_position("X", "1")["page_index"] == 0
+
+    def test_scroll_ratio_clamped_to_unit_range(self, state):
+        state.set_reader_position("X", "1", mode="webtoon", scroll_ratio=1.7)
+        assert state.get_reader_position("X", "1")["scroll_ratio"] == 1.0
+        state.set_reader_position("X", "2", mode="webtoon", scroll_ratio=-0.3)
+        assert state.get_reader_position("X", "2")["scroll_ratio"] == 0.0
+
+    def test_chapter_keys_are_stringified(self, state):
+        state.set_reader_position("X", 7, mode="paged", page_index=1)
+        assert state.get_reader_position("X", "7")["page_index"] == 1
+
+    def test_get_unknown_manga_or_chapter_returns_none(self, state):
+        assert state.get_reader_position("never-added", "1") is None
+        state.set_reader_position("X", "1", mode="paged", page_index=0)
+        assert state.get_reader_position("X", "99") is None
+
+    def test_clear_reader_position(self, state):
+        state.set_reader_position("X", "1", mode="paged", page_index=4)
+        state.clear_reader_position("X", "1")
+        assert state.get_reader_position("X", "1") is None
+
+    def test_clear_unknown_is_noop(self, state):
+        state.clear_reader_position("never-added", "1")  # must not raise
+        state.set_reader_position("X", "1", mode="paged", page_index=0)
+        state.clear_reader_position("X", "99")  # must not raise
+
+    def test_blank_chapter_id_ignored(self, state):
+        state.set_reader_position("X", "", mode="paged", page_index=1)
+        state.set_reader_position("X", None, mode="paged", page_index=1)
+        assert state.get_manga_state("X").get("reader_positions", {}) == {}
+
+    def test_old_state_file_without_reader_positions(self, state):
+        # Entry created before the feature existed lacks the key entirely.
+        state._ensure_manga_entry("Legacy")
+        state._data["manga"]["Legacy"].pop("reader_positions", None)
+        assert state.get_reader_position("Legacy", "1") is None
+        state.clear_reader_position("Legacy", "1")  # must not raise
+        state.set_reader_position("Legacy", "1", mode="paged", page_index=2)
+        assert state.get_reader_position("Legacy", "1")["page_index"] == 2
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -255,8 +439,18 @@ class TestSourceHealth:
         assert h["status"] == "ok"
         assert h["latency_ms"] == 120
 
+    def test_moderate_latency_stays_ok(self, state):
+        # Sub-threshold responses are normal network variance, not a
+        # problem — they must not be flagged. Regression test for the
+        # old 500 ms threshold that painted healthy sources "warning".
+        for latency in (589, 635, 711, state.SLOW_LATENCY_MS):
+            state.update_source_health("ok.test", True, latency_ms=latency)
+            assert state.get_source_health("ok.test")["status"] == "ok"
+
     def test_slow_latency_flagged_warning(self, state):
-        state.update_source_health("slow.test", True, latency_ms=900)
+        state.update_source_health(
+            "slow.test", True, latency_ms=state.SLOW_LATENCY_MS + 1,
+        )
         assert state.get_source_health("slow.test")["status"] == "warning"
 
     def test_repeated_failures_escalate_to_error(self, state):
@@ -293,6 +487,47 @@ class TestResetManga:
         # Only chapters strictly < 3 survive
         assert "1" in kept and "2" in kept
         assert "3" not in kept and "4" not in kept and "5" not in kept
+
+    def test_reset_with_threshold_tolerates_nonnumeric_labels(self, state):
+        # Issue #112: part-style labels like "2 Part 1" must not raise
+        # during a partial reset, and their leading chapter number should
+        # decide whether they are kept.
+        for c in ["1", "2 Part 1", "2 Part 2", "3", "4"]:
+            state.add_downloaded_chapter("X", c)
+        state.reset_manga_progress("X", from_chapter=3)
+        kept = state.get_downloaded_chapters("X")
+        assert "1" in kept
+        assert "2 Part 1" in kept and "2 Part 2" in kept
+        assert "3" not in kept and "4" not in kept
+        assert state.get_last_chapter("X") is None
+
+    def test_reset_with_threshold_removes_part_labels_at_or_above_threshold(self, state):
+        for c in ["Extra", "1", "2 Part 1", "3 Part 1", "3 Part 2", "10 Part 1"]:
+            state.add_downloaded_chapter("X", c)
+
+        state.reset_manga_progress("X", from_chapter=3)
+
+        kept = state.get_downloaded_chapters("X")
+        assert "Extra" in kept
+        assert "1" in kept and "2 Part 1" in kept
+        assert "3 Part 1" not in kept
+        assert "3 Part 2" not in kept
+        assert "10 Part 1" not in kept
+        assert state.get_last_chapter("X") is None
+
+    def test_reset_with_zero_clears_nonnumeric_labels(self, state):
+        state.add_downloaded_chapter("X", "1")
+        state.add_downloaded_chapter("X", "2 Part 1")
+        state.reset_manga_progress("X", from_chapter=0)
+        assert state.get_downloaded_chapters("X") == []
+
+    def test_reset_with_threshold_handles_labelled_chapters(self, state):
+        # float("2 Part 1") raises; the threshold filter must use the
+        # same numeric extraction as the downloaded-list sort (issue #107).
+        for c in ["1", "2 Part 1", "Chapter 3", "4"]:
+            state.add_downloaded_chapter("X", c)
+        state.reset_manga_progress("X", from_chapter=3)
+        assert state.get_downloaded_chapters("X") == ["1", "2 Part 1"]
 
     def test_remove_manga(self, state):
         state.add_downloaded_chapter("X", "1")

--- a/tests/unit/test_state_persistence.py
+++ b/tests/unit/test_state_persistence.py
@@ -49,6 +49,69 @@ class TestAtomicSave:
         s = State(config_dir=cfg)
         assert s.get_notifications() == []
 
+    def test_older_save_cannot_overwrite_newer_state(self, state, monkeypatch):
+        """A delayed old save must not publish after a newer mutation."""
+        state.set("publication_order", "old")
+        original_replace = __import__("os").replace
+        first_replace_ready = threading.Event()
+        release_first_replace = threading.Event()
+        replace_count = 0
+        count_lock = threading.Lock()
+        publication_lock_held = []
+        thread_errors = []
+
+        def controlled_replace(src, dst):
+            nonlocal replace_count
+            with count_lock:
+                replace_count += 1
+                call_number = replace_count
+
+            probe_acquired_lock = []
+
+            def probe_lock():
+                acquired = state._lock.acquire(blocking=False)
+                probe_acquired_lock.append(acquired)
+                if acquired:
+                    state._lock.release()
+
+            probe = threading.Thread(target=probe_lock)
+            probe.start()
+            probe.join(timeout=5)
+            assert not probe.is_alive()
+            publication_lock_held.append(not probe_acquired_lock[0])
+
+            if call_number == 1:
+                first_replace_ready.set()
+                assert release_first_replace.wait(timeout=5)
+            original_replace(src, dst)
+
+        monkeypatch.setattr("memanga.state.os.replace", controlled_replace)
+
+        def capture_errors(fn, *args):
+            try:
+                fn(*args)
+            except Exception as exc:  # pragma: no cover - failure path
+                thread_errors.append(exc)
+
+        old_save = threading.Thread(target=capture_errors, args=(state.save,))
+        old_save.start()
+        assert first_replace_ready.wait(timeout=5)
+
+        newer_save = threading.Thread(
+            target=capture_errors,
+            args=(state.set, "publication_order", "new"))
+        newer_save.start()
+
+        release_first_replace.set()
+        old_save.join(timeout=5)
+        newer_save.join(timeout=5)
+
+        assert not old_save.is_alive()
+        assert not newer_save.is_alive()
+        assert thread_errors == []
+        assert publication_lock_held == [True, True]
+        assert json.loads(state.state_path.read_text())["publication_order"] == "new"
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Concurrent mutation — multiple workers writing State at once
@@ -88,6 +151,64 @@ class TestConcurrency:
         # File should still be valid JSON.
         data = json.loads(state.state_path.read_text())
         assert "notifications" in data
+
+    def test_import_merge_serializes_with_worker_mutation(self, state):
+        """Backup merge must not publish an old manga snapshot over workers."""
+        state.add_downloaded_chapter("Existing", "1")
+        worker_started = threading.Event()
+        worker_done = threading.Event()
+        worker_errors = []
+        worker_threads = []
+
+        class InterleavingImport(dict):
+            def items(self):
+                def worker():
+                    try:
+                        worker_started.set()
+                        state.add_downloaded_chapter("Existing", "2")
+                        worker_done.set()
+                    except Exception as exc:  # pragma: no cover - failure path
+                        worker_errors.append(exc)
+
+                thread = threading.Thread(target=worker)
+                worker_threads.append(thread)
+                thread.start()
+                assert worker_started.wait(timeout=5)
+                time.sleep(0.02)
+                assert not worker_done.is_set()
+                return super().items()
+
+        imported = InterleavingImport({
+            "Existing": {"downloaded": ["imported"]},
+            "Missing": {"downloaded": ["9"]},
+        })
+
+        state.merge_missing_manga_state(imported)
+
+        for thread in worker_threads:
+            thread.join(timeout=5)
+            assert not thread.is_alive()
+        assert worker_errors == []
+        assert state.get_downloaded_chapters("Existing") == ["1", "2"]
+        assert state.get_downloaded_chapters("Missing") == ["9"]
+
+    def test_cli_import_merge_unions_downloaded_under_lock(self, state):
+        state.add_downloaded_chapter("Existing", "1")
+
+        state.merge_missing_manga_state(
+            {
+                "Existing": {"downloaded": ["2", "10"]},
+                "Missing": {"downloaded": ["3"]},
+            },
+            merge_existing_downloaded=True,
+        )
+
+        assert state.get_downloaded_chapters("Existing") == ["1", "2", "10"]
+        assert state.get_downloaded_chapters("Missing") == ["3"]
+
+    def test_import_merge_rejects_non_dict_state(self, state):
+        with pytest.raises(TypeError):
+            state.merge_missing_manga_state([])
 
 
 # ─────────────────────────────────────────────────────────────────────────
@@ -153,3 +274,247 @@ class TestSchemaCompat:
         # Even with zero history, get_manga_state must not raise.
         st = state.get_manga_state("never-touched")
         assert isinstance(st, dict)
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Getter isolation (issue #110) — returned containers are snapshots, so
+# GUI code can iterate them while workers mutate the underlying state
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGetterIsolation:
+    def test_downloaded_list_is_a_copy(self, state):
+        state.add_downloaded_chapter("X", "1")
+        state.get_downloaded_chapters("X").append("999")
+        assert state.get_downloaded_chapters("X") == ["1"]
+
+    def test_manga_state_is_a_snapshot(self, state):
+        state.add_downloaded_chapter("X", "1")
+        snap = state.get_manga_state("X")
+        snap["downloaded"].append("999")
+        snap["last_chapter"] = "999"
+        assert state.get_downloaded_chapters("X") == ["1"]
+        assert state.get_last_chapter("X") == "1"
+
+    def test_source_health_is_a_copy(self, state):
+        state.update_source_health("a.test", True, latency_ms=50)
+        state.get_all_source_health()["a.test"]["status"] = "error"
+        state.get_source_health("a.test")["status"] = "error"
+        assert state.get_source_health("a.test")["status"] == "ok"
+
+    def test_notifications_are_copies(self, state):
+        state.add_notification("info", "x")
+        state.get_notifications()[0]["read"] = True
+        assert state.get_unread_count() == 1
+
+    def test_generic_get_returns_copy(self, state):
+        state.set("custom", {"nested": [1]})
+        state.get("custom")["nested"].append(2)
+        assert state.get("custom") == {"nested": [1]}
+
+    @pytest.mark.parametrize("getter", [
+        lambda state: state.get_available_chapters("X"),
+        lambda state: state.get_download_history(),
+        lambda state: state.get_all_pending_backups("X"),
+        lambda state: state.get_failed_chapters("X"),
+        lambda state: state.get_source_health("src.test"),
+        lambda state: state.get_all_source_health(),
+        lambda state: state.get_reading_progress("X"),
+        lambda state: state.get_check_history(),
+    ])
+    def test_nested_getters_return_snapshots(self, state, getter):
+        state.set("manga", {"X": {
+            "available_chapters": [{"metadata": {"tags": ["original"]}}],
+            "pending_backup": {"1": {"metadata": {"tags": ["original"]}}},
+            "failed_chapters": {"1": {"failed_pages": [[1]]}},
+            "reading_progress": {"metadata": {"tags": ["original"]}},
+        }})
+        state.set("download_history", [
+            {"metadata": {"tags": ["original"]}},
+        ])
+        state.set("check_history", [
+            {"metadata": {"tags": ["original"]}},
+        ])
+        state.set("source_health", {
+            "src.test": {"metadata": {"tags": ["original"]}},
+        })
+
+        snapshot = getter(state)
+        original = state._snapshot(snapshot)
+
+        def mutate_nested(value):
+            if isinstance(value, dict):
+                for child in value.values():
+                    if isinstance(child, (dict, list)):
+                        mutate_nested(child)
+                        return
+            elif isinstance(value, list):
+                if value and isinstance(value[0], (dict, list)):
+                    mutate_nested(value[0])
+                else:
+                    value.append("changed")
+
+        mutate_nested(snapshot)
+        assert getter(state) == original
+
+    def test_setter_inputs_are_snapshotted(self, state):
+        available = [{"metadata": {"tags": ["original"]}}]
+        suspicious = {"chapters": [{"number": "1"}]}
+        failed_pages = [[1]]
+        custom = {"nested": ["original"]}
+
+        state.set_available_chapters("X", available)
+        state.set_suspicious_batch("X", suspicious)
+        state.add_failed_chapter("X", "1", "src.test", "boom", failed_pages)
+        state.set("custom", custom)
+
+        available[0]["metadata"]["tags"].append("changed")
+        suspicious["chapters"][0]["number"] = "999"
+        failed_pages[0].append(2)
+        custom["nested"].append("changed")
+
+        assert state.get_available_chapters("X") == [
+            {"metadata": {"tags": ["original"]}},
+        ]
+        assert state.get_suspicious_batch("X") == {
+            "chapters": [{"number": "1"}],
+        }
+        assert state.get_failed_chapters("X")["1"]["failed_pages"] == [[1]]
+        assert state.get("custom") == {"nested": ["original"]}
+
+    def test_mutator_that_saves_does_not_deadlock(self, state):
+        # Immediate-save mutators call save() while holding the state
+        # lock — the reentrant lock must let that through.
+        state.set_pending_backup("X", "1", "backup.test", "https://b/1")
+        state.add_failed_chapter("X", "2", "src.test", "boom")
+        state.clear_pending_backup("X", "1")
+        assert state.get_pending_backup("X", "1") is None
+
+    def test_rename_manga_moves_state_entry_and_persists(self, state):
+        state.add_downloaded_chapter("Old", "1")
+
+        assert state.rename_manga("Old", "New") is True
+        assert state.get_manga_state("Old") == {}
+        assert state.get_downloaded_chapters("New") == ["1"]
+        assert "New" in json.loads(state.state_path.read_text())["manga"]
+
+    def test_rename_manga_returns_false_for_missing_entry(self, state):
+        assert state.rename_manga("Missing", "New") is False
+        assert state.get_manga_state("New") == {}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Stress (issue #110) — GUI-style worker mutations interleaved with the
+# main thread's periodic flush + close-time save
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestFlushMutationStress:
+    N_MANGA = 4
+    N_CHAPTERS = 25
+    N_SOURCES = 4
+    N_NOTIFICATIONS = 80
+
+    def test_no_lost_updates_under_interleaved_flush(self, state):
+        """Simulate the GUI: download/check/health workers mutating state
+        while the flush timer and close handler serialize it. No chapter,
+        read mark, notification, history entry, or health entry may be
+        lost, and the file on disk must stay valid JSON."""
+        stop = threading.Event()
+        errors = []
+
+        def guarded(fn):
+            def run(*args):
+                try:
+                    fn(*args)
+                except Exception as e:  # pragma: no cover - failure path
+                    errors.append(e)
+            return run
+
+        @guarded
+        def flusher():
+            while True:
+                state.flush()
+                state.save()
+                if stop.is_set():
+                    return
+                time.sleep(0.001)
+
+        @guarded
+        def download_worker(idx):
+            title = "Manga %d" % idx
+            for n in range(1, self.N_CHAPTERS + 1):
+                state.add_downloaded_chapter(title, str(n))
+                state.mark_chapter_read(title, str(n))
+                state.add_download_history(title, str(n), "cbz", size_mb=1.0)
+                state.add_failed_chapter(title, "f%d" % n, "src.test", "boom")
+
+        @guarded
+        def check_worker(idx):
+            title = "Manga %d" % idx
+            for n in range(self.N_CHAPTERS):
+                state.set_new_chapters(title, n)
+                state.set_available_chapters(
+                    title, [dict(number=str(i)) for i in range(n + 1)])
+                state.get_manga_state(title)  # GUI refresh-style read
+                state.get_stats()
+
+        @guarded
+        def health_worker(idx):
+            domain = "src%d.test" % idx
+            for n in range(self.N_CHAPTERS):
+                state.update_source_health(domain, n % 4 != 0,
+                                           "timeout", latency_ms=100 + n)
+                state.get_all_source_health()
+
+        @guarded
+        def notify_worker():
+            for n in range(self.N_NOTIFICATIONS):
+                state.add_notification("download", "n%d" % n)
+                state.get_notifications()
+
+        flush_thread = threading.Thread(target=flusher, daemon=True)
+        workers = []
+        for i in range(self.N_MANGA):
+            workers.append(threading.Thread(target=download_worker, args=(i,)))
+            workers.append(threading.Thread(target=check_worker, args=(i,)))
+        for i in range(self.N_SOURCES):
+            workers.append(threading.Thread(target=health_worker, args=(i,)))
+        workers.append(threading.Thread(target=notify_worker))
+
+        flush_thread.start()
+        for t in workers:
+            t.start()
+        for t in workers:
+            t.join(timeout=60)
+        stop.set()
+        flush_thread.join(timeout=60)
+        alive = [t for t in workers + [flush_thread] if t.is_alive()]
+        assert not alive, "threads deadlocked or still running"
+        assert errors == []
+
+        # In-memory: nothing lost.
+        expected = [str(n) for n in range(1, self.N_CHAPTERS + 1)]
+        for i in range(self.N_MANGA):
+            title = "Manga %d" % i
+            assert sorted(state.get_downloaded_chapters(title),
+                          key=float) == expected
+            assert sorted(state.get_read_chapters(title),
+                          key=float) == expected
+            assert len(state.get_failed_chapters(title)) == self.N_CHAPTERS
+            assert len(state.get_available_chapters(title)) == self.N_CHAPTERS
+        assert len(state.get_download_history(limit=1000)) == \
+            self.N_MANGA * self.N_CHAPTERS
+        assert len(state.get_notifications(limit=1000)) == self.N_NOTIFICATIONS
+        for i in range(self.N_SOURCES):
+            health = state.get_source_health("src%d.test" % i)
+            assert health.get("latency_ms") == 100 + self.N_CHAPTERS - 1
+
+        # On disk: valid JSON that round-trips the same data.
+        data = json.loads(state.state_path.read_text())
+        for i in range(self.N_MANGA):
+            assert sorted(data["manga"]["Manga %d" % i]["downloaded"],
+                          key=float) == expected
+        assert len(data["download_history"]) == self.N_MANGA * self.N_CHAPTERS
+        assert len(data["notifications"]) == self.N_NOTIFICATIONS
+        assert len(data["source_health"]) == self.N_SOURCES

--- a/tests/unit/test_suspicion.py
+++ b/tests/unit/test_suspicion.py
@@ -308,6 +308,184 @@ class TestCheckForUpdatesGuard:
 
 
 # -------------------------------------------------------------------------
+# #102: existing catalogue backlog must not read as a suspicious jump
+# -------------------------------------------------------------------------
+
+
+# Blue Lock scenario: a large existing catalogue with only chapter 1 grabbed.
+BLUE_LOCK_MANGA = {
+    "title": "Blue Lock",
+    "mode": "manual",
+    "source": "primary.test",
+    "url": "https://primary.test/m",
+}
+
+
+def _cache_catalogue(state, title, numbers):
+    """Mimic the GUI persisting the primary chapter list after a check."""
+    state.set_available_chapters(title, [
+        {"number": f"{n:g}", "title": "", "source": "primary.test",
+         "source_url": "https://primary.test/m", "is_backup": False,
+         "url": f"u/{n:g}"}
+        for n in numbers
+    ])
+
+
+class TestManualBacklogNotSuspicious:
+    def test_first_manual_check_bootstraps_catalogue_baseline(self, state, monkeypatch):
+        # Exact #102 shape: no cached catalogue yet, only chapter 1 is
+        # downloaded, and the source reports a large existing catalogue.
+        # Manual mode should snapshot that catalogue instead of treating the
+        # old backlog as an auto-delivery anomaly.
+        from memanga.downloader import check_for_updates
+
+        state.add_downloaded_chapter("Blue Lock", "1")
+        assert state.get_available_chapters("Blue Lock") == []
+        assert state.get_catalogue_baseline("Blue Lock") is None
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 354)]),
+        })
+
+        new = check_for_updates(BLUE_LOCK_MANGA, state)
+
+        assert [c.number for c in new] == [str(n) for n in range(2, 354)]
+        assert state.get_suspicious_batch("Blue Lock") is None
+        assert state.get_catalogue_baseline("Blue Lock") == 353.0
+        assert not any(n["type"] == "warn" for n in state.get_notifications())
+
+    def test_undownloaded_backlog_is_not_flagged(self, state, monkeypatch):
+        # Manual manga: chapter 1 downloaded out of an existing 1..344
+        # catalogue that has since grown to 353. The backlog must stay
+        # visible/downloadable without a suspicious record (#102).
+        from memanga.downloader import check_for_updates
+
+        state.add_downloaded_chapter("Blue Lock", "1")
+        state.set_catalogue_baseline("Blue Lock", 344.0)
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 354)]),
+        })
+
+        new = check_for_updates(BLUE_LOCK_MANGA, state)
+
+        # The whole undownloaded backlog (2..353) is offered, none withheld.
+        assert [c.number for c in new] == [str(n) for n in range(2, 354)]
+        assert state.get_suspicious_batch("Blue Lock") is None
+        assert not any(n["type"] == "warn" for n in state.get_notifications())
+
+    def test_baseline_bootstrapped_from_cached_catalogue(self, state, monkeypatch):
+        # No explicit baseline yet (pre-existing manga), but the GUI has
+        # cached the catalogue up to 344 from an earlier check. That cache
+        # bootstraps the baseline so the backlog isn't flagged.
+        from memanga.downloader import check_for_updates
+
+        state.add_downloaded_chapter("Blue Lock", "1")
+        _cache_catalogue(state, "Blue Lock", range(1, 345))
+        assert state.get_catalogue_baseline("Blue Lock") is None
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 354)]),
+        })
+
+        new = check_for_updates(BLUE_LOCK_MANGA, state)
+
+        assert state.get_suspicious_batch("Blue Lock") is None
+        assert [c.number for c in new] == [str(n) for n in range(2, 354)]
+        # The baseline is now persisted at the current catalogue high.
+        assert state.get_catalogue_baseline("Blue Lock") == 353.0
+
+    def test_growth_beyond_baseline_is_still_scored(self, state, monkeypatch):
+        # A genuine bogus jump beyond the known catalogue is still caught,
+        # even when an old backlog sits below the baseline.
+        from memanga.downloader import check_for_updates
+
+        state.add_downloaded_chapter("Blue Lock", "1")
+        state.set_catalogue_baseline("Blue Lock", 344.0)
+        # Source suddenly re-numbers far past the catalogue high.
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning(
+                [float(n) for n in range(1, 345)] + [900.0, 950.0, 999.0]
+            ),
+        })
+
+        new = check_for_updates(BLUE_LOCK_MANGA, state)
+
+        record = state.get_suspicious_batch("Blue Lock")
+        assert record is not None
+        # Only the newly-appeared chapters beyond 344 are held back; the
+        # existing backlog (2..344) is still offered.
+        assert record["chapters"] == ["900", "950", "999"]
+        assert [c.number for c in new] == [str(n) for n in range(2, 345)]
+        # Baseline stays at the trusted 344 — not advanced past the jump.
+        assert state.get_catalogue_baseline("Blue Lock") == 344.0
+
+    def test_baseline_advances_on_normal_growth(self, state, monkeypatch):
+        # A first check with no download baseline snapshots the catalogue;
+        # later growth is measured from that snapshot.
+        from memanga.downloader import check_for_updates
+
+        # Fresh manual manga, nothing downloaded yet: guard doesn't run but
+        # the catalogue is snapshotted as trusted.
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 345)]),
+        })
+        check_for_updates(BLUE_LOCK_MANGA, state)
+        assert state.get_catalogue_baseline("Blue Lock") == 344.0
+
+        # Now one chapter is downloaded and the source grows modestly.
+        state.add_downloaded_chapter("Blue Lock", "1")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([float(n) for n in range(1, 354)]),
+        })
+        check_for_updates(BLUE_LOCK_MANGA, state)
+        assert state.get_suspicious_batch("Blue Lock") is None
+        assert state.get_catalogue_baseline("Blue Lock") == 353.0
+
+    def test_mangafire_jump_still_flagged_with_cached_catalogue(self, state, monkeypatch):
+        # #35 must be preserved: a manga tracked at 52.3 whose cached
+        # catalogue is also ~52 still flags the bogus jump to 148.
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _cache_catalogue(state, "Tomodachi", [50, 51, 52, 52.3])
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3] + MANGAFIRE_BOGUS_BATCH),
+        })
+
+        new = check_for_updates(SINGLE_SOURCE_MANGA, state)
+
+        assert new == []
+        assert state.get_suspicious_batch("Tomodachi") is not None
+
+    def test_withheld_batch_not_trusted_from_gui_cache_on_next_check(self, state, monkeypatch):
+        # GUI checks cache `all_chapters`, including chapters that were
+        # withheld as suspicious. That cache must not become a trusted
+        # catalogue baseline while the suspicious record is active.
+        from memanga.downloader import check_for_updates
+
+        state.set_last_chapter("Tomodachi", "52.3")
+        _patch_scrapers(monkeypatch, {
+            "primary.test": _scraper_returning([52.3] + MANGAFIRE_BOGUS_BATCH),
+        })
+
+        first_new, first_all = check_for_updates(SINGLE_SOURCE_MANGA, state, return_all=True)
+        assert first_new == []
+        first_record = state.get_suspicious_batch("Tomodachi")
+        assert first_record is not None
+
+        state.set_available_chapters("Tomodachi", [
+            {"number": c.number, "title": c.title, "source": c.source,
+             "source_url": c.source_url, "is_backup": c.is_backup, "url": c.url}
+            for c in first_all
+        ])
+
+        second_new, _ = check_for_updates(SINGLE_SOURCE_MANGA, state, return_all=True)
+
+        assert second_new == []
+        second_record = state.get_suspicious_batch("Tomodachi")
+        assert second_record is not None
+        assert second_record["chapters"] == first_record["chapters"]
+
+
+# -------------------------------------------------------------------------
 # State persistence of the suspicious record
 # -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Sync the cli branch with CLI-relevant v0.4.0 release changes before tagging.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Docs
- [ ] Scraper added or fixed
- [x] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Testing

- `python -m pytest tests/unit` (685 passed)
- `python -m compileall -q memanga`
- `git diff --check`
- CLI branch invariant checks: no GUI package/tests, no Docker publishing/release workflows, no PySide6 or `memanga-gui`, version `0.4.0`
- `sudo docker build -t memanga:cli-v0.4.0-sync .`
- Docker smoke: `--help`, `--gui` rejection, no `memanga.gui`, no `PySide6`

## Related issues

Closes #