### PR TITLE
Add macOS Intel release asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,18 @@ jobs:
           - os: windows-latest
             artifact_name: MeManga.exe
             asset_name: MeManga-windows-x64.exe
+          # macos-latest is an Apple Silicon (arm64) runner.
           - os: macos-latest
             artifact_name: MeManga
             asset_name: MeManga-macos-arm64
+            target_arch: arm64
+          # macos-26-intel is GitHub's current standard x64 macOS runner
+          # image, so the x86_64 slice is built natively rather than
+          # cross-compiled from Apple Silicon.
+          - os: macos-26-intel
+            artifact_name: MeManga
+            asset_name: MeManga-macos-x64
+            target_arch: x86_64
           - os: ubuntu-latest
             artifact_name: MeManga
             asset_name: MeManga-linux-x64
@@ -62,7 +71,29 @@ jobs:
         # build_app.py produces a single-file binary under `release/`
         # (release/MeManga.exe on Windows, release/MeManga elsewhere)
         # and sweeps the build/ + dist/ scratch dirs afterwards.
+        #
+        # MEMANGA_TARGET_ARCH pins the macOS CPU slice (see
+        # packaging/memanga-release.spec). It is empty on Windows/Linux,
+        # where the spec ignores it and follows the build host.
+        env:
+          MEMANGA_TARGET_ARCH: ${{ matrix.target_arch }}
         run: python build_app.py
+
+      - name: Verify macOS artifact architecture
+        # Guard against the release silently shipping the wrong slice
+        # (issue #146). `lipo -archs` reports the Mach-O bootloader's
+        # architecture; it must equal the arch this matrix leg targets
+        # before the binary is renamed and uploaded.
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          bin="release/${{ matrix.artifact_name }}"
+          archs=$(lipo -archs "$bin")
+          echo "lipo -archs $bin -> $archs"
+          if [ "$archs" != "${{ matrix.target_arch }}" ]; then
+            echo "::error::Expected ${{ matrix.target_arch }} slice but built binary reports '$archs'"
+            exit 1
+          fi
 
       - name: Verify Playwright works inside the built executable (Windows)
         # Release gate for issue #28: run the actual artifact on the

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The fastest path is the release binary. Just double-click and you're in.
 |---|---|
 | Windows | [`MeManga-windows-x64.exe`](https://github.com/meellm/MeManga/releases/latest) |
 | macOS (Apple Silicon) | [`MeManga-macos-arm64`](https://github.com/meellm/MeManga/releases/latest) |
+| macOS (Intel) | [`MeManga-macos-x64`](https://github.com/meellm/MeManga/releases/latest) |
 | Linux (x86_64) | [`MeManga-linux-x64`](https://github.com/meellm/MeManga/releases/latest) |
 
 > **First launch downloads Firefox** (~80 MB download, one-time.)

--- a/packaging/memanga-release.spec
+++ b/packaging/memanga-release.spec
@@ -169,6 +169,20 @@ if _sys.platform == "darwin":
 else:
     _icon = os.path.join(project_root, "packaging", "icon.ico")
 
+# Target CPU architecture for the macOS build. PyInstaller only honours
+# `target_arch` on macOS ("x86_64", "arm64", or "universal2"); it is
+# ignored on Windows / Linux. Left unset it follows the build host,
+# which silently ships an Apple-Silicon-only binary whenever the runner
+# happens to be arm64 - leaving Intel Mac users with nothing to run
+# (issue #146). The release workflow pins it per-runner via the
+# MEMANGA_TARGET_ARCH env var so Intel and Apple Silicon each get an
+# explicit, verifiable slice. We deliberately do NOT default to
+# universal2: one non-universal wheel in the PySide6 + Playwright stack
+# would turn that into a fragile, silently-broken bundle.
+_target_arch = None
+if _sys.platform == "darwin":
+    _target_arch = os.environ.get("MEMANGA_TARGET_ARCH") or None
+
 exe = EXE(
     pyz,
     a.scripts,
@@ -190,7 +204,7 @@ exe = EXE(
     icon=_icon,
     disable_windowed_traceback=False,
     argv_emulation=False,
-    target_arch=None,
+    target_arch=_target_arch,
     codesign_identity=None,
     entitlements_file=None,
 )

--- a/tests/unit/test_release_packaging.py
+++ b/tests/unit/test_release_packaging.py
@@ -1,0 +1,88 @@
+"""Static guards for the macOS release packaging (issue #146).
+
+The release binary's CPU architecture follows PyInstaller's `target_arch`
+in `packaging/memanga-release.spec`. Left unset it silently follows the
+build host, so a run on an Apple Silicon runner shipped an arm64-only
+binary and left Intel Mac users with nothing to run. The fix pins the
+arch per-runner via the `MEMANGA_TARGET_ARCH` env var and ships two
+distinct macOS assets. These are cheap text/YAML checks because the real
+build only runs on a macOS CI runner and can't be exercised here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SPEC = REPO_ROOT / "packaging" / "memanga-release.spec"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+# The GitHub Actions expression the workflow uses to thread the matrix
+# arch into both the build env and the verification step.
+ARCH_EXPR = '${{ matrix.target_arch }}'
+
+
+def test_spec_parameterizes_target_arch_from_env():
+    """The spec must read MEMANGA_TARGET_ARCH (macOS only) and feed it to
+    the EXE's `target_arch`, rather than hard-coding None."""
+    text = SPEC.read_text(encoding="utf-8")
+    assert "MEMANGA_TARGET_ARCH" in text, \
+        "spec no longer reads the MEMANGA_TARGET_ARCH env var"
+    assert "target_arch=_target_arch" in text, \
+        "EXE() no longer wired to the parameterized _target_arch"
+    # The hard-coded default must be gone so an arm64 runner cannot ship
+    # an Apple-Silicon-only binary by accident.
+    assert "target_arch=None" not in text
+
+
+def _build_matrix():
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return data["jobs"]["build"]["strategy"]["matrix"]["include"]
+
+
+def test_workflow_ships_both_macos_arch_assets():
+    """Release must produce clearly named Intel and Apple Silicon assets,
+    each pinned to its own architecture."""
+    include = _build_matrix()
+    by_asset = {e["asset_name"]: e for e in include}
+
+    assert "MeManga-macos-arm64" in by_asset, "Apple Silicon asset dropped"
+    assert "MeManga-macos-x64" in by_asset, "Intel macOS asset missing"
+
+    arm = by_asset["MeManga-macos-arm64"]
+    intel = by_asset["MeManga-macos-x64"]
+    assert arm["target_arch"] == "arm64"
+    assert intel["target_arch"] == "x86_64"
+    # Intel slice must be built natively on an Intel runner image
+    # (macos-26-intel is GitHub's current standard x64 macOS runner),
+    # not cross-compiled from Apple Silicon.
+    assert intel["os"] == "macos-26-intel"
+
+
+def _step_named(fragment):
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    for step in data["jobs"]["build"]["steps"]:
+        if fragment in step.get("name", ""):
+            return step
+    return None
+
+
+def test_build_step_forwards_target_arch_env():
+    """The arch only reaches the spec if the build step exports it."""
+    step = _step_named("Build release executable")
+    assert step is not None
+    env = step.get("env", {})
+    assert env.get("MEMANGA_TARGET_ARCH") == ARCH_EXPR
+
+
+def test_workflow_verifies_architecture_before_upload():
+    """A macOS-gated step must assert the built slice matches the target
+    so a mis-built asset never reaches the release page."""
+    step = _step_named("Verify macOS artifact architecture")
+    assert step is not None, "architecture verification step missing"
+    assert step.get("if") == "runner.os == 'macOS'"
+    run = step.get("run", "")
+    assert "lipo -archs" in run
+    assert ARCH_EXPR in run


### PR DESCRIPTION
## Summary

Add a dedicated macOS Intel release asset so releases ship separate Apple Silicon and Intel binaries. The release workflow now builds the Intel asset on a native x64 macOS runner and checks the built slice before upload.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [x] Build / CI

## Checklist

- [ ] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Testing

- `venv/bin/python -m pytest tests/unit/test_release_packaging.py -q`
- Static workflow/spec parse and release step-ordering probe
- `git diff --check`

## Notes

The full local pytest suite was not completed; it was stopped after about 20 minutes while progressing through unrelated existing tests. The new release asset still needs to be proven by the tag-triggered release workflow on GitHub-hosted macOS runners.

## Related issues

Closes #146