### PR TITLE
chore(release): prepare v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-02
+
 ### Fixed
 - #142 MangaFire now signs each JSON API call with a per-request token, so
   search, chapter listing, and page fetches no longer fail with HTTP 403.

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.4.0"
+version = "0.4.1"
 description = "Automatic manga downloader with Kindle support"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- Bump release metadata to 0.4.1.
- Move the MangaFire API signing fix into the v0.4.1 changelog section.

## Tests
- `venv/bin/python -m compileall -q memanga`
- `venv/bin/python -m pytest tests/unit/scrapers/test_mangafire.py tests/unit/scrapers/test_base_interface.py`
- `venv/bin/python -m pytest -m live tests/scrapers/live/test_live_parsing.py -k mangafire -v`