### PR TITLE
chore(release): sync cli for v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-08-02
+
+### Fixed
+- #142 MangaFire now signs each JSON API call with a per-request token, so
+  search, chapter listing, and page fetches no longer fail with HTTP 403.
+
 ## [0.4.0] - 2026-07-19
 
 ### Added

--- a/docs/SUPPORTED_SOURCES.md
+++ b/docs/SUPPORTED_SOURCES.md
@@ -20,7 +20,7 @@ Large sites with extensive manga libraries.
 |--------|------|-------|
 | mangadex.org | API | Largest fan translation library |
 | weebcentral.com | Playwright | 1000+ series, fast search |
-| mangafire.to | Playwright | VRF bypass + image descrambling |
+| mangafire.to | Playwright | VRF-signed API + image descrambling |
 | mangapill.com | Requests | Fast, no Cloudflare |
 | bato.to, batoto.to | Requests | Community-driven |
 | comick.io, comick.dev | Requests | Clean API |

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"

--- a/memanga/scrapers/mangafire.py
+++ b/memanga/scrapers/mangafire.py
@@ -8,20 +8,21 @@ endpoints to an SPA under /title/hid-slug backed by a JSON API:
 - GET /api/titles/{hid}/chapters?language=en&limit=100&page=N  (chapter list)
 - GET /api/chapters/{chapter_id}                               (page image URLs)
 
-All work with plain HTTP (no VRF token or browser needed).
+All three are token-protected: a tokenless call is answered with HTTP 403
+``{"message": "Missing token."}``. Every request has to carry a ``vrf``
+query parameter minted by ``VRFGenerator`` below.
 
 Image descrambling based on:
 - https://github.com/f4rh4d-4hmed/MangaFire-API
 """
 
 import re
-import json
 import threading
 import time
 from io import BytesIO
-from typing import List, Optional, Dict, Tuple
+from typing import List, Optional, Dict, Sequence, Tuple
 from pathlib import Path
-from urllib.parse import quote, urlparse
+from urllib.parse import parse_qsl, urlencode, urlparse
 from concurrent.futures import ThreadPoolExecutor
 
 from PIL import Image
@@ -46,6 +47,14 @@ except ImportError:
     CLOUDSCRAPER_AVAILABLE = False
 
 import requests
+
+
+BASE_URL = "https://mangafire.to"
+
+# The SPA's axios client is created with baseURL "/api", so the path it
+# signs is relative to that prefix: /api/titles/dkw/chapters is signed as
+# /titles/dkw/chapters. Strip the prefix before minting a token.
+API_PREFIX = "/api"
 
 
 class MangaFireError(RuntimeError):
@@ -142,13 +151,48 @@ class ImageDescrambler:
 _vrf_thread_local = threading.local()
 
 
+# Asks the site's own generator to sign one API call. Returns a wrapper
+# object rather than the bare token so a thrown JS error crosses back as
+# data instead of a Playwright evaluation failure — and so a genuinely
+# unprotected endpoint (null) stays distinguishable from a failure.
+_TOKEN_SCRIPT = """
+([path, pairs]) => {
+    const generate = window.getProtectionToken;
+    if (typeof generate !== 'function') {
+        return {error: 'window.getProtectionToken is not available'};
+    }
+    const params = {};
+    for (const [key, value] of pairs) { params[key] = value; }
+    return Promise.resolve()
+        .then(() => generate(path, params))
+        .then(token => ({token: token == null ? null : String(token)}))
+        .catch(err => ({error: String(err)}));
+}
+"""
+
+
 # ==================== VRF Token Generator ====================
 class VRFGenerator:
     """
-    Generates VRF tokens by capturing them from actual page requests.
+    Mints the ``vrf`` tokens MangaFire's JSON API requires.
 
-    MangaFire uses VRF tokens to protect AJAX endpoints. This class uses
-    Playwright to load pages and intercept the VRF tokens from requests.
+    MangaFire signs every protected API call with a ``vrf`` query
+    parameter derived from that call's own path and parameters, so tokens
+    are single-purpose: replaying the token minted for
+    ``/titles?keyword=one piece`` against ``keyword=naruto`` is answered
+    with HTTP 403 ``{"message": "Invalid token."}``.
+
+    The signing routine ships inside MangaFire's VM-obfuscated bundle,
+    which exposes it as ``window.getProtectionToken(path, params)``. We
+    call that function in a headless page instead of reimplementing the
+    cipher in Python: both the algorithm and the per-response key blob the
+    site hands its SPA can be rotated at any time, and a reimplementation
+    would then mint rejected tokens with no obvious cause.
+
+    The browser stays on the *token* path only. Minted tokens are plain
+    strings that replay fine over the normal ``requests`` session with no
+    browser cookies, so chapter listing, page extraction and image
+    downloads all keep running on ordinary HTTP.
 
     Uses ThreadPoolExecutor to run Playwright in a separate thread,
     avoiding conflicts with asyncio event loops (e.g., from rich library).
@@ -178,7 +222,9 @@ class VRFGenerator:
         if self._initialized:
             return
 
-        self._pages_data_cache: Dict[str, dict] = {}
+        # Tokens are a pure function of path + params, so the same lookup
+        # never needs a second browser round-trip within a run.
+        self._token_cache: Dict[Tuple, Optional[str]] = {}
         self._initialized = True
 
     def _ensure_browser_in_thread(self):
@@ -207,7 +253,7 @@ class VRFGenerator:
         # so sync_playwright().start() doesn't raise "already started".
         self._close_in_thread()
 
-        print("[MangaFire] Starting Firefox browser (bypasses bot detection)...")
+        print("[MangaFire] Starting the browser used to mint API tokens...")
         pw = sync_playwright().start()
         try:
             browser = pw.firefox.launch(headless=True)
@@ -231,91 +277,92 @@ class VRFGenerator:
         _vrf_thread_local.page = page
         return _vrf_thread_local.page
 
-    def _get_chapter_pages_in_thread(self, chapter_url: str) -> Tuple[List[str], List[int]]:
-        """Get page URLs and scramble offsets - runs in executor thread."""
-        page = self._ensure_browser_in_thread()
+    def _ensure_token_page_in_thread(self):
+        """Ensure the browser page has MangaFire's token generator loaded.
 
-        image_urls = []
-        offsets = []
-        captured_images = []
-
-        def handle_route(route):
-            """Intercept AJAX requests and capture image data."""
-            nonlocal captured_images
-            response = route.fetch()
-            url = route.request.url
-
-            if 'mangafire.to' in url and 'ajax/read' in url:
-                if '/chapter/' in url or '/volume/' in url:
-                    try:
-                        body = response.body().decode('utf-8')
-                        data = json.loads(body)
-                        if isinstance(data.get('result'), dict) and 'images' in data['result']:
-                            captured_images = data['result']['images']
-                            print(f"[MangaFire] Captured {len(captured_images)} images from AJAX")
-                    except Exception as e:
-                        print(f"[MangaFire] AJAX parse error: {e}")
-
-            route.fulfill(response=response)
-
-        # Set up route interception
-        page.route('**/ajax/**', handle_route)
-
-        try:
-            print(f"[MangaFire] Loading chapter page: {chapter_url}")
-            page.goto(chapter_url, wait_until='domcontentloaded', timeout=60000)
-
-            # Wait for AJAX to complete
-            print("[MangaFire] Waiting for AJAX response...")
-            page.wait_for_timeout(15000)  # 15 seconds for AJAX
-
-            if captured_images:
-                for img_data in captured_images:
-                    if isinstance(img_data, list) and len(img_data) >= 1:
-                        url = img_data[0]
-                        # Offset is typically the 3rd element (index 2)
-                        offset = img_data[2] if len(img_data) > 2 else 0
-                        if not isinstance(offset, int):
-                            offset = 0
-
-                        image_urls.append(url)
-                        offsets.append(offset)
-
-                # Cache the result
-                self._pages_data_cache[chapter_url] = {
-                    'urls': image_urls,
-                    'offsets': offsets
-                }
-
-                print(f"[MangaFire] Found {len(image_urls)} pages")
-            else:
-                print("[MangaFire] No page data captured from browser")
-
-        except Exception as e:
-            print(f"[MangaFire] Browser error: {e}")
-        finally:
-            # Remove route handler
-            page.unroute('**/ajax/**')
-
-        return image_urls, offsets
-
-    def get_chapter_pages(self, chapter_url: str) -> Tuple[List[str], List[int]]:
+        The generator is installed by the site's own bundle, so the page
+        has to sit on a MangaFire document. One load serves every
+        subsequent mint — after that a token costs a single evaluate().
         """
-        Get page URLs and scramble offsets for a chapter.
+        page = self._ensure_browser_in_thread()
+        if getattr(_vrf_thread_local, 'token_page_ready', False):
+            return page
+
+        print("[MangaFire] Loading the site's token generator...")
+        page.goto(BASE_URL, wait_until='domcontentloaded', timeout=60000)
+        page.wait_for_function(
+            "() => typeof window.getProtectionToken === 'function'",
+            timeout=60000,
+        )
+        _vrf_thread_local.token_page_ready = True
+        return page
+
+    def _mint_token_in_thread(self, api_path: str,
+                              params: List[Tuple[str, str]]) -> Optional[str]:
+        """Sign one API call - runs in executor thread."""
+        page = self._ensure_token_page_in_thread()
+        result = page.evaluate(_TOKEN_SCRIPT, [api_path, [list(p) for p in params]])
+
+        detail = None
+        if not isinstance(result, dict):
+            detail = f"unexpected generator result: {result!r}"
+        elif result.get('error'):
+            detail = result['error']
+        if detail:
+            raise MangaFireError(
+                f"MangaFire token generation failed for {api_path}: {detail}"
+            )
+        return result.get('token')
+
+    def get_token(self, api_path: str,
+                  params: Sequence[Tuple[str, str]] = ()) -> Optional[str]:
+        """
+        Return the ``vrf`` token for one API call.
+
+        ``api_path`` is relative to the API prefix (``/titles``, not
+        ``/api/titles``) and ``params`` are the call's other query
+        parameters, decoded. ``None`` means MangaFire does not protect
+        that endpoint - its generator returns null for those (``/me``,
+        ``/top-titles``) and the request must then be sent unsigned.
 
         Dispatches to executor thread to avoid asyncio conflicts.
         """
+        key = (api_path, tuple(params))
         # Check cache first (no thread needed)
-        if chapter_url in self._pages_data_cache:
-            cached = self._pages_data_cache[chapter_url]
-            return cached['urls'], cached['offsets']
+        if key in self._token_cache:
+            return self._token_cache[key]
 
-        return self._run_serialized(
-            self._get_chapter_pages_in_thread, chapter_url, timeout=120,
+        token = self._run_serialized(
+            self._mint_token_in_thread, api_path, list(params), timeout=120,
         )
+        self._token_cache[key] = token
+        return token
+
+    def invalidate(self):
+        """Drop cached tokens and reload the generator before the next mint.
+
+        MangaFire keys the generator off a config blob handed out with
+        each document, so a page left open long enough can start minting
+        tokens the server no longer accepts. A rejected token is the only
+        signal we get, so treat it as "reload the page and re-mint".
+        """
+        self._token_cache.clear()
+        try:
+            self._run_serialized(self._reset_token_page_in_thread, timeout=10)
+        except Exception:
+            pass
+
+    def _reset_token_page_in_thread(self):
+        """Force the next mint to reload the page - executor-thread only."""
+        if hasattr(_vrf_thread_local, 'token_page_ready'):
+            del _vrf_thread_local.token_page_ready
 
     def _close_in_thread(self):
         """Clean up browser resources - runs in executor thread."""
+        # The generator lives in the page being torn down, so the next
+        # mint has to load it again.
+        self._reset_token_page_in_thread()
+
         try:
             if hasattr(_vrf_thread_local, 'page'):
                 _vrf_thread_local.page.close()
@@ -352,7 +399,7 @@ class VRFGenerator:
             pass
 
         # Clear cache to free memory
-        self._pages_data_cache.clear()
+        self._token_cache.clear()
 
     def restart(self):
         """Restart browser (close and clear state so next call re-opens)."""
@@ -377,20 +424,20 @@ class MangaFireScraper(BaseScraper):
     Scraper for MangaFire.to
 
     Features:
-    - Direct AJAX API access (faster, no browser needed for most operations)
-    - VRF bypass via Playwright (fallback for protected endpoints)
+    - JSON API access, signed with a per-request VRF token
     - Image descrambling for protected images
     - Multi-language support (en, es, fr, ja, pt, etc.)
     """
 
     name = "mangafire"
-    base_url = "https://mangafire.to"
+    base_url = BASE_URL
 
     # Supported languages
     LANGUAGES = ['en', 'es', 'es-la', 'fr', 'ja', 'pt', 'pt-br']
 
-    # Search uses the JSON API directly (see search() below).
-    # Chapter-pages route through VRFGenerator's own _run_serialized.
+    # Every API call is signed in _api_get_json(). Token minting routes
+    # through VRFGenerator's own _run_serialized; image downloads and the
+    # API fetches themselves stay on the plain session.
 
     def __init__(self):
         super().__init__()
@@ -436,19 +483,114 @@ class MangaFireScraper(BaseScraper):
             return str(int(value))
         return str(value).strip()
 
-    def _api_get_json(self, url: str) -> dict:
-        """Fetch a MangaFire API endpoint and raise useful scraper errors."""
+    def _split_api_url(self, url: str) -> Tuple[str, List[Tuple[str, str]]]:
+        """Split a MangaFire API URL into the path and params to sign.
+
+        The path is returned relative to ``API_PREFIX`` because that is
+        what the site's generator signs. Any ``vrf`` already on the URL is
+        dropped: a token covers the request's *other* parameters, so
+        signing over a previous token could never validate.
+        """
+        parsed = urlparse(url)
+        path = parsed.path
+        if path.startswith(API_PREFIX):
+            path = path[len(API_PREFIX):]
+        params = [
+            (key, value)
+            for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+            if key != 'vrf'
+        ]
+        return path, params
+
+    def _signed_api_url(self, api_path: str, params: List[Tuple[str, str]],
+                        token: Optional[str]) -> str:
+        """Rebuild the request URL with its ``vrf`` token appended."""
+        query = list(params)
+        if token:
+            query.append(('vrf', token))
+        suffix = f"?{urlencode(query)}" if query else ''
+        return f"{self.base_url}{API_PREFIX}{api_path}{suffix}"
+
+    def _vrf_token(self, api_path: str, params: List[Tuple[str, str]]
+                   ) -> Tuple[Optional[str], Optional[str]]:
+        """Mint the token for one API call, returning ``(token, error)``.
+
+        A missing token is not fatal on its own - MangaFire leaves some
+        endpoints unprotected and its generator returns null for those -
+        so the failure is carried alongside instead of raised. If the
+        server then answers 403, the error explains that token generation,
+        not the request itself, is what actually broke.
+        """
         try:
-            response = self.session.get(url, timeout=30)
-        except requests.RequestException as e:
-            raise MangaFireError(f"MangaFire request failed for {url}: {e}") from e
+            return get_vrf_generator().get_token(api_path, params), None
         except Exception as e:
-            raise MangaFireError(f"MangaFire request failed for {url}: {e}") from e
+            return None, str(e)
+
+    def _api_error_message(self, url: str, status: int, token: Optional[str],
+                           token_error: Optional[str]) -> str:
+        """Explain an API failure, naming the token step when it's to blame."""
+        message = f"MangaFire returned HTTP {status} for {url}"
+        if status != 403:
+            return message
+        if token_error:
+            return f"{message} (VRF token generation failed: {token_error})"
+        if not token:
+            return (f"{message} (endpoint is token-protected but MangaFire's "
+                    f"generator issued no VRF token)")
+        return f"{message} (MangaFire rejected the VRF token)"
+
+    def _is_token_403(self, response) -> bool:
+        """Decide whether a 403 blames the token rather than the caller.
+
+        MangaFire answers a bad token with ``{"message": "Invalid
+        token."}`` or ``{"message": "Missing token."}``, but a 403 can
+        also mean something a reload will never fix. Only the former is
+        worth a browser round-trip. A body we cannot read counts as
+        token-related: Cloudflare interstitials arrive that way, and one
+        wasted reload beats giving up on a recoverable failure.
+        """
+        try:
+            payload = response.json()
+        except Exception:
+            return True
+        if not isinstance(payload, dict):
+            return True
+        message = str(payload.get('message') or payload.get('error') or '')
+        if not message:
+            return True
+        return 'token' in message.lower()
+
+    def _api_get_json(self, url: str) -> dict:
+        """Fetch a MangaFire API endpoint and raise useful scraper errors.
+
+        Signs the call with a ``vrf`` token; a tokenless request is
+        answered with HTTP 403 ``{"message": "Missing token."}``. A
+        rejected token buys one retry against a freshly reloaded
+        generator, which is what recovers when MangaFire rotates the
+        config keying it mid-run.
+        """
+        api_path, params = self._split_api_url(url)
+
+        token, token_error = self._vrf_token(api_path, params)
+        response = self._api_get(url, api_path, params, token)
+
+        if (response.status_code == 403 and token_error is None
+                and self._is_token_403(response)):
+            # The generator answered, and the server still refused over
+            # the token. That is what a rotated config looks like from
+            # here - both for a token that was minted and refused, and
+            # for a stale generator that claimed the endpoint was
+            # unprotected (null token) when it is not. Reload it and
+            # sign the call once more before giving up. A generator that
+            # failed outright (token_error) gets no retry: the browser
+            # step is broken, so a second mint would fail the same way.
+            get_vrf_generator().invalidate()
+            token, token_error = self._vrf_token(api_path, params)
+            response = self._api_get(url, api_path, params, token)
 
         if response.status_code != 200:
-            raise MangaFireError(
-                f"MangaFire returned HTTP {response.status_code} for {url}"
-            )
+            raise MangaFireError(self._api_error_message(
+                url, response.status_code, token, token_error))
 
         try:
             return response.json()
@@ -456,6 +598,17 @@ class MangaFireScraper(BaseScraper):
             raise MangaFireError(
                 f"MangaFire returned a non-JSON response for {url}: {e}"
             ) from e
+
+    def _api_get(self, url: str, api_path: str,
+                 params: List[Tuple[str, str]], token: Optional[str]):
+        """Issue one signed API request, mapping transport errors."""
+        try:
+            return self.session.get(
+                self._signed_api_url(api_path, params, token), timeout=30)
+        except requests.RequestException as e:
+            raise MangaFireError(f"MangaFire request failed for {url}: {e}") from e
+        except Exception as e:
+            raise MangaFireError(f"MangaFire request failed for {url}: {e}") from e
 
     def _parse_chapter_url(self, chapter_url: str) -> Tuple[str, str, str]:
         """
@@ -507,7 +660,8 @@ class MangaFireScraper(BaseScraper):
         The browse page renders results client-side, but the SPA's own
         /api/titles endpoint returns the search payload directly.
         """
-        api_url = f"{self.base_url}/api/titles?keyword={quote(query, safe='')}"
+        api_url = (f"{self.base_url}/api/titles"
+                   f"?{urlencode({'keyword': query})}")
         data = self._api_get_json(api_url)
         items = data.get('items')
         if not isinstance(items, list):
@@ -620,55 +774,6 @@ class MangaFireScraper(BaseScraper):
                 return chapter.url
 
         raise MangaFireError(f"MangaFire chapter {wanted} not found for {manga_id}")
-
-    def _try_direct_ajax(self, manga_id: str, lang: str, chap_num: str) -> Tuple[List[str], List[int]]:
-        """
-        Try to fetch pages directly via AJAX (without VRF).
-
-        Some endpoints work without VRF, especially for older chapters.
-        """
-        image_urls = []
-        offsets = []
-
-        # Try different URL formats
-        url_formats = [
-            f"{self.base_url}/ajax/read/{manga_id}/chapter/{lang}/{chap_num}",
-            f"{self.base_url}/ajax/read/{manga_id}/{lang}/{chap_num}",
-        ]
-
-        for url in url_formats:
-            try:
-                print(f"[MangaFire] Trying direct AJAX: {url}")
-                response = self.session.get(url, timeout=30)
-
-                if response.status_code != 200:
-                    continue
-
-                data = response.json()
-
-                if data.get('status') == 200 and 'result' in data:
-                    result = data['result']
-                    images = result.get('images', [])
-
-                    for img_data in images:
-                        if isinstance(img_data, list) and len(img_data) >= 1:
-                            img_url = img_data[0]
-                            offset = img_data[2] if len(img_data) > 2 else 0
-                            if not isinstance(offset, int):
-                                offset = 0
-
-                            image_urls.append(img_url)
-                            offsets.append(offset)
-
-                    if image_urls:
-                        print(f"[MangaFire] Direct AJAX success! Found {len(image_urls)} pages")
-                        return image_urls, offsets
-
-            except Exception as e:
-                print(f"[MangaFire] Direct AJAX failed for {url}: {e}")
-                continue
-
-        return [], []
 
     def get_pages(self, chapter_url: str) -> List[str]:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.4.0"
+version = "0.4.1"
 description = "Automatic manga downloader with Kindle support (CLI)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/scrapers/live/test_live_parsing.py
+++ b/tests/scrapers/live/test_live_parsing.py
@@ -69,6 +69,11 @@ PARSING_PROBES = {
     # chapters, so probe a title that is actually hosted there.
     "mangadex.org": ProbeSpec("API client", query="chainsaw man"),
     "mangapill.com": ProbeSpec("Simple HTTP aggregator", query="one piece"),
+    # Signs every API call with a vrf token minted in a headless browser
+    # (issue #142). This probe is what catches MangaFire changing that
+    # scheme again — without a valid token every stage 403s at once.
+    "mangafire.to": ProbeSpec("MangaFire (vrf-signed JSON API)",
+                                query="one piece"),
     "mangapark1.com": ProbeSpec("MangaPark", query="one piece"),
     "tcbonepiecechapters.com": ProbeSpec("TCB Scans (project list)",
                                            query="one piece"),

--- a/tests/unit/scrapers/test_base_interface.py
+++ b/tests/unit/scrapers/test_base_interface.py
@@ -193,8 +193,11 @@ class TestMangaFireSearchUsesJsonApi:
     `.info a[href*="/manga/"]` result links. The browse page the search
     bar redirects to renders results client-side under /title/hid-slug
     links, so that selector matched nothing and every search returned 0
-    results. search() must hit GET /api/titles?keyword=... over plain HTTP
-    instead - no browser involved at all.
+    results. search() must hit GET /api/titles?keyword=... instead.
+
+    Issue #142 added a `vrf` token to that call, so the browser is back -
+    but only to mint the token. The result set still comes from one JSON
+    request, never from scraped HTML.
     """
 
     class _FakeResponse:
@@ -215,8 +218,20 @@ class TestMangaFireSearchUsesJsonApi:
             self.urls.append(url)
             return TestMangaFireSearchUsesJsonApi._FakeResponse(self._payload)
 
-    def test_search_hits_titles_api_with_encoded_keyword(self):
+    class _StubVRF:
+        def __init__(self, token="TOKEN"):
+            self._token = token
+
+        def get_token(self, api_path, params=()):
+            return self._token
+
+        def invalidate(self):
+            pass
+
+    def test_search_hits_titles_api_with_encoded_keyword(self, monkeypatch):
         from memanga.scrapers import mangafire as mf
+
+        monkeypatch.setattr(mf, "get_vrf_generator", lambda: self._StubVRF())
 
         scraper = mf.MangaFireScraper()
         scraper.session = self._FakeSession({
@@ -230,14 +245,18 @@ class TestMangaFireSearchUsesJsonApi:
 
         results = scraper.search("blue lock/2")
 
+        # One JSON call, keyword still escaped so the slash can't break
+        # out into the path, now signed with the vrf token.
         assert scraper.session.urls == [
-            "https://mangafire.to/api/titles?keyword=blue%20lock%2F2",
+            "https://mangafire.to/api/titles?keyword=blue+lock%2F2&vrf=TOKEN",
         ]
         assert results and results[0].url == "https://mangafire.to/title/abc-blue-lock"
 
-    def test_search_does_not_launch_firefox(self, monkeypatch):
-        """Hard guard: calling MangaFireScraper.search() must NOT start
-        Playwright at all - search works over plain HTTP.
+    def test_search_only_touches_the_browser_to_mint_a_token(self, monkeypatch):
+        """Hard guard: the browser is a token source, not the search
+        transport. With an unprotected endpoint (MangaFire's generator
+        returns null) the whole path stays browser-free, and results
+        never come from a rendered page.
         """
         from memanga.scrapers import mangafire as mf
 
@@ -258,11 +277,15 @@ class TestMangaFireSearchUsesJsonApi:
 
         import playwright.sync_api as pwapi
         monkeypatch.setattr(pwapi, "sync_playwright", lambda: _BoomPW())
+        monkeypatch.setattr(mf, "get_vrf_generator",
+                            lambda: self._StubVRF(token=None))
 
         scraper = mf.MangaFireScraper()
         scraper.session = self._FakeSession({"items": [], "meta": {}})
         scraper.search("x")
+
         assert called["n"] == 0, "search must stay browser-free"
+        assert scraper.session.urls == ["https://mangafire.to/api/titles?keyword=x"]
 
 
 class TestWeebCentralSearchHitsDataEndpoint:

--- a/tests/unit/scrapers/test_mangafire.py
+++ b/tests/unit/scrapers/test_mangafire.py
@@ -21,13 +21,48 @@ class _Session:
     def __init__(self, responses):
         self.responses = list(responses)
         self.calls = 0
+        self.urls = []
 
     def get(self, *args, **kwargs):
         self.calls += 1
+        self.urls.append(args[0] if args else kwargs.get("url"))
         item = self.responses.pop(0)
         if isinstance(item, BaseException):
             raise item
         return item
+
+
+class _StubVRF:
+    """Stand-in for the Playwright-backed token generator.
+
+    Issue #142: every MangaFire API call is signed now, so a scraper test
+    that didn't stub this would launch a real Firefox.
+    """
+
+    def __init__(self, token="TOKEN", error=None):
+        self._token = token
+        self._error = error
+        self.minted = []
+        self.invalidations = 0
+
+    def get_token(self, api_path, params=()):
+        self.minted.append((api_path, tuple(params)))
+        if self._error:
+            raise self._error
+        return self._token
+
+    def invalidate(self):
+        self.invalidations += 1
+
+
+@pytest.fixture(autouse=True)
+def stub_vrf(monkeypatch):
+    """Keep every test in this module off the real browser."""
+    from memanga.scrapers import mangafire as mf
+
+    stub = _StubVRF()
+    monkeypatch.setattr(mf, "get_vrf_generator", lambda: stub)
+    return stub
 
 
 class TestMangaFireGetChapters:
@@ -239,6 +274,331 @@ class TestMangaFireSearch:
 
         with pytest.raises(MangaFireError, match="HTTP 503"):
             scraper.search("one piece")
+
+
+class TestMangaFireVRFToken:
+    """Issue #142: MangaFire's JSON API answers tokenless calls with HTTP
+    403 {"message": "Missing token."}. Every API call must carry a `vrf`
+    parameter minted for that exact path + params - a token issued for one
+    query is rejected ("Invalid token.") on any other.
+    """
+
+    def test_search_signs_the_decoded_keyword(self, stub_vrf):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([_Response(payload={"items": []})])
+
+        scraper.search("one piece")
+
+        # Signed over the API-relative path and the decoded keyword.
+        assert stub_vrf.minted == [("/titles", (("keyword", "one piece"),))]
+        assert "vrf=TOKEN" in scraper.session.urls[0]
+
+    def test_chapter_list_signs_language_limit_and_page(self, stub_vrf):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={
+                "items": [{"id": 101, "number": 1, "name": ""}],
+                "meta": {"hasNext": False},
+            }),
+        ])
+
+        scraper.get_chapters("https://mangafire.to/title/abc-demo")
+
+        assert stub_vrf.minted == [(
+            "/titles/abc/chapters",
+            (("language", "en"), ("limit", "100"), ("page", "1")),
+        )]
+        # The full URL sent must carry exactly the signed params plus the
+        # token - a mismatch between what was signed and what was sent is
+        # what MangaFire rejects with "Invalid token.".
+        assert scraper.session.urls[0] == (
+            "https://mangafire.to/api/titles/abc/chapters"
+            "?language=en&limit=100&page=1&vrf=TOKEN"
+        )
+
+    def test_pages_sign_the_chapter_endpoint(self, stub_vrf):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={"data": {"pages": [{"url": "https://cdn/1.jpg"}]}}),
+        ])
+
+        scraper.get_pages("https://mangafire.to/api/chapters/123")
+
+        assert stub_vrf.minted == [("/chapters/123", ())]
+        assert scraper.session.urls[0] == (
+            "https://mangafire.to/api/chapters/123?vrf=TOKEN"
+        )
+
+    def test_stale_token_on_a_saved_url_is_replaced_not_signed_over(
+            self, stub_vrf):
+        """A vrf carried on a saved URL must not become part of the
+        plaintext - the token covers the request's *other* params, so
+        signing over an old one could never validate."""
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={"data": {"pages": [{"url": "https://cdn/1.jpg"}]}}),
+        ])
+
+        scraper.get_pages("https://mangafire.to/api/chapters/123?vrf=EXPIRED")
+
+        assert stub_vrf.minted == [("/chapters/123", ())]
+        assert "EXPIRED" not in scraper.session.urls[0]
+        assert "vrf=TOKEN" in scraper.session.urls[0]
+
+    def test_unprotected_endpoint_is_sent_unsigned(self, monkeypatch):
+        """MangaFire's generator returns null for endpoints it doesn't
+        protect; those must go out without an empty vrf tacked on."""
+        from memanga.scrapers import mangafire as mf
+
+        monkeypatch.setattr(mf, "get_vrf_generator", lambda: _StubVRF(token=None))
+
+        scraper = mf.MangaFireScraper()
+        scraper.session = _Session([
+            _Response(payload={"data": {"pages": [{"url": "https://cdn/1.jpg"}]}}),
+        ])
+
+        scraper.get_pages("https://mangafire.to/api/chapters/123")
+
+        assert scraper.session.urls[0] == "https://mangafire.to/api/chapters/123"
+
+    def test_rejected_token_reloads_the_generator_and_retries_once(
+            self, stub_vrf):
+        from memanga.scrapers.mangafire import MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(status_code=403, payload={"message": "Invalid token."}),
+            _Response(payload={"data": {"pages": [{"url": "https://cdn/1.jpg"}]}}),
+        ])
+
+        pages = scraper.get_pages("https://mangafire.to/api/chapters/123")
+
+        assert pages == ["https://cdn/1.jpg"]
+        assert stub_vrf.invalidations == 1
+        assert scraper.session.calls == 2
+
+    def test_persistent_403_raises_after_a_single_retry(self, stub_vrf):
+        from memanga.scrapers.mangafire import MangaFireError, MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(status_code=403, payload={"message": "Invalid token."}),
+            _Response(status_code=403, payload={"message": "Invalid token."}),
+        ])
+
+        with pytest.raises(MangaFireError, match="rejected the VRF token"):
+            scraper.search("one piece")
+
+        assert scraper.session.calls == 2
+
+    def test_non_token_403_is_not_retried(self, stub_vrf):
+        """A 403 whose body doesn't blame the token (a plain block, a
+        rate limit) can't be fixed by reloading the generator, so it must
+        fail fast instead of spending a browser round-trip on it."""
+        from memanga.scrapers.mangafire import MangaFireError, MangaFireScraper
+
+        scraper = MangaFireScraper()
+        scraper.session = _Session([
+            _Response(status_code=403, payload={"message": "Forbidden"}),
+        ])
+
+        with pytest.raises(MangaFireError, match="HTTP 403"):
+            scraper.search("one piece")
+
+        assert scraper.session.calls == 1
+        assert stub_vrf.invalidations == 0
+
+    def test_stale_null_token_recovers_after_a_reload(self, monkeypatch):
+        """A generator whose config went stale can wrongly report an
+        endpoint as unprotected (null token). The tokenless call 403s with
+        a token message, so one reload must still get a chance to mint a
+        real token and recover."""
+        from memanga.scrapers import mangafire as mf
+
+        class _SequenceVRF:
+            def __init__(self, tokens):
+                self._tokens = list(tokens)
+                self.invalidations = 0
+
+            def get_token(self, api_path, params=()):
+                return self._tokens.pop(0)
+
+            def invalidate(self):
+                self.invalidations += 1
+
+        stub = _SequenceVRF([None, "FRESH"])
+        monkeypatch.setattr(mf, "get_vrf_generator", lambda: stub)
+
+        scraper = mf.MangaFireScraper()
+        scraper.session = _Session([
+            _Response(status_code=403, payload={"message": "Missing token."}),
+            _Response(payload={"data": {"pages": [{"url": "https://cdn/1.jpg"}]}}),
+        ])
+
+        pages = scraper.get_pages("https://mangafire.to/api/chapters/123")
+
+        assert pages == ["https://cdn/1.jpg"]
+        assert stub.invalidations == 1
+        assert scraper.session.calls == 2
+        assert "vrf=FRESH" in scraper.session.urls[1]
+
+    def test_403_names_token_generation_as_the_cause_when_it_failed(
+            self, monkeypatch):
+        """Without this the user just sees a bare 403 and has no way to
+        tell that the browser step, not the site, is what broke."""
+        from memanga.scrapers import mangafire as mf
+
+        monkeypatch.setattr(
+            mf, "get_vrf_generator",
+            lambda: _StubVRF(error=RuntimeError("Playwright not available")))
+
+        scraper = mf.MangaFireScraper()
+        scraper.session = _Session([
+            _Response(status_code=403, payload={"message": "Missing token."}),
+        ])
+
+        with pytest.raises(mf.MangaFireError) as exc:
+            scraper.search("one piece")
+
+        message = str(exc.value)
+        assert "HTTP 403" in message
+        assert "Playwright not available" in message
+        # No token was ever issued, so the retry would be pointless.
+        assert scraper.session.calls == 1
+
+
+class TestVRFGeneratorTokens:
+    """Token minting itself, with the browser round-trip stubbed out."""
+
+    def _generator(self, monkeypatch, mint):
+        from memanga.scrapers import mangafire as mf
+
+        gen = mf.VRFGenerator()
+        gen._token_cache.clear()
+        # Run whatever the caller hands the executor, in this thread. A
+        # stub that ignored `fn` and always minted would let a
+        # wrong-signature dispatch pass unnoticed - invalidate() swallows
+        # every exception, so the resulting TypeError would look like a
+        # successful reload.
+        monkeypatch.setattr(
+            mf.VRFGenerator, "_run_serialized",
+            classmethod(lambda cls, fn, *a, timeout, **kw: fn(*a, **kw)))
+        monkeypatch.setattr(
+            mf.VRFGenerator, "_mint_token_in_thread",
+            lambda self, api_path, params: mint(api_path, params))
+        return gen
+
+    def test_tokens_are_cached_per_path_and_params(self, monkeypatch):
+        """A library refresh re-checks the same endpoints repeatedly; each
+        distinct call should cost one browser round-trip, not one per
+        request."""
+        calls = []
+
+        def mint(api_path, params):
+            calls.append((api_path, tuple(params)))
+            return f"tok-{len(calls)}"
+
+        gen = self._generator(monkeypatch, mint)
+
+        first = gen.get_token("/titles", [("keyword", "one piece")])
+        again = gen.get_token("/titles", [("keyword", "one piece")])
+        other = gen.get_token("/titles", [("keyword", "naruto")])
+
+        assert first == again == "tok-1"
+        assert other == "tok-2"
+        assert len(calls) == 2
+
+    def test_invalidate_drops_cached_tokens(self, monkeypatch):
+        counter = {"n": 0}
+
+        def mint(api_path, params):
+            counter["n"] += 1
+            return f"tok-{counter['n']}"
+
+        gen = self._generator(monkeypatch, mint)
+
+        assert gen.get_token("/titles", [("keyword", "x")]) == "tok-1"
+        gen.invalidate()
+        assert gen.get_token("/titles", [("keyword", "x")]) == "tok-2"
+
+    def test_invalidate_dispatches_reset_and_forces_a_page_reload(
+            self, monkeypatch):
+        """invalidate() must both drop cached tokens and run the reset in
+        the executor thread so the next mint reloads MangaFire's config.
+
+        Guards against the reset silently not running: the earlier test
+        only proved the cache cleared, and because invalidate() swallows
+        every exception a misdispatched reset would look like success.
+        Here `_run_serialized` actually invokes what it's handed, so the
+        real `_reset_token_page_in_thread` runs and must clear the
+        `token_page_ready` flag that gates the reload.
+        """
+        from memanga.scrapers import mangafire as mf
+
+        gen = mf.VRFGenerator()
+        gen._token_cache[("/titles", (("keyword", "x"),))] = "stale"
+
+        dispatched = []
+        real_reset = mf.VRFGenerator._reset_token_page_in_thread
+
+        def spy_reset(self):
+            dispatched.append(True)
+            return real_reset(self)
+
+        monkeypatch.setattr(
+            mf.VRFGenerator, "_run_serialized",
+            classmethod(lambda cls, fn, *a, timeout, **kw: fn(*a, **kw)))
+        monkeypatch.setattr(
+            mf.VRFGenerator, "_reset_token_page_in_thread", spy_reset)
+
+        # Simulate a page that has already loaded the generator, and make
+        # sure the flag doesn't leak to sibling tests regardless of path.
+        mf._vrf_thread_local.token_page_ready = True
+        try:
+            gen.invalidate()
+
+            assert dispatched == [True], "reset must run in the executor thread"
+            assert gen._token_cache == {}, "cached tokens must be dropped"
+            assert not hasattr(mf._vrf_thread_local, "token_page_ready"), \
+                "next mint must be forced to reload the generator page"
+        finally:
+            if hasattr(mf._vrf_thread_local, "token_page_ready"):
+                del mf._vrf_thread_local.token_page_ready
+
+    def test_generator_error_surfaces_as_scraper_error(self, monkeypatch):
+        from memanga.scrapers import mangafire as mf
+
+        class _Page:
+            def evaluate(self, script, arg):
+                return {"error": "TypeError: bad argument"}
+
+        gen = mf.VRFGenerator()
+        monkeypatch.setattr(mf.VRFGenerator, "_ensure_token_page_in_thread",
+                            lambda self: _Page())
+
+        with pytest.raises(mf.MangaFireError, match="TypeError: bad argument"):
+            gen._mint_token_in_thread("/titles", [("keyword", "x")])
+
+    def test_null_token_means_the_endpoint_is_unprotected(self, monkeypatch):
+        from memanga.scrapers import mangafire as mf
+
+        class _Page:
+            def evaluate(self, script, arg):
+                return {"token": None}
+
+        gen = mf.VRFGenerator()
+        monkeypatch.setattr(mf.VRFGenerator, "_ensure_token_page_in_thread",
+                            lambda self: _Page())
+
+        assert gen._mint_token_in_thread("/me", []) is None
 
 
 class TestVRFBrowserInitAtomicity:


### PR DESCRIPTION
## Summary
- Bump CLI release metadata to 0.4.1.
- Carry the shared MangaFire API signing fix and its scraper coverage to the CLI branch.

## Tests
- `venv/bin/python -m compileall -q memanga`
- `venv/bin/python -m pytest tests/unit/scrapers/test_mangafire.py tests/unit/scrapers/test_base_interface.py`
- `venv/bin/python -m pytest -m live tests/scrapers/live/test_live_parsing.py -k mangafire -v`