### PR TITLE
Sync cli for v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-08-06
+
+### Changed
+- Version metadata synchronized for the v0.4.2 release.
+
 ## [0.4.1] - 2026-08-02
 
 ### Fixed

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.4.1"
+version = "0.4.2"
 description = "Automatic manga downloader with Kindle support (CLI)"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Sync the CLI branch release metadata for v0.4.2.

## Changes

- Bump CLI package and module version metadata to 0.4.2.
- Add a CLI branch changelog entry for the v0.4.2 release sync.

## Testing

- Not run (release requested without local test runs).
