### PR TITLE
feat(scraper): add Atsumaru source

### DIFF
--- a/memanga/scrapers/__init__.py
+++ b/memanga/scrapers/__init__.py
@@ -76,6 +76,7 @@ from .mangayy import MangaYYScraper
 from .manga4life import Manga4LifeScraper
 from .zazamanga import ZazaMangaScraper
 from .mangaball import MangaBallScraper
+from .atsumaru import AtsumaruScraper
 from .manytoon import ManyToonScraper
 from .pururin import PururinScraper
 from .hentairead import HentaiReadScraper
@@ -392,6 +393,9 @@ SCRAPERS = {
 
     # MangaBall - Multi-language aggregator (HTTP JSON API)
     "mangaball.net": MangaBallScraper,
+
+    # Atsumaru - Manga aggregator (Typesense search + REST API)
+    "atsu.moe": AtsumaruScraper,
 
     # MangaClash - Manga aggregator (Playwright + Madara + CF)
     "mangaclash.com": MangaClashScraper,

--- a/memanga/scrapers/atsumaru.py
+++ b/memanga/scrapers/atsumaru.py
@@ -1,0 +1,200 @@
+"""
+Atsumaru scraper - Manga aggregator
+Site: atsu.moe
+
+Atsumaru is a React SPA backed by a Typesense search endpoint and REST APIs.
+This scraper uses the APIs directly:
+
+* search   -> GET /collections/manga/documents/search?q=...
+* chapters -> GET /api/manga/allChapters?mangaId=...
+* pages    -> GET /api/read/chapter?mangaId=...&chapterId=...
+"""
+
+import re
+from datetime import datetime, timezone
+from typing import List, Optional
+from urllib.parse import urlparse, parse_qs, urlencode
+
+from .base import BaseScraper, Chapter, Manga
+
+
+class AtsumaruScraper(BaseScraper):
+    """Scraper for Atsumaru (atsu.moe)."""
+
+    name = "atsumaru"
+    base_url = "https://atsu.moe"
+
+    # IDs are short randomly-generated identifiers whose alphabet can include
+    # "-" and "_" (e.g. "9L82jefe"), so match those too. The class stops at
+    # "/", "?" or "#", so a trailing path or query is still excluded.
+    _MANGA_ID_RE = re.compile(r"/manga/([A-Za-z0-9_-]+)")
+    _READ_RE = re.compile(r"/read/([A-Za-z0-9_-]+)/([A-Za-z0-9_-]+)")
+
+    def __init__(self):
+        super().__init__()
+        self.session.headers.update({
+            "Accept": "application/json, text/plain, */*",
+            "Referer": self.base_url + "/",
+        })
+
+    def _abs_static_url(self, path: str) -> str:
+        """Absolutize a static/CDN path, using cdn.atsu.moe directly."""
+        if not path:
+            return ""
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        if not path.startswith("/"):
+            path = "/" + path
+        return "https://cdn.atsu.moe" + path
+
+    @classmethod
+    def _extract_manga_id(cls, url: str) -> Optional[str]:
+        """Extract manga ID from a manga URL like /manga/<id>."""
+        match = cls._MANGA_ID_RE.search(url or "")
+        return match.group(1) if match else None
+
+    @classmethod
+    def _extract_read_ids(cls, url: str) -> tuple:
+        """Extract (manga_id, chapter_id) from a read URL like /read/<manga>/<chapter>."""
+        match = cls._READ_RE.search(url or "")
+        if match:
+            return match.group(1), match.group(2)
+        return None, None
+
+    def search(self, query: str) -> List[Manga]:
+        """Search for manga by title via Typesense endpoint."""
+        params = urlencode({
+            "q": query,
+            "query_by": "title,otherNames",
+            "per_page": "20",
+        })
+        url = f"{self.base_url}/collections/manga/documents/search?{params}"
+        try:
+            data = self._get_json(url)
+        except Exception:
+            return []
+        return self._parse_search(data)
+
+    def _parse_search(self, data: dict) -> List[Manga]:
+        """Parse Typesense search response into Manga objects."""
+        results = []
+        seen = set()
+        for hit in (data or {}).get("hits") or []:
+            doc = hit.get("document") or {}
+            manga_id = doc.get("id")
+            title = (doc.get("title") or "").strip()
+            if not manga_id or not title:
+                continue
+            if manga_id in seen:
+                continue
+            seen.add(manga_id)
+
+            cover = doc.get("posterMedium") or doc.get("poster") or doc.get("posterSmall")
+            cover_url = self._abs_static_url(cover) if cover else None
+
+            results.append(Manga(
+                title=title,
+                url=f"{self.base_url}/manga/{manga_id}",
+                cover_url=cover_url,
+                description=doc.get("synopsis"),
+            ))
+
+        return results[:20]
+
+    def get_chapters(self, manga_url: str) -> List[Chapter]:
+        """Get all chapters for a manga via the allChapters API."""
+        manga_id = self._extract_manga_id(manga_url)
+        if not manga_id:
+            return []
+
+        url = f"{self.base_url}/api/manga/allChapters?mangaId={manga_id}"
+        try:
+            data = self._get_json(url)
+        except Exception:
+            return []
+        return self._parse_chapters(data, manga_id)
+
+    def _parse_chapters(self, data: dict, manga_id: str) -> List[Chapter]:
+        """Parse allChapters response into Chapter objects, sorted ascending."""
+        chapters = []
+        seen = set()
+
+        for entry in (data or {}).get("chapters") or []:
+            chapter_id = entry.get("id")
+            if not chapter_id or chapter_id in seen:
+                continue
+            seen.add(chapter_id)
+
+            number = self._chapter_number(entry)
+            title = (entry.get("title") or "").strip() or f"Chapter {number}"
+
+            date = None
+            ts = entry.get("createdAt")
+            if ts:
+                try:
+                    date = datetime.fromtimestamp(ts / 1000, timezone.utc).strftime("%Y-%m-%d")
+                except Exception:
+                    pass
+
+            chapters.append(Chapter(
+                number=number,
+                title=title,
+                url=f"{self.base_url}/read/{manga_id}/{chapter_id}",
+                date=date,
+            ))
+
+        return sorted(chapters, key=lambda ch: ch.numeric)
+
+    @staticmethod
+    def _chapter_number(entry: dict) -> str:
+        """Extract clean chapter number from an allChapters entry."""
+        raw = entry.get("number")
+        if raw is not None:
+            try:
+                num = float(raw)
+                return str(int(num)) if num.is_integer() else str(num)
+            except (TypeError, ValueError):
+                pass
+
+        index = entry.get("index")
+        if index is not None:
+            try:
+                return str(int(index) + 1)
+            except (TypeError, ValueError):
+                pass
+
+        title = entry.get("title") or ""
+        match = re.search(r"(\d+(?:\.\d+)?)", title)
+        return match.group(1) if match else "0"
+
+    def get_pages(self, chapter_url: str) -> List[str]:
+        """Get all page image URLs for a chapter via the read API."""
+        manga_id, chapter_id = self._extract_read_ids(chapter_url)
+
+        if not manga_id or not chapter_id:
+            parsed = urlparse(chapter_url)
+            qs = parse_qs(parsed.query)
+            manga_id = manga_id or (qs.get("mangaId") or [None])[0]
+            chapter_id = chapter_id or (qs.get("chapterId") or [None])[0]
+
+        if not manga_id or not chapter_id:
+            return []
+
+        url = f"{self.base_url}/api/read/chapter?mangaId={manga_id}&chapterId={chapter_id}"
+        try:
+            data = self._get_json(url)
+        except Exception:
+            return []
+        return self._parse_pages(data)
+
+    def _parse_pages(self, data: dict) -> List[str]:
+        """Parse read/chapter response into ordered page URLs."""
+        pages_list = ((data or {}).get("readChapter") or {}).get("pages") or []
+
+        pages = []
+        for page in sorted(pages_list, key=lambda p: p.get("number", 0)):
+            img = page.get("image")
+            if img:
+                pages.append(self._abs_static_url(img))
+
+        return pages

--- a/tests/scrapers/live/test_live_parsing.py
+++ b/tests/scrapers/live/test_live_parsing.py
@@ -85,6 +85,11 @@ PARSING_PROBES = {
     # (issue #152) - this probe catches that endpoint/host changing.
     "mangataro.org": ProbeSpec("MangaTaro (JSON page API)",
                                 query="koi to yobu"),
+    # Search is a Typesense collection endpoint; chapters and pages come
+    # from separate REST APIs keyed by the ids in the manga/read URLs.
+    # This probe catches any of those three endpoints changing shape.
+    "atsu.moe": ProbeSpec("Atsumaru (Typesense search + REST API)",
+                           query="one piece"),
 
     # ── One representative per template family ──
     "dddmanga.com": ProbeSpec("NuxtSSR template (single-manga)"),

--- a/tests/scrapers/test_atsumaru_api.py
+++ b/tests/scrapers/test_atsumaru_api.py
@@ -1,0 +1,334 @@
+"""JSON-fixture tests for Atsumaru's API-driven scraper.
+
+The network-facing helpers (``_get_json``) are never invoked here - these tests
+exercise only the pure parsing/normalisation layer, using payloads shaped after
+the live Typesense and REST API responses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import get_scraper
+from memanga.scrapers.atsumaru import AtsumaruScraper
+
+
+@pytest.fixture
+def scraper():
+    return AtsumaruScraper()
+
+
+# Smoke
+
+
+def test_instantiates_and_has_required_api():
+    s = get_scraper("atsu.moe")
+    assert isinstance(s, AtsumaruScraper)
+    for method in ("search", "get_chapters", "get_pages", "download_image"):
+        assert callable(getattr(s, method))
+
+
+# URL helpers
+
+
+class TestUrlHelpers:
+    def test_extract_manga_id(self):
+        assert AtsumaruScraper._extract_manga_id(
+            "https://atsu.moe/manga/sVC2A"
+        ) == "sVC2A"
+
+    def test_extract_manga_id_missing(self):
+        assert AtsumaruScraper._extract_manga_id("https://atsu.moe/foo/bar") is None
+
+    def test_extract_manga_id_with_trailing_path(self):
+        assert AtsumaruScraper._extract_manga_id(
+            "https://atsu.moe/manga/sVC2A/chapters"
+        ) == "sVC2A"
+
+    def test_extract_manga_id_with_query_string(self):
+        assert AtsumaruScraper._extract_manga_id(
+            "https://atsu.moe/manga/sVC2A?ref=home"
+        ) == "sVC2A"
+
+    def test_extract_manga_id_allows_dash_and_underscore(self):
+        # IDs are nanoid-style identifiers whose alphabet may include "-"/"_".
+        assert AtsumaruScraper._extract_manga_id(
+            "https://atsu.moe/manga/9L8-2j_efe"
+        ) == "9L8-2j_efe"
+
+    def test_extract_read_ids(self):
+        manga_id, chapter_id = AtsumaruScraper._extract_read_ids(
+            "https://atsu.moe/read/sVC2A/Nd6vV"
+        )
+        assert manga_id == "sVC2A"
+        assert chapter_id == "Nd6vV"
+
+    def test_extract_read_ids_allows_dash_and_underscore(self):
+        manga_id, chapter_id = AtsumaruScraper._extract_read_ids(
+            "https://atsu.moe/read/sV-C2A/Nd_6vV"
+        )
+        assert manga_id == "sV-C2A"
+        assert chapter_id == "Nd_6vV"
+
+    def test_extract_read_ids_missing(self):
+        manga_id, chapter_id = AtsumaruScraper._extract_read_ids(
+            "https://atsu.moe/manga/sVC2A"
+        )
+        assert manga_id is None
+        assert chapter_id is None
+
+    def test_abs_static_url(self, scraper):
+        path = "/static/pages/abc123/Nd6vV/0.webp"
+        assert scraper._abs_static_url(path) == "https://cdn.atsu.moe" + path
+
+    def test_abs_static_url_already_absolute(self, scraper):
+        url = "https://cdn.atsu.moe/static/pages/abc123/Nd6vV/0.webp"
+        assert scraper._abs_static_url(url) == url
+
+    def test_abs_static_url_no_leading_slash(self, scraper):
+        path = "static/pages/abc123/Nd6vV/0.webp"
+        assert scraper._abs_static_url(path) == "https://cdn.atsu.moe/static/pages/abc123/Nd6vV/0.webp"
+
+
+# Search
+
+
+SEARCH_PAYLOAD = {
+    "found": 2,
+    "hits": [
+        {
+            "document": {
+                "id": "sVC2A",
+                "title": "One Piece",
+                "otherNames": ["OP", "Wan Piisu"],
+                "chapterCount": 1189,
+                "poster": "/static/posters/sVC2A/poster.webp",
+                "posterMedium": "/static/posters/sVC2A/poster_medium.webp",
+                "posterSmall": "/static/posters/sVC2A/poster_small.webp",
+                "synopsis": "Monkey D. Luffy sets off on an adventure...",
+            }
+        },
+        {
+            "document": {
+                "id": "xYZ12",
+                "title": "One Punch Man",
+                "otherNames": ["OPM"],
+                "chapterCount": 200,
+                "poster": "/static/posters/xYZ12/poster.webp",
+                "synopsis": "Saitama is a hero who defeats everyone...",
+            }
+        },
+        # Duplicate ID should be dropped
+        {
+            "document": {
+                "id": "sVC2A",
+                "title": "One Piece (Duplicate)",
+            }
+        },
+        # Missing title should be dropped
+        {
+            "document": {
+                "id": "noTitle",
+                "title": "",
+            }
+        },
+    ],
+}
+
+
+class TestSearch:
+    def test_parses_manga_with_covers(self, scraper):
+        results = scraper._parse_search(SEARCH_PAYLOAD)
+        assert len(results) == 2
+        assert results[0].title == "One Piece"
+        assert results[0].url == "https://atsu.moe/manga/sVC2A"
+        assert results[0].cover_url == "https://cdn.atsu.moe/static/posters/sVC2A/poster_medium.webp"
+        assert results[0].description == "Monkey D. Luffy sets off on an adventure..."
+
+    def test_deduplicates_manga_ids(self, scraper):
+        results = scraper._parse_search(SEARCH_PAYLOAD)
+        ids = [r.url.split("/")[-1] for r in results]
+        assert ids == ["sVC2A", "xYZ12"]
+
+    def test_empty_response_returns_empty(self, scraper):
+        assert scraper._parse_search({}) == []
+        assert scraper._parse_search({"hits": []}) == []
+        assert scraper._parse_search(None) == []
+
+    def test_search_calls_api_and_parses(self, monkeypatch, scraper):
+        captured = {}
+
+        def fake_get_json(url):
+            captured["url"] = url
+            return SEARCH_PAYLOAD
+
+        monkeypatch.setattr(scraper, "_get_json", fake_get_json)
+        results = scraper.search("one piece")
+        assert "q=one+piece" in captured["url"]
+        assert "query_by=title" in captured["url"]
+        assert "otherNames" in captured["url"]
+        assert "per_page=20" in captured["url"]
+        assert len(results) == 2
+
+    def test_search_encodes_special_characters(self, monkeypatch, scraper):
+        captured = {}
+
+        def fake_get_json(url):
+            captured["url"] = url
+            return {"hits": []}
+
+        monkeypatch.setattr(scraper, "_get_json", fake_get_json)
+        scraper.search("kaguya-sama & love is war")
+        assert "q=kaguya-sama+%26+love+is+war" in captured["url"]
+        assert "query_by=title" in captured["url"]
+        assert "otherNames" in captured["url"]
+        assert "per_page=20" in captured["url"]
+
+
+# Chapters
+
+
+CHAPTERS_PAYLOAD = {
+    "chapters": [
+        {
+            "id": "zSZfP",
+            "title": "Chapter 1189",
+            "number": 1189,
+            "createdAt": 1722880800000,  # 2024-08-05T18:00:00Z
+            "index": 1188,
+            "pageCount": 15,
+            "scanlationMangaId": "sVC2A",
+        },
+        {
+            "id": "Nd6vV",
+            "title": "Chapter 1188",
+            "number": 1188,
+            "createdAt": 1722276000000,  # 2024-07-29T18:00:00Z
+            "index": 1187,
+            "pageCount": 18,
+            "scanlationMangaId": "sVC2A",
+        },
+        {
+            "id": "abc12",
+            "title": "Chapter 1",
+            "number": 1,
+            "createdAt": 1600000000000,
+            "index": 0,
+            "pageCount": 20,
+            "scanlationMangaId": "sVC2A",
+        },
+        # Half chapter
+        {
+            "id": "half1",
+            "title": "Chapter 1.5",
+            "number": 1.5,
+            "createdAt": 1600100000000,
+            "index": 1,
+            "pageCount": 10,
+        },
+    ]
+}
+
+
+class TestChapters:
+    def test_parses_chapters_sorted_ascending(self, scraper):
+        chapters = scraper._parse_chapters(CHAPTERS_PAYLOAD, "sVC2A")
+        assert [c.number for c in chapters] == ["1", "1.5", "1188", "1189"]
+
+    def test_chapter_urls_include_both_ids(self, scraper):
+        chapters = scraper._parse_chapters(CHAPTERS_PAYLOAD, "sVC2A")
+        first = chapters[0]
+        assert first.url == "https://atsu.moe/read/sVC2A/abc12"
+
+    def test_chapter_dates_parsed(self, scraper):
+        chapters = scraper._parse_chapters(CHAPTERS_PAYLOAD, "sVC2A")
+        latest = chapters[-1]
+        assert latest.date == "2024-08-05"
+
+    def test_empty_response_returns_empty(self, scraper):
+        assert scraper._parse_chapters({}, "sVC2A") == []
+        assert scraper._parse_chapters({"chapters": []}, "sVC2A") == []
+
+    def test_get_chapters_invalid_url_returns_empty(self, scraper):
+        assert scraper.get_chapters("https://atsu.moe/unknown/path") == []
+
+    def test_chapter_number_extraction(self):
+        assert AtsumaruScraper._chapter_number({"number": 42}) == "42"
+        assert AtsumaruScraper._chapter_number({"number": 42.5}) == "42.5"
+        assert AtsumaruScraper._chapter_number({"index": 9}) == "10"
+        assert AtsumaruScraper._chapter_number({"title": "Ch. 100"}) == "100"
+        assert AtsumaruScraper._chapter_number({}) == "0"
+
+
+# Pages
+
+
+PAGES_PAYLOAD = {
+    "readChapter": {
+        "id": "Nd6vV",
+        "mangaId": "sVC2A",
+        "pages": [
+            {"number": 0, "image": "/static/pages/cmgzkjxs70k8hm191srm4qxf9/Nd6vV/0.webp", "width": 784, "height": 1145},
+            {"number": 1, "image": "/static/pages/cmgzkjxs70k8hm191srm4qxf9/Nd6vV/1.webp", "width": 784, "height": 1145},
+            {"number": 2, "image": "/static/pages/cmgzkjxs70k8hm191srm4qxf9/Nd6vV/2.avif", "width": 784, "height": 1145},
+        ],
+    }
+}
+
+
+class TestPages:
+    def test_extracts_ordered_pages(self, scraper):
+        pages = scraper._parse_pages(PAGES_PAYLOAD)
+        assert len(pages) == 3
+        assert pages[0] == "https://cdn.atsu.moe/static/pages/cmgzkjxs70k8hm191srm4qxf9/Nd6vV/0.webp"
+        assert pages[1].endswith("/1.webp")
+        assert pages[2].endswith("/2.avif")  # AVIF preserved
+
+    def test_pages_sorted_by_number(self, scraper):
+        data = {
+            "readChapter": {
+                "pages": [
+                    {"number": 2, "image": "/static/page2.webp"},
+                    {"number": 0, "image": "/static/page0.webp"},
+                    {"number": 1, "image": "/static/page1.webp"},
+                ]
+            }
+        }
+        pages = scraper._parse_pages(data)
+        assert [p.split("/")[-1] for p in pages] == ["page0.webp", "page1.webp", "page2.webp"]
+
+    def test_empty_response_returns_empty(self, scraper):
+        assert scraper._parse_pages({}) == []
+        assert scraper._parse_pages({"readChapter": {}}) == []
+        assert scraper._parse_pages({"readChapter": {"pages": []}}) == []
+
+    def test_get_pages_from_read_url(self, monkeypatch, scraper):
+        captured = {}
+
+        def fake_get_json(url):
+            captured["url"] = url
+            return PAGES_PAYLOAD
+
+        monkeypatch.setattr(scraper, "_get_json", fake_get_json)
+        pages = scraper.get_pages("https://atsu.moe/read/sVC2A/Nd6vV")
+        assert "mangaId=sVC2A" in captured["url"]
+        assert "chapterId=Nd6vV" in captured["url"]
+        assert len(pages) == 3
+
+    def test_get_pages_from_api_query_url(self, monkeypatch, scraper):
+        captured = {}
+
+        def fake_get_json(url):
+            captured["url"] = url
+            return PAGES_PAYLOAD
+
+        monkeypatch.setattr(scraper, "_get_json", fake_get_json)
+        pages = scraper.get_pages(
+            "https://atsu.moe/api/read/chapter?mangaId=sVC2A&chapterId=Nd6vV"
+        )
+        assert "mangaId=sVC2A" in captured["url"]
+        assert "chapterId=Nd6vV" in captured["url"]
+        assert len(pages) == 3
+
+    def test_get_pages_invalid_url_returns_empty(self, scraper):
+        assert scraper.get_pages("https://atsu.moe/unknown/path") == []


### PR DESCRIPTION
## Summary

Adds Atsumaru (`atsu.moe`) as a supported scraper source. The scraper uses Atsumaru's Typesense search endpoint plus REST chapter and reader APIs so MeManga can search titles, list chapters, extract ordered page image URLs, and download page images from the CDN.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Tests

- `venv/bin/pytest tests/scrapers/test_atsumaru_api.py tests/scrapers/test_registry_coverage.py` - 1003 passed
- `venv/bin/pytest tests/scrapers -m 'not live'` - 1263 passed, 244 deselected\n- `venv/bin/pytest -m live tests/scrapers/live/test_live_parsing.py -k atsu -v` - 1 passed, 17 deselected\n- Live Atsumaru probe: searched `one piece`, loaded 7 search results, found 1190 chapters for `https://atsu.moe/manga/sVC2A`, extracted 16 page URLs for chapter 1190, and downloaded a 290100-byte AVIF page.\n\n## Related issues\n\nCloses #153