### PR TITLE
fix(scraper): bound Mangago blocked connections

### DIFF
--- a/memanga/scrapers/mangago.py
+++ b/memanga/scrapers/mangago.py
@@ -6,17 +6,62 @@ Large yaoi/shoujo collection, general manga too.
 """
 
 import re
+import time
 from typing import List
 from pathlib import Path
-from .base import BaseScraper, Chapter, Manga
+
+import requests
+
+from .base import BaseScraper, Chapter, Manga, _retry
 
 
 class MangagoScraper(BaseScraper):
     """Scraper for Mangago.me"""
-    
+
     name = "mangago"
     base_url = "https://www.mangago.me"
-    
+
+    # mangago.me is periodically DNS-poisoned and SNI-filtered in some
+    # regions (hence its place in search.BROKEN_SEARCH_SOURCES). On such a
+    # network every connect() stalls without an RST, so BaseScraper's 30s
+    # timeout x 3 retries makes a direct search()/get_chapters() call hang
+    # ~90-180s. Bound the connect wait and skip retries for connection
+    # failures -- a blocked host won't recover inside a retry window -- so
+    # direct calls fail in seconds. Only transient ReadTimeout / HTTPError
+    # responses (i.e. we did connect) keep the full read budget + retries.
+    _CONNECT_TIMEOUT = 8    # seconds to establish TCP + TLS
+    _READ_TIMEOUT = 30      # seconds to receive the response body
+
+    def _request(self, url: str, **kwargs) -> requests.Response:
+        """Rate-limited GET with a bounded connect timeout.
+
+        Overrides BaseScraper._request so a region-blocked mangago.me
+        fails fast instead of hanging: connection errors propagate on the
+        first attempt, while transient read/HTTP errors still get retried.
+        """
+        kwargs.setdefault("timeout", (self._CONNECT_TIMEOUT, self._READ_TIMEOUT))
+
+        def _do_request():
+            with self._rate_lock:
+                elapsed = time.time() - self._last_request
+                if elapsed < self._rate_limit:
+                    time.sleep(self._rate_limit - elapsed)
+                self._last_request = time.time()
+            response = self.session.get(url, **kwargs)
+            response.raise_for_status()
+            return response
+
+        # ConnectionError / ConnectTimeout mean the host is unreachable
+        # from here; retrying only multiplies the wait, so let them raise
+        # on the first attempt. Only post-connect hiccups are retried.
+        return _retry(
+            _do_request,
+            max_attempts=3,
+            base_delay=1.0,
+            exceptions=(requests.exceptions.ReadTimeout,
+                        requests.exceptions.HTTPError),
+        )
+
     def search(self, query: str) -> List[Manga]:
         """Search for manga by title."""
         from bs4 import BeautifulSoup
@@ -126,7 +171,9 @@ class MangagoScraper(BaseScraper):
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 "Referer": f"{self.base_url}/",
             }
-            response = self.session.get(url, headers=headers, timeout=30)
+            response = self.session.get(
+                url, headers=headers,
+                timeout=(self._CONNECT_TIMEOUT, self._READ_TIMEOUT))
             response.raise_for_status()
             Path(path).parent.mkdir(parents=True, exist_ok=True)
             Path(path).write_bytes(response.content)

--- a/memanga/search.py
+++ b/memanga/search.py
@@ -111,6 +111,11 @@ BROKEN_SEARCH_SOURCES = {
     "manhwa18.cc",
     "mangafreak.me", "mangafreak.ws", "ww2.mangafreak.me",
     "bato.to", "batoto.to",
+    # region-blocked (DNS poison + SNI filter) on some networks, where
+    # connect() stalls and the 30s-timeout x 3-retry sweep slot hangs
+    # ~90s+, so drop it from the sweep. Reachable elsewhere, so it stays
+    # usable by direct URL.
+    "mangago.me", "www.mangago.me",
     # NEEDS_JS_API — static HTML returns 0 hits, real search is client-side
     "asuracomic.net", "asurascans.com", "asuratoon.com",
     "mgeko.cc",

--- a/tests/scrapers/test_mangago.py
+++ b/tests/scrapers/test_mangago.py
@@ -1,0 +1,137 @@
+"""Unit tests for MangagoScraper's region-block-resilient request path.
+
+mangago.me is DNS-poisoned / SNI-filtered in some regions (issue #151),
+so from a blocked network every connect() stalls. These tests prove a
+direct MangagoScraper call fails fast there instead of hanging through
+BaseScraper's 30s x 3-retry budget, while transient post-connect errors
+still get retried. All network is faked; nothing leaves the process.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+import requests
+
+from memanga.scrapers.mangago import MangagoScraper
+
+
+@pytest.fixture
+def scraper():
+    return MangagoScraper()
+
+
+@pytest.fixture(autouse=True)
+def no_real_sleep(monkeypatch):
+    """Record and neutralise every sleep so retries don't slow the suite."""
+    slept: list[float] = []
+    monkeypatch.setattr(time, "sleep", slept.append)
+    return slept
+
+
+class _FakeGet:
+    """session.get stand-in: counts calls, records the timeout kwarg,
+    and raises the supplied exception on every call."""
+
+    def __init__(self, raise_exc):
+        self.calls = 0
+        self.timeouts: list = []
+        self._raise = raise_exc
+
+    def __call__(self, url, **kwargs):
+        self.calls += 1
+        self.timeouts.append(kwargs.get("timeout"))
+        raise self._raise
+
+
+# -- connection failures must fail fast (no BaseScraper 3x retry) --
+
+
+class TestRegionBlockFailsFast:
+    # Every public read path routes through _request, so all three must
+    # fail fast, not just search().
+    OPS = {
+        "search": lambda s: s.search("one piece"),
+        "get_chapters": lambda s: s.get_chapters(
+            "https://www.mangago.me/read-manga/one_piece/"),
+        "get_pages": lambda s: s.get_pages(
+            "https://www.mangago.me/read-manga/one_piece/mr/nml_chapter-1/pg-1/"),
+    }
+
+    @pytest.mark.parametrize("op", list(OPS.values()), ids=list(OPS))
+    @pytest.mark.parametrize("exc", [
+        requests.exceptions.ConnectTimeout("connect timed out"),
+        requests.exceptions.ConnectionError("Connection reset by peer"),
+    ], ids=["connect_timeout", "connection_reset"])
+    def test_connection_error_not_retried(self, scraper, monkeypatch,
+                                          no_real_sleep, op, exc):
+        get = _FakeGet(exc)
+        monkeypatch.setattr(scraper.session, "get", get)
+
+        with pytest.raises(requests.exceptions.RequestException):
+            op(scraper)
+
+        # BaseScraper would call get() 3 times; the override stops at 1.
+        assert get.calls == 1
+        # Nothing to back off for, so no exponential-backoff sleep either.
+        assert no_real_sleep == []
+
+    def test_bounded_connect_timeout_passed(self, scraper, monkeypatch,
+                                            no_real_sleep):
+        get = _FakeGet(requests.exceptions.ConnectTimeout("x"))
+        monkeypatch.setattr(scraper.session, "get", get)
+
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            scraper.search("one piece")
+
+        assert get.timeouts == [
+            (scraper._CONNECT_TIMEOUT, scraper._READ_TIMEOUT)]
+        # The connect bound is well under BaseScraper's flat 30s.
+        assert scraper._CONNECT_TIMEOUT < 30
+
+
+# -- transient post-connect errors keep BaseScraper's resilience --
+
+
+class TestTransientErrorsStillRetry:
+    def test_read_timeout_is_retried(self, scraper, monkeypatch, no_real_sleep):
+        get = _FakeGet(requests.exceptions.ReadTimeout("slow body"))
+        monkeypatch.setattr(scraper.session, "get", get)
+
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            scraper.search("one piece")
+
+        # A read hiccup means we did connect, so retry as before: 3 tries.
+        assert get.calls == 3
+
+    def test_http_error_is_retried(self, scraper, monkeypatch, no_real_sleep):
+        get = _FakeGet(requests.exceptions.HTTPError("503"))
+        monkeypatch.setattr(scraper.session, "get", get)
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            scraper.search("one piece")
+
+        assert get.calls == 3
+
+
+# -- download_image bypasses _request but must still bound connect --
+
+
+class TestDownloadImageBoundedTimeout:
+    def test_uses_bounded_timeout_and_swallows_block(self, scraper,
+                                                     monkeypatch, tmp_path):
+        seen = {}
+
+        def fake_get(url, **kwargs):
+            seen["timeout"] = kwargs.get("timeout")
+            raise requests.exceptions.ConnectTimeout("blocked")
+
+        monkeypatch.setattr(scraper.session, "get", fake_get)
+
+        ok = scraper.download_image(
+            "https://i.mangapicgallery.com/x.jpg", tmp_path / "x.jpg")
+
+        assert ok is False  # download_image swallows and reports failure
+        assert seen["timeout"] == (
+            scraper._CONNECT_TIMEOUT, scraper._READ_TIMEOUT)

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -191,6 +191,15 @@ class TestComputeSearchSources:
         assert "mangasee123.com" not in sources
         assert "manganato.com" not in sources
 
+    def test_region_blocked_mangago_excluded(self):
+        # mangago.me is reachable globally but DNS/SNI-blocked in some
+        # regions, where every request stalls in connect() and hangs the
+        # sweep slot (issue #151). Both aliases must stay out of the sweep;
+        # the www one used to win the canonical de-dup and get probed.
+        sources = compute_search_sources(FakeConfig())
+        assert "mangago.me" not in sources
+        assert "www.mangago.me" not in sources
+
     def test_disabled_sources_removed(self):
         sources = compute_search_sources(FakeConfig({
             "sources.disabled": ["mangadex.org"],


### PR DESCRIPTION
## Summary

Prevents Mangago from stalling searches on networks where the host is blocked during connection setup. Multi-source search now skips Mangago aliases, while direct Mangago scraper calls use bounded connect/read timeouts and avoid retrying unreachable-host connection failures.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Tests

- `venv/bin/pytest tests/scrapers/test_mangago.py tests/unit/test_search.py` (29 passed)
- `git diff --check` (clean)
- Live Mangago probe on a blocked network: direct `MangagoScraper().search("one piece")` returned within the 20-second guard with a connection failure instead of hanging.

## Related issues

Closes #151
