### PR TITLE
fix(scraper): restore MangaBall API flow

### DIFF
--- a/memanga/scrapers/__init__.py
+++ b/memanga/scrapers/__init__.py
@@ -390,7 +390,7 @@ SCRAPERS = {
     "readhellsing.com": ZazaMangaScraper,
     "readoverlord.com": ZazaMangaScraper,
 
-    # MangaBall - Multi-language aggregator (Playwright, limited search)
+    # MangaBall - Multi-language aggregator (HTTP JSON API)
     "mangaball.net": MangaBallScraper,
 
     # MangaClash - Manga aggregator (Playwright + Madara + CF)

--- a/memanga/scrapers/mangaball.py
+++ b/memanga/scrapers/mangaball.py
@@ -2,153 +2,261 @@
 MangaBall scraper - Multi-language manga aggregator
 Site: mangaball.net
 
-Uses Playwright for JS rendering.
-Note: Search is broken (redirects to 404), but direct manga URLs work.
-Users must provide manga URL directly.
+MangaBall is an API-driven SPA (Laravel backend). The homepage and title
+pages ship only skeleton placeholders and pull their real data from JSON
+``/api/v1/`` endpoints guarded by a per-session CSRF token, while reader
+pages embed the page-image list as a JSON blob. This scraper talks to those
+endpoints directly over HTTP instead of rendering the SPA in a browser:
+
+* search  -> POST /api/v1/smart-search/search/
+* chapters -> POST /api/v1/chapter/chapter-listing-by-title-id/
+* pages   -> the ``chapterImages`` JSON array embedded in the reader page
 """
 
+import json
 import re
-from typing import List
+import time
+from typing import List, Optional
+from urllib.parse import urljoin
+
+import requests
 from bs4 import BeautifulSoup
 
-from .playwright_base import PlaywrightScraper
-from .base import Chapter, Manga
+from .base import BaseScraper, Chapter, Manga, _retry
 
 
-class MangaBallScraper(PlaywrightScraper):
+class MangaBallScraper(BaseScraper):
     """Scraper for MangaBall."""
-    
+
     name = "mangaball"
     base_url = "https://mangaball.net"
-    
-    def search(self, query: str) -> List[Manga]:
+
+    # Every /title-detail/<slug>-<id>/ URL ends in a 24-hex-char title id,
+    # which the chapter-listing API keys off. Anchor to the trailing
+    # "-<id>" segment so a hex-looking run earlier in the slug is ignored;
+    # allow an optional trailing slash, query, or fragment after it.
+    _TITLE_ID_RE = re.compile(r"-([0-9a-f]{24})(?:[/?#]|$)")
+
+    # Reader pages inline the ordered page list as `chapterImages = JSON.parse(`...`)`.
+    _CHAPTER_IMAGES_RE = re.compile(
+        r"chapterImages\s*=\s*JSON\.parse\(\s*`(.*?)`\s*\)", re.S
+    )
+
+    def __init__(self):
+        super().__init__()
+        self._csrf_token: Optional[str] = None
+
+    # CSRF / POST helpers
+
+    def _get_csrf_token(self, force: bool = False) -> Optional[str]:
+        """Fetch and cache the per-session CSRF token.
+
+        The /api/v1 endpoints validate an ``X-CSRF-TOKEN`` header against the
+        session cookie, so both are primed by loading a normal page once and
+        reading ``<meta name="csrf-token">``. The token is stable for the life
+        of the session cookie, so it is cached and only refreshed on demand.
         """
-        Search for manga.
-        Note: MangaBall's search is JS-heavy and often fails.
-        Returns results from homepage instead.
-        """
-        html = self._get_page_content(self.base_url, wait_time=3000)
+        if self._csrf_token and not force:
+            return self._csrf_token
+        html = self._get_html(self.base_url + "/")
         soup = BeautifulSoup(html, "html.parser")
-        
+        meta = soup.find("meta", attrs={"name": "csrf-token"})
+        self._csrf_token = meta.get("content") if meta else None
+        return self._csrf_token
+
+    def _api_post(self, path: str, data: dict) -> dict:
+        """Rate-limited form POST to an /api/v1 endpoint, returning JSON.
+
+        A stale session makes Laravel answer HTTP 419; on that we refresh the
+        CSRF token so the retry (driven by ``_retry``) posts a valid one.
+        """
+        url = urljoin(self.base_url, path)
+
+        def _do_post():
+            with self._rate_lock:
+                elapsed = time.time() - self._last_request
+                if elapsed < self._rate_limit:
+                    time.sleep(self._rate_limit - elapsed)
+                self._last_request = time.time()
+
+            resp = self.session.post(
+                url,
+                data=data,
+                headers={
+                    "X-CSRF-TOKEN": self._get_csrf_token() or "",
+                    "X-Requested-With": "XMLHttpRequest",
+                    "Referer": self.base_url + "/",
+                },
+                timeout=30,
+            )
+            if resp.status_code == 419:
+                # CSRF/session expired - refresh so the retry sends a fresh one.
+                self._get_csrf_token(force=True)
+            resp.raise_for_status()
+            return resp.json()
+
+        return _retry(
+            _do_post,
+            max_attempts=3,
+            base_delay=1.0,
+            exceptions=(requests.RequestException,),
+        )
+
+    # URL helpers
+
+    def _abs_url(self, href: str) -> str:
+        """Absolutize a site-relative URL and force https.
+
+        The chapter API returns ``http://`` links even though the site serves
+        https, so normalise the scheme to avoid a needless redirect per page.
+        """
+        url = urljoin(self.base_url + "/", href or "")
+        if url.startswith("http://"):
+            url = "https://" + url[len("http://"):]
+        return url
+
+    @classmethod
+    def _extract_title_id(cls, url: str) -> Optional[str]:
+        match = cls._TITLE_ID_RE.search(url or "")
+        return match.group(1) if match else None
+
+    # Search
+
+    def search(self, query: str) -> List[Manga]:
+        """Search for manga by title via the smart-search API."""
+        payload = self._api_post(
+            "/api/v1/smart-search/search/", {"search_input": query}
+        )
+        return self._parse_search(payload)
+
+    def _parse_search(self, payload: dict) -> List[Manga]:
+        """Parse a smart-search JSON response into Manga results."""
+        if (payload or {}).get("code") != 200:
+            return []
+
         results = []
         seen = set()
-        
-        # Find manga links on homepage
-        for link in soup.select('a[href*="title-detail"]'):
-            href = link.get('href', '')
-            if not href or href in seen:
+        for item in (payload.get("data") or {}).get("manga") or []:
+            href = item.get("url") or ""
+            title = (item.get("title") or "").strip()
+            if not href or not title:
                 continue
-            
-            # Normalize URL
-            if href.startswith('/'):
-                href = self.base_url + href
-            elif href.startswith('http://'):
-                href = href.replace('http://', 'https://')
-            
-            seen.add(href)
-            
-            # Get title
-            title = link.get('title', '') or link.get_text(strip=True)
-            if not title or len(title) < 2:
+
+            url = self._abs_url(href)
+            if url in seen:
                 continue
-            
-            # Filter by query if provided
-            if query and query.lower() not in title.lower():
-                continue
-            
-            # Get cover
-            img = link.select_one('img')
-            cover_url = None
-            if img:
-                cover_url = img.get('src') or img.get('data-src')
-            
+            seen.add(url)
+
             results.append(Manga(
                 title=title,
-                url=href,
-                cover_url=cover_url,
+                url=url,
+                cover_url=item.get("img") or None,
             ))
-        
+
         return results[:20]
-    
+
+    # Chapters
+
     def get_chapters(self, manga_url: str) -> List[Chapter]:
-        """Get all chapters for a manga."""
-        # Normalize URL
-        if manga_url.startswith('http://'):
-            manga_url = manga_url.replace('http://', 'https://')
-        
-        html = self._get_page_content(manga_url, wait_time=4000)
-        soup = BeautifulSoup(html, "html.parser")
-        
+        """Get all chapters for a manga via the chapter-listing API."""
+        title_id = self._extract_title_id(manga_url)
+        if not title_id:
+            return []
+
+        payload = self._api_post(
+            "/api/v1/chapter/chapter-listing-by-title-id/",
+            {"title_id": title_id, "userSettingsEnabled": "false"},
+        )
+        return self._parse_chapters(payload)
+
+    def _parse_chapters(self, payload: dict) -> List[Chapter]:
+        """Parse a chapter-listing JSON response into Chapter objects.
+
+        Each entry groups the same chapter number across translation groups and
+        languages; pick one readable translation per chapter (English first).
+        """
+        if (payload or {}).get("code") != 200:
+            return []
+
         chapters = []
         seen = set()
-        
-        # MangaBall structure: .chapter-block contains .chapter-number and links
-        for block in soup.select('.chapter-block'):
-            # Get chapter number from .chapter-number element
-            num_el = block.select_one('.chapter-number')
-            if not num_el:
+        for entry in payload.get("ALL_CHAPTERS") or []:
+            translation = self._pick_translation(entry.get("translations") or [])
+            if not translation:
                 continue
-            
-            num_text = num_el.get_text(strip=True)
-            match = re.search(r'ch\.?\s*(\d+\.?\d*)', num_text, re.I)
-            if not match:
-                match = re.search(r'(\d+\.?\d*)', num_text)
-            
-            chapter_num = match.group(1) if match else None
-            if not chapter_num:
+
+            url = self._abs_url(translation.get("url") or "")
+            if not translation.get("url") or url in seen:
                 continue
-            
-            # Get the first chapter-detail link in this block
-            link = block.select_one('a[href*="/chapter-detail/"]')
-            if not link:
-                continue
-            
-            href = link.get('href', '')
-            if not href or href in seen:
-                continue
-            
-            # Normalize URL
-            if href.startswith('/'):
-                href = self.base_url + href
-            elif href.startswith('http://'):
-                href = href.replace('http://', 'https://')
-            
-            seen.add(href)
-            
+            seen.add(url)
+
+            number = self._chapter_number(entry)
+            title = (entry.get("title") or "").strip() or f"Chapter {number}"
             chapters.append(Chapter(
-                number=chapter_num,
-                title=f"Chapter {chapter_num}",
-                url=href,
+                number=number,
+                title=title,
+                url=url,
+                date=translation.get("date"),
             ))
-        
-        # Remove duplicates by chapter number (keep first)
-        unique = {}
-        for ch in chapters:
-            if ch.number not in unique:
-                unique[ch.number] = ch
-        
-        return sorted(unique.values(), key=lambda x: x.numeric)
-    
+
+        return sorted(chapters, key=lambda ch: ch.numeric)
+
+    @staticmethod
+    def _pick_translation(translations: list) -> Optional[dict]:
+        """Choose one readable translation per chapter, preferring English."""
+        usable = [t for t in translations if t.get("url")]
+        if not usable:
+            return None
+        for t in usable:
+            if (t.get("language") or "").lower().startswith("en"):
+                return t
+        return usable[0]
+
+    @staticmethod
+    def _chapter_number(entry: dict) -> str:
+        """Derive a clean chapter-number string from a listing entry."""
+        raw = entry.get("number_float")
+        try:
+            num = float(raw)
+            return str(int(num)) if num.is_integer() else str(num)
+        except (TypeError, ValueError):
+            pass
+        text = str(entry.get("number") or entry.get("title") or "")
+        match = re.search(r"(\d+(?:\.\d+)?)", text)
+        return match.group(1) if match else "0"
+
+    # Pages
+
     def get_pages(self, chapter_url: str) -> List[str]:
         """Get all page image URLs for a chapter."""
-        # Normalize URL
-        if chapter_url.startswith('http://'):
-            chapter_url = chapter_url.replace('http://', 'https://')
-        
-        html = self._get_page_content(chapter_url, wait_time=4000)
+        html = self._get_html(self._abs_url(chapter_url))
+        return self._parse_pages(html)
+
+    def _parse_pages(self, html: str) -> List[str]:
+        """Extract ordered page image URLs from a reader page.
+
+        The reader embeds the list as ``chapterImages = JSON.parse(`[...]`)``;
+        fall back to scraping CDN ``<img>`` tags if that shape ever changes.
+        """
+        match = self._CHAPTER_IMAGES_RE.search(html)
+        if match:
+            try:
+                urls = json.loads(match.group(1))
+                pages = [self._abs_url(u.strip()) for u in urls
+                         if isinstance(u, str) and u.strip()]
+                if pages:
+                    return pages
+            except (ValueError, TypeError):
+                pass
+
         soup = BeautifulSoup(html, "html.parser")
-        
         pages = []
-        
-        # Find manga page images
-        for img in soup.select('img'):
-            src = img.get('src') or img.get('data-src')
+        for img in soup.select("img"):
+            src = img.get("src") or img.get("data-src")
             if not src:
                 continue
-            
-            # Filter for actual manga pages (from CDN)
-            if 'poke-black-and-white.net' in src or re.search(r'-\d{3}\.webp', src):
+            if "poke-black-and-white.net" in src or re.search(r"-\d{3}\.(webp|jpg|png)", src):
+                src = src.strip()
                 if src not in pages:
-                    pages.append(src.strip())
-        
+                    pages.append(src)
         return pages

--- a/tests/scrapers/test_mangaball_api.py
+++ b/tests/scrapers/test_mangaball_api.py
@@ -1,0 +1,254 @@
+"""JSON/HTML-fixture tests for MangaBall's API-driven scraper.
+
+The network-facing helpers (``_api_post`` / ``_get_html``) are never invoked
+here - these tests exercise only the pure parsing/normalisation layer, using
+payloads shaped after the live ``/api/v1`` responses and reader pages.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import get_scraper
+from memanga.scrapers.mangaball import MangaBallScraper
+
+
+@pytest.fixture
+def mb():
+    return MangaBallScraper()
+
+
+# Smoke
+
+
+def test_instantiates_and_has_required_api():
+    s = get_scraper("mangaball.net")
+    assert isinstance(s, MangaBallScraper)
+    for method in ("search", "get_chapters", "get_pages", "download_image"):
+        assert callable(getattr(s, method))
+
+
+# URL helpers
+
+
+class TestUrlHelpers:
+    def test_extract_title_id(self):
+        assert MangaBallScraper._extract_title_id(
+            "https://mangaball.net/title-detail/kubera-official-6889f402e00aa4d41d07e044/"
+        ) == "6889f402e00aa4d41d07e044"
+
+    def test_extract_title_id_missing(self):
+        assert MangaBallScraper._extract_title_id("https://mangaball.net/foo/bar") is None
+
+    def test_extract_title_id_ignores_earlier_hex_run(self):
+        # A slug containing an earlier 24-hex-looking run must not shadow the
+        # real trailing title id.
+        url = (
+            "https://mangaball.net/title-detail/"
+            "deadbeefcafebabefacefeed0042-6889f402e00aa4d41d07e044/"
+        )
+        assert MangaBallScraper._extract_title_id(url) == "6889f402e00aa4d41d07e044"
+
+    def test_extract_title_id_with_query_and_fragment(self):
+        url = "https://mangaball.net/title-detail/x-6889f402e00aa4d41d07e044?a=1#top"
+        assert MangaBallScraper._extract_title_id(url) == "6889f402e00aa4d41d07e044"
+
+    def test_abs_url_relative(self, mb):
+        assert mb._abs_url("/title-detail/x-abc/") == \
+            "https://mangaball.net/title-detail/x-abc/"
+
+    def test_abs_url_forces_https(self, mb):
+        # The chapter API hands back http:// links.
+        assert mb._abs_url("http://mangaball.net/chapter-detail/deadbeef/") == \
+            "https://mangaball.net/chapter-detail/deadbeef/"
+
+
+# Search
+
+
+SEARCH_PAYLOAD = {
+    "code": 200,
+    "message": "Search smart success",
+    "data": {
+        "manga": [
+            {
+                "img": "https://cdn.poke-black-and-white.net/covers/a/cover.jpg",
+                "title": "Kubera (Official)",
+                "url": "/title-detail/kubera-official-6889f402e00aa4d41d07e044/",
+            },
+            {
+                "img": "https://cdn.poke-black-and-white.net/covers/b/cover.jpg",
+                "title": "KubeRag Arena",
+                "url": "/title-detail/kuberag-arena-68525476048c12fa14c40b6c/",
+            },
+            # Duplicate URL + a blank-title row must be dropped.
+            {"img": None, "title": "dup", "url": "/title-detail/kubera-official-6889f402e00aa4d41d07e044/"},
+            {"img": None, "title": "", "url": "/title-detail/nameless-000000000000000000000000/"},
+        ],
+        "authors": "",
+        "tags": "",
+    },
+}
+
+
+class TestSearch:
+    def test_parses_manga_with_covers(self, mb):
+        results = mb._parse_search(SEARCH_PAYLOAD)
+        assert [r.title for r in results] == ["Kubera (Official)", "KubeRag Arena"]
+        assert results[0].url == \
+            "https://mangaball.net/title-detail/kubera-official-6889f402e00aa4d41d07e044/"
+        assert results[0].cover_url.endswith("cover.jpg")
+
+    def test_non_200_returns_empty(self, mb):
+        assert mb._parse_search({"code": 419, "message": "expired"}) == []
+        assert mb._parse_search({}) == []
+
+    def test_search_calls_api_and_parses(self, monkeypatch, mb):
+        captured = {}
+
+        def fake_post(path, data):
+            captured["path"] = path
+            captured["data"] = data
+            return SEARCH_PAYLOAD
+
+        monkeypatch.setattr(mb, "_api_post", fake_post)
+        results = mb.search("kubera")
+        assert captured["path"] == "/api/v1/smart-search/search/"
+        assert captured["data"] == {"search_input": "kubera"}
+        assert len(results) == 2
+
+
+# Chapters
+
+
+def _translation(url, language="en", date="2026-08-03 05:07:13"):
+    return {"url": url, "language": language, "languageName": language, "date": date}
+
+
+CHAPTERS_PAYLOAD = {
+    "code": 200,
+    "ALL_CHAPTERS": [
+        {
+            "number": "Ch. 726",
+            "number_float": 726,
+            "title": "Ch. 726",
+            "translations": [
+                _translation("http://mangaball.net/chapter-detail/en726a/"),
+                _translation("http://mangaball.net/chapter-detail/en726b/"),
+            ],
+        },
+        {
+            "number": "Ch. 725.5",
+            "number_float": 725.5,
+            "title": "Ch. 725.5",
+            "translations": [
+                # No English -> fall back to first usable translation.
+                _translation("http://mangaball.net/chapter-detail/fr7255/", language="fr"),
+            ],
+        },
+        {
+            "number": "Ch. 10",
+            "number_float": 10,
+            "title": "Ch. 10",
+            "translations": [_translation("http://mangaball.net/chapter-detail/en10/")],
+        },
+        # Entry with no usable translation is skipped entirely.
+        {"number": "Ch. 9", "number_float": 9, "title": "Ch. 9", "translations": [{"language": "en"}]},
+    ],
+}
+
+
+class TestChapters:
+    def test_prefers_english_sorts_and_normalises(self, mb):
+        chapters = mb._parse_chapters(CHAPTERS_PAYLOAD)
+        # 3 entries yield chapters (the translation-less one is dropped).
+        assert [c.number for c in chapters] == ["10", "725.5", "726"]
+        # English translation chosen for 726 (first en URL, not the fr one).
+        top = chapters[-1]
+        assert top.url == "https://mangaball.net/chapter-detail/en726a/"
+        # http -> https normalisation applied.
+        assert all(c.url.startswith("https://") for c in chapters)
+        # Non-English chapter still resolved via fallback.
+        mid = next(c for c in chapters if c.number == "725.5")
+        assert mid.url.endswith("/fr7255/")
+        assert mid.date == "2026-08-03 05:07:13"
+
+    def test_non_200_returns_empty(self, mb):
+        assert mb._parse_chapters({"code": 500}) == []
+
+    def test_pick_translation_prefers_english(self):
+        picked = MangaBallScraper._pick_translation([
+            _translation("u1", language="es"),
+            _translation("u2", language="en"),
+        ])
+        assert picked["url"] == "u2"
+
+    def test_pick_translation_none_when_no_urls(self):
+        assert MangaBallScraper._pick_translation([{"language": "en"}]) is None
+
+    def test_chapter_number_from_float_and_text(self):
+        assert MangaBallScraper._chapter_number({"number_float": 726}) == "726"
+        assert MangaBallScraper._chapter_number({"number_float": 725.5}) == "725.5"
+        assert MangaBallScraper._chapter_number({"number": "Ch. 42"}) == "42"
+        assert MangaBallScraper._chapter_number({}) == "0"
+
+    def test_get_chapters_invalid_url_returns_empty(self, mb):
+        assert mb.get_chapters("https://mangaball.net/no-id-here/") == []
+
+
+# Pages
+
+
+READER_HTML = """
+<html><head><meta name="csrf-token" content="abc"></head><body>
+<script>
+    const chapterImages = JSON.parse(`["https://jigglypuff.poke-black-and-white.net/storage/x/0/726/en/aa-001.jpg","https://jigglypuff.poke-black-and-white.net/storage/x/0/726/en/aa-002.jpg"]`);
+</script>
+</body></html>
+"""
+
+READER_HTML_FALLBACK = """
+<html><body>
+<img src="https://mangaball.net/public/logo.png">
+<img data-src="https://jigglypuff.poke-black-and-white.net/storage/x/0/1/en/bb-001.jpg">
+<img src="https://jigglypuff.poke-black-and-white.net/storage/x/0/1/en/bb-002.jpg">
+</body></html>
+"""
+
+
+class TestPages:
+    def test_extracts_embedded_json(self, mb):
+        pages = mb._parse_pages(READER_HTML)
+        assert len(pages) == 2
+        assert pages[0].endswith("aa-001.jpg")
+        assert all("poke-black-and-white.net" in p for p in pages)
+
+    def test_embedded_json_normalises_http_to_https(self, mb):
+        html = (
+            "<script>const chapterImages = JSON.parse(`"
+            '["http://jigglypuff.poke-black-and-white.net/storage/x/0/726/en/aa-001.jpg"]'
+            "`);</script>"
+        )
+        pages = mb._parse_pages(html)
+        assert pages == [
+            "https://jigglypuff.poke-black-and-white.net/storage/x/0/726/en/aa-001.jpg"
+        ]
+
+    def test_falls_back_to_cdn_img_tags(self, mb):
+        pages = mb._parse_pages(READER_HTML_FALLBACK)
+        assert pages == [
+            "https://jigglypuff.poke-black-and-white.net/storage/x/0/1/en/bb-001.jpg",
+            "https://jigglypuff.poke-black-and-white.net/storage/x/0/1/en/bb-002.jpg",
+        ]
+
+    def test_get_pages_fetches_normalised_url(self, monkeypatch, mb):
+        seen = {}
+
+        def fake_get_html(url, *a, **k):
+            seen["url"] = url
+            return READER_HTML
+
+        monkeypatch.setattr(mb, "_get_html", fake_get_html)
+        pages = mb.get_pages("http://mangaball.net/chapter-detail/en726a/")
+        assert seen["url"] == "https://mangaball.net/chapter-detail/en726a/"
+        assert len(pages) == 2

--- a/tests/scrapers/test_playwright_scrapers.py
+++ b/tests/scrapers/test_playwright_scrapers.py
@@ -155,7 +155,6 @@ PLAYWRIGHT_DOMAINS = [
     "isekaiscan.com",
     "zinmanga.com",
     "zazamanga.com",
-    "mangaball.net",
     "mangaclash.com",
     "kunmanga.com",
     "manytoon.com",


### PR DESCRIPTION
## Summary

Restores MangaBall by using the site's current CSRF-backed JSON endpoints for search and chapter listings, then parsing reader page image data from the embedded chapter image payload.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Tests

- `venv/bin/python -m pytest tests/scrapers/test_mangaball_api.py tests/scrapers/test_playwright_scrapers.py tests/scrapers/test_registry_coverage.py tests/unit/scrapers/test_scraper_registry.py`
- Live MangaBall probe: searched `kubera`, selected Kubera Official, loaded 803 chapters, extracted 33 page URLs for chapter 726, and downloaded a 122789-byte JPEG page.

## Related issues

Closes #150