### PR TITLE
Prepare v0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-08-06
+
+### Added
+- #147 macOS releases now publish separate Apple Silicon and Intel assets.
+
 ## [0.4.1] - 2026-08-02
 
 ### Fixed

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.4.1"
+version = "0.4.2"
 description = "Automatic manga downloader with Kindle support"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Prepare the v0.4.2 release metadata for the macOS Intel release asset update.

## Changes

- Bump package and module version metadata to 0.4.2.
- Add the v0.4.2 changelog entry for separate macOS Apple Silicon and Intel assets.

## Testing

- Not run (release requested without local test runs).
