### PR TITLE
Add VY Manga scraper support

### DIFF
--- a/memanga/scrapers/__init__.py
+++ b/memanga/scrapers/__init__.py
@@ -161,6 +161,7 @@ from .bakirahen import BakiRahenScraper
 from .blamemanga import BlameMangaScraper
 from .jjkmanga import JJKMangaScraper
 from .kagane import KaganeScraper
+from .vymanga import VyMangaScraper
 
 # ── Scrapers kept as individual files (unique domain mappings) ──
 
@@ -617,6 +618,10 @@ SCRAPERS = {
     # Kagane - Multi-manga REST API + Playwright for DRM-protected images
     "kagane.org": KaganeScraper,
     "www.kagane.org": KaganeScraper,
+
+    # VyManga - General aggregator (chapter links via ad-redirect -> Blogger CDN)
+    "mangavyvy.net": VyMangaScraper,
+    "vymanga.net": VyMangaScraper,
 }
 
 # Merge template-based scrapers into SCRAPERS dict

--- a/memanga/scrapers/__init__.py
+++ b/memanga/scrapers/__init__.py
@@ -620,8 +620,12 @@ SCRAPERS = {
     "www.kagane.org": KaganeScraper,
 
     # VyManga - General aggregator (chapter links via ad-redirect -> Blogger CDN)
+    # Legacy hosts (vymanga.net / vyvymanga.net) 403 on their own /manga/ pages
+    # but the scraper canonicalises them to mangavyvy.net; register them so
+    # saved/manual entries resolve to a scraper before canonicalisation runs.
     "mangavyvy.net": VyMangaScraper,
     "vymanga.net": VyMangaScraper,
+    "vyvymanga.net": VyMangaScraper,
 }
 
 # Merge template-based scrapers into SCRAPERS dict

--- a/memanga/scrapers/vymanga.py
+++ b/memanga/scrapers/vymanga.py
@@ -4,16 +4,23 @@ https://mangavyvy.net (formerly vymanga.net / vyvymanga.net)
 
 General manga aggregator. Search and detail pages live on the main site,
 but each chapter link routes through an encrypted ad-redirect chain
-(aovheroes.com -> summonersky.com) that resolves to a reader page. The
-reader page's images are served from Blogger/Google storage. requests
-follows the redirect chain automatically, so get_pages just parses the
-reader HTML the chain lands on.
+(aovheroes.com -> aov-news.com / summonersky.com; the exact ad domains
+rotate per request) that resolves to a reader page. The reader page's
+images are served from Blogger/Google storage and need no Referer.
+requests follows the redirect chain automatically, so get_pages just
+parses the reader HTML the chain lands on -- taking care to keep only the
+carousel slide images and drop the "same author" recommendation cover
+thumbnails the reader embeds inside that same carousel.
 """
 
 import re
 from typing import List
-from urllib.parse import quote
+from urllib.parse import quote, urlparse, urlunparse
 from .base import BaseScraper, Chapter, Manga
+
+# Old hosts still handed to us by the registry / saved libraries. Their
+# /manga/ pages now 403; the identical path resolves on the canonical host.
+_LEGACY_HOSTS = {"vymanga.net", "vyvymanga.net"}
 
 
 class VyMangaScraper(BaseScraper):
@@ -21,6 +28,18 @@ class VyMangaScraper(BaseScraper):
 
     name = "vymanga"
     base_url = "https://mangavyvy.net"
+    _canonical_host = "mangavyvy.net"
+
+    def _canonical_url(self, url: str) -> str:
+        """Rewrite legacy vymanga.net / vyvymanga.net hosts to the canonical
+        host so direct old-domain manga URLs don't 403."""
+        parsed = urlparse(url)
+        host = parsed.netloc.lower()
+        if host.startswith("www."):
+            host = host[4:]
+        if host in _LEGACY_HOSTS:
+            return urlunparse(parsed._replace(netloc=self._canonical_host))
+        return url
 
     def search(self, query: str) -> List[Manga]:
         from bs4 import BeautifulSoup
@@ -62,7 +81,7 @@ class VyMangaScraper(BaseScraper):
     def get_chapters(self, manga_url: str) -> List[Chapter]:
         from bs4 import BeautifulSoup
 
-        soup = BeautifulSoup(self._get_html(manga_url), "html.parser")
+        soup = BeautifulSoup(self._get_html(self._canonical_url(manga_url)), "html.parser")
 
         chapters = []
         seen = set()
@@ -93,22 +112,36 @@ class VyMangaScraper(BaseScraper):
     def get_pages(self, chapter_url: str) -> List[str]:
         from bs4 import BeautifulSoup
 
-        # The chapter link routes through an ad-redirect chain that requests
-        # follows automatically to the reader page holding the images.
+        # The chapter link routes through an ad-redirect chain (rotating ad
+        # domains such as aovheroes.com -> aov-news.com / summonersky.com) that
+        # requests follows automatically to the reader page holding the images.
         soup = BeautifulSoup(self._get_html(chapter_url), "html.parser")
 
-        container = soup.select_one("#carousel, .vview, .carousel-inner")
-        images = container.select("img") if container else soup.select(".carousel-item img")
+        # Page images are the reader carousel slides: a single <img> directly
+        # inside each .carousel-item. The reader also embeds a "same author"
+        # recommendation table *inside* the same carousel whose cover thumbnails
+        # (<img class="img-recommend">, served from the site's own cover CDN)
+        # would otherwise be scraped as pages, so take only the direct slide
+        # images and skip anything flagged as a recommendation thumbnail.
+        images = soup.select(".carousel-item > img")
+        if not images:
+            container = soup.select_one("#carousel, .vview, .carousel-inner")
+            images = container.select("img") if container else []
 
         pages = []
         seen = set()
         for img in images:
-            src = img.get("data-src") or img.get("src") or ""
-            src = src.strip()
+            if "img-recommend" in (img.get("class") or []):
+                continue
+            src = (img.get("data-src") or img.get("src") or "").strip()
             if not src or src in seen:
                 continue
-            low = src.lower()
-            if low.endswith(".gif") or any(x in low for x in ("loading", "blank", "logo", "icon")):
+            # Skip the lazy-load placeholder (loading.gif / blank.gif). Test the
+            # filename only, never the whole URL: reader page IDs are opaque
+            # base64 blobs that can coincidentally contain "icon"/"logo"/etc.,
+            # so a substring scan over the full URL would silently drop pages.
+            name = urlparse(src).path.rsplit("/", 1)[-1].lower()
+            if src.startswith("data:") or name.endswith(".gif"):
                 continue
             seen.add(src)
             pages.append(src)

--- a/memanga/scrapers/vymanga.py
+++ b/memanga/scrapers/vymanga.py
@@ -1,0 +1,116 @@
+"""
+VyManga scraper
+https://mangavyvy.net (formerly vymanga.net / vyvymanga.net)
+
+General manga aggregator. Search and detail pages live on the main site,
+but each chapter link routes through an encrypted ad-redirect chain
+(aovheroes.com -> summonersky.com) that resolves to a reader page. The
+reader page's images are served from Blogger/Google storage. requests
+follows the redirect chain automatically, so get_pages just parses the
+reader HTML the chain lands on.
+"""
+
+import re
+from typing import List
+from urllib.parse import quote
+from .base import BaseScraper, Chapter, Manga
+
+
+class VyMangaScraper(BaseScraper):
+    """Scraper for VyManga (mangavyvy.net)."""
+
+    name = "vymanga"
+    base_url = "https://mangavyvy.net"
+
+    def search(self, query: str) -> List[Manga]:
+        from bs4 import BeautifulSoup
+
+        url = f"{self.base_url}/search?q={quote(query)}"
+        soup = BeautifulSoup(self._get_html(url), "html.parser")
+
+        results = []
+        seen = set()
+
+        for item in soup.select("div.comic-item"):
+            link = item.select_one('a[href*="/manga/"]')
+            if not link:
+                continue
+            href = link.get("href", "")
+            if not href or href in seen:
+                continue
+            seen.add(href)
+
+            img = item.select_one("img")
+
+            title_el = item.select_one(".comic-title")
+            title = title_el.get_text(strip=True) if title_el else ""
+            if not title and img:
+                title = img.get("title") or img.get("alt") or ""
+            title = title.strip()
+            if not title:
+                continue
+
+            cover_url = None
+            if img:
+                cover_url = img.get("data-src") or img.get("src")
+
+            manga_url = href if href.startswith("http") else f"{self.base_url}{href}"
+            results.append(Manga(title=title, url=manga_url, cover_url=cover_url))
+
+        return results[:20]
+
+    def get_chapters(self, manga_url: str) -> List[Chapter]:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(self._get_html(manga_url), "html.parser")
+
+        chapters = []
+        seen = set()
+
+        for link in soup.select("a.list-chapter"):
+            href = link.get("href", "")
+            if not href or href in seen:
+                continue
+
+            span = link.select_one("span")
+            label = span.get_text(strip=True) if span else ""
+
+            # Chapter number lives in id="chapter-<num>"; fall back to label.
+            match = re.search(r"chapter-([\d.]+)", link.get("id", ""), re.I)
+            if not match:
+                match = re.search(r"chapter\s*([\d.]+)", label, re.I)
+            number = match.group(1).rstrip(".") if match else label
+
+            seen.add(href)
+            chapters.append(Chapter(
+                number=number,
+                title=label or f"Chapter {number}",
+                url=href,
+            ))
+
+        return sorted(chapters, key=lambda c: c.numeric)
+
+    def get_pages(self, chapter_url: str) -> List[str]:
+        from bs4 import BeautifulSoup
+
+        # The chapter link routes through an ad-redirect chain that requests
+        # follows automatically to the reader page holding the images.
+        soup = BeautifulSoup(self._get_html(chapter_url), "html.parser")
+
+        container = soup.select_one("#carousel, .vview, .carousel-inner")
+        images = container.select("img") if container else soup.select(".carousel-item img")
+
+        pages = []
+        seen = set()
+        for img in images:
+            src = img.get("data-src") or img.get("src") or ""
+            src = src.strip()
+            if not src or src in seen:
+                continue
+            low = src.lower()
+            if low.endswith(".gif") or any(x in low for x in ("loading", "blank", "logo", "icon")):
+                continue
+            seen.add(src)
+            pages.append(src)
+
+        return pages

--- a/tests/scrapers/fixtures/vymanga/chapter.html
+++ b/tests/scrapers/fixtures/vymanga/chapter.html
@@ -13,11 +13,36 @@
         <div class="carousel-item">
           <img class="d-block w-100 lozad" data-src="https://2.bp.blogspot.com/drive-storage/PAGE-003=w700" src="https://mangavyvy.net/web/img/loading.gif">
         </div>
+
+        <!-- "Same author" recommendation table embedded INSIDE the carousel
+             (this is how the live reader ships it). The cover thumbnails are
+             nested in a table, not direct slide children, and carry the
+             img-recommend class: they must NOT be scraped as pages. -->
+        <div class="carousel-item">
+          <div class="p-5"><div class="mt-2"><div class="table table-same_author info-area">
+            <table class="table-responsive-md same-author"><tbody>
+              <tr>
+                <td><a href="/manga/other-1"><div class="div-hover-zoom-outer img-md img-same-author">
+                  <img class="img-recommend lozad" data-src="https://cdnxyz.xyz/web/cover/19394/thumbnail.png" src="https://mangavyvy.net/web/img/loading.gif">
+                </div></a></td>
+                <td><a href="/manga/other-2"><div class="div-hover-zoom-outer img-md img-same-author">
+                  <img class="img-recommend lozad" data-src="https://cdnxyz.xyz/storage/collections/8616-1657985705.jpg" src="https://mangavyvy.net/web/img/loading.gif">
+                </div></a></td>
+              </tr>
+            </tbody></table>
+          </div></div></div>
+        </div>
+
+        <!-- Defense-in-depth: a recommendation cover promoted to a direct
+             slide child is still excluded by its img-recommend class. -->
+        <div class="carousel-item">
+          <img class="img-recommend lozad" data-src="https://cdnxyz.xyz/web/cover/66281/thumbnail.png" src="https://mangavyvy.net/web/img/loading.gif">
+        </div>
       </div>
     </div>
   </div>
 
-  <!-- Related manga block OUTSIDE the reader carousel: must NOT be scraped as pages -->
+  <!-- Related manga block OUTSIDE the reader carousel: must NOT be scraped. -->
   <div class="row book-list">
     <div class="comic-item">
       <img class="image lozad" data-src="https://cdnxyz.xyz/storage/collections/8616-1657985705.jpg">

--- a/tests/scrapers/fixtures/vymanga/chapter.html
+++ b/tests/scrapers/fixtures/vymanga/chapter.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div class="col-lg-8 col-md-12">
+    <div class="carousel slide" id="carousel">
+      <div class="vview carousel-inner">
+        <div class="carousel-item active">
+          <img class="d-block w-100 lozad" data-src="https://2.bp.blogspot.com/drive-storage/PAGE-001=w700" src="https://mangavyvy.net/web/img/loading.gif">
+        </div>
+        <div class="carousel-item">
+          <img class="d-block w-100 lozad" data-src="https://2.bp.blogspot.com/drive-storage/PAGE-002=w700" src="https://mangavyvy.net/web/img/loading.gif">
+        </div>
+        <div class="carousel-item">
+          <img class="d-block w-100 lozad" data-src="https://2.bp.blogspot.com/drive-storage/PAGE-003=w700" src="https://mangavyvy.net/web/img/loading.gif">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Related manga block OUTSIDE the reader carousel: must NOT be scraped as pages -->
+  <div class="row book-list">
+    <div class="comic-item">
+      <img class="image lozad" data-src="https://cdnxyz.xyz/storage/collections/8616-1657985705.jpg">
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/scrapers/fixtures/vymanga/manga.html
+++ b/tests/scrapers/fixtures/vymanga/manga.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head><meta property="og:image" content="https://cdnxyz.xyz/web/cover/841/thumbnail.png"/></head>
+<body>
+  <div class="list-group">
+    <!-- Newest first on the page; scraper sorts ascending. Decimal + volume prefix cases. -->
+    <a class="list-group-item list-group-item-action list-chapter"
+       href="https://aovheroes.com/rds/br/rdsd?data=AAA%3D%3D"
+       id="chapter-700.5" rel="noopener noreferrer nofollow" target="_blank">
+      <span>Chapter 700.5 : Uzumaki Naruto</span>
+      <p class="text-right font-italic small">Dec 26, 2021</p>
+    </a>
+    <a class="list-group-item list-group-item-action list-chapter"
+       href="https://aovheroes.com/rds/br/rdsd?data=BBB%3D%3D"
+       id="chapter-700" rel="noopener noreferrer nofollow" target="_blank">
+      <span>Vol.72 Chapter 700 : Uzumaki Naruto!!</span>
+      <p class="text-right font-italic small">Dec 26, 2021</p>
+    </a>
+    <a class="list-group-item list-group-item-action list-chapter"
+       href="https://aovheroes.com/rds/br/rdsd?data=CCC%3D%3D"
+       id="chapter-1" rel="noopener noreferrer nofollow" target="_blank">
+      <span>Vol.1 Chapter 1 : Uzumaki Naruto</span>
+      <p class="text-right font-italic small">Jan 01, 2000</p>
+    </a>
+    <!-- duplicate href: must be de-duped -->
+    <a class="list-group-item list-group-item-action list-chapter"
+       href="https://aovheroes.com/rds/br/rdsd?data=CCC%3D%3D"
+       id="chapter-1" rel="noopener noreferrer nofollow" target="_blank">
+      <span>Vol.1 Chapter 1 : Uzumaki Naruto</span>
+    </a>
+  </div>
+</body>
+</html>

--- a/tests/scrapers/fixtures/vymanga/search.html
+++ b/tests/scrapers/fixtures/vymanga/search.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div class="row book-list">
+    <div class="col-lg-2 col-md-3 col-4">
+      <div class="comic-item">
+        <a href="/manga/naruto-bc8">
+          <div class="comic-image">
+            <img alt="Naruto" class="image lozad" data-src="https://cdnxyz.xyz/web/cover/841/thumbnail.png" src="/web/img/blank.gif" title="Naruto">
+            <span class="tray-item">Chapter 700.5 : Uzumaki Naruto</span>
+          </div>
+          <div class="comic-title">Naruto</div>
+        </a>
+      </div>
+    </div>
+
+    <!-- duplicate href: must be de-duped -->
+    <div class="col-lg-2 col-md-3 col-4">
+      <div class="comic-item">
+        <a href="/manga/naruto-bc8">
+          <div class="comic-image">
+            <img class="image lozad" data-src="https://cdnxyz.xyz/web/cover/841/thumbnail.png" src="/web/img/blank.gif">
+          </div>
+          <div class="comic-title">Naruto</div>
+        </a>
+      </div>
+    </div>
+
+    <!-- absolute href + title only via img alt (no .comic-title) -->
+    <div class="col-lg-2 col-md-3 col-4">
+      <div class="comic-item">
+        <a href="https://mangavyvy.net/manga/boruto-naruto-next-generations-2f">
+          <div class="comic-image">
+            <img class="image lozad" alt="Boruto: Naruto Next Generations" data-src="https://cdnxyz.xyz/web/cover/22508/thumbnail.png" src="/web/img/blank.gif">
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/scrapers/test_vymanga.py
+++ b/tests/scrapers/test_vymanga.py
@@ -1,0 +1,104 @@
+"""HTML-fixture tests for VyMangaScraper."""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import get_scraper
+from memanga.scrapers.vymanga import VyMangaScraper
+
+
+@pytest.fixture
+def scraper():
+    return VyMangaScraper()
+
+
+class TestSearch:
+    def test_extracts_dedupes_and_reads_cover(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "search.html"))
+        results = scraper.search("naruto")
+        # 2 unique manga after de-dup (duplicate /manga/naruto-bc8 collapsed)
+        assert len(results) == 2
+        first = results[0]
+        assert first.title == "Naruto"
+        assert first.url == "https://mangavyvy.net/manga/naruto-bc8"
+        assert first.cover_url == "https://cdnxyz.xyz/web/cover/841/thumbnail.png"
+
+    def test_relative_urls_are_absolutised(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "search.html"))
+        results = scraper.search("naruto")
+        assert all(r.url.startswith("https://mangavyvy.net/manga/") for r in results)
+
+    def test_title_falls_back_to_img_alt(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "search.html"))
+        results = scraper.search("naruto")
+        # The third fixture entry has no .comic-title, only img alt.
+        assert any(r.title == "Boruto: Naruto Next Generations" for r in results)
+
+    def test_no_results(self, scraper, patch_html):
+        patch_html(scraper, "<html><body></body></html>")
+        assert scraper.search("nothing") == []
+
+
+class TestGetChapters:
+    def test_numbers_from_id_sorted_ascending_and_deduped(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "manga.html"))
+        chapters = scraper.get_chapters("https://mangavyvy.net/manga/naruto-bc8")
+        # 3 unique chapters (the duplicate chapter-1 href is collapsed)
+        assert len(chapters) == 3
+        nums = [c.numeric for c in chapters]
+        assert nums == sorted(nums)
+        # Number comes from id="chapter-<num>", ignoring the "Vol.72" prefix text.
+        assert [c.number for c in chapters] == ["1", "700", "700.5"]
+
+    def test_decimal_chapter_detected(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "manga.html"))
+        chapters = scraper.get_chapters("https://mangavyvy.net/manga/naruto-bc8")
+        assert any(c.number == "700.5" for c in chapters)
+
+    def test_chapter_url_is_the_redirect_href(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "manga.html"))
+        chapters = scraper.get_chapters("https://mangavyvy.net/manga/naruto-bc8")
+        assert all("aovheroes.com" in c.url for c in chapters)
+
+
+class TestGetPages:
+    def test_reads_carousel_and_skips_loading_and_related(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "chapter.html"))
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        # 3 reader pages; loading.gif skipped and the related-manga
+        # collection thumbnail (outside #carousel) excluded.
+        assert len(pages) == 3
+        assert all("drive-storage" in p for p in pages)
+        assert not any("loading" in p.lower() for p in pages)
+        assert not any("collections" in p for p in pages)
+
+    def test_preserves_page_order(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "chapter.html"))
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        assert pages == [
+            "https://2.bp.blogspot.com/drive-storage/PAGE-001=w700",
+            "https://2.bp.blogspot.com/drive-storage/PAGE-002=w700",
+            "https://2.bp.blogspot.com/drive-storage/PAGE-003=w700",
+        ]
+
+
+class TestDownloadImage:
+    def test_success_writes_file(self, monkeypatch, scraper, tmp_path, fake_response):
+        monkeypatch.setattr(scraper.session, "get",
+                             lambda *a, **k: fake_response(content=b"data" * 100))
+        ok = scraper.download_image("https://x.com/p.jpg", tmp_path / "p.jpg")
+        assert ok is True
+        assert (tmp_path / "p.jpg").exists()
+
+    def test_failure_returns_false(self, monkeypatch, scraper, tmp_path):
+        def boom(*a, **k):
+            raise IOError("nope")
+        monkeypatch.setattr(scraper.session, "get", boom)
+        assert scraper.download_image("https://x", tmp_path / "p.jpg") is False
+
+
+class TestRegistry:
+    @pytest.mark.parametrize("domain", ["mangavyvy.net", "vymanga.net", "www.vymanga.net"])
+    def test_domains_resolve(self, domain):
+        assert isinstance(get_scraper(domain), VyMangaScraper)

--- a/tests/scrapers/test_vymanga.py
+++ b/tests/scrapers/test_vymanga.py
@@ -61,16 +61,61 @@ class TestGetChapters:
         chapters = scraper.get_chapters("https://mangavyvy.net/manga/naruto-bc8")
         assert all("aovheroes.com" in c.url for c in chapters)
 
+    @pytest.mark.parametrize("legacy_url", [
+        "https://vymanga.net/manga/naruto-bc8",
+        "https://www.vymanga.net/manga/naruto-bc8",
+        "https://vyvymanga.net/manga/naruto-bc8",
+        "https://www.vyvymanga.net/manga/naruto-bc8",
+    ])
+    def test_legacy_host_urls_are_fetched_from_canonical_host(
+        self, scraper, load_fixture, monkeypatch, legacy_url
+    ):
+        # Direct old-domain manga URLs 403 upstream; get_chapters must fetch the
+        # identical path from the canonical host instead.
+        fetched = []
+
+        def fake_get_html(url):
+            fetched.append(url)
+            return load_fixture("vymanga", "manga.html")
+
+        monkeypatch.setattr(scraper, "_get_html", fake_get_html)
+        chapters = scraper.get_chapters(legacy_url)
+        assert fetched == ["https://mangavyvy.net/manga/naruto-bc8"]
+        assert len(chapters) == 3
+
+    def test_canonical_host_url_is_left_untouched(self, scraper, load_fixture, monkeypatch):
+        fetched = []
+
+        def fake_get_html(url):
+            fetched.append(url)
+            return load_fixture("vymanga", "manga.html")
+
+        monkeypatch.setattr(scraper, "_get_html", fake_get_html)
+        scraper.get_chapters("https://mangavyvy.net/manga/naruto-bc8?x=1")
+        assert fetched == ["https://mangavyvy.net/manga/naruto-bc8?x=1"]
+
 
 class TestGetPages:
     def test_reads_carousel_and_skips_loading_and_related(self, scraper, patch_html, load_fixture):
         patch_html(scraper, load_fixture("vymanga", "chapter.html"))
         pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
         # 3 reader pages; loading.gif skipped and the related-manga
-        # collection thumbnail (outside #carousel) excluded.
+        # collection thumbnail excluded.
         assert len(pages) == 3
         assert all("drive-storage" in p for p in pages)
         assert not any("loading" in p.lower() for p in pages)
+        assert not any("collections" in p for p in pages)
+
+    def test_excludes_same_author_recommendation_thumbnails(self, scraper, patch_html, load_fixture):
+        # The live reader embeds a "same author" recommendation table *inside*
+        # the page carousel; its cover thumbnails (img-recommend, served from
+        # the site's own cover CDN) must never be scraped as pages.
+        patch_html(scraper, load_fixture("vymanga", "chapter.html"))
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        assert len(pages) == 3
+        assert all("2.bp.blogspot.com" in p for p in pages)
+        assert not any("cdnxyz" in p for p in pages)
+        assert not any("/cover/" in p for p in pages)
         assert not any("collections" in p for p in pages)
 
     def test_preserves_page_order(self, scraper, patch_html, load_fixture):
@@ -81,6 +126,50 @@ class TestGetPages:
             "https://2.bp.blogspot.com/drive-storage/PAGE-002=w700",
             "https://2.bp.blogspot.com/drive-storage/PAGE-003=w700",
         ]
+
+    def test_keeps_pages_whose_cdn_id_contains_placeholder_words(self, scraper, patch_html):
+        # Reader page IDs are opaque base64 blobs that can coincidentally
+        # contain "icon"/"logo"/"blank" etc. Those pages must NOT be dropped.
+        html = """
+        <div id="carousel" class="carousel slide"><div class="vview carousel-inner">
+          <div class="carousel-item active">
+            <img class="d-block w-100" data-src="https://2.bp.blogspot.com/drive-storage/AAiconBBlogoCC=w700"
+                 src="https://mangavyvy.net/web/img/loading.gif">
+          </div>
+          <div class="carousel-item">
+            <img class="d-block w-100" data-src="https://2.bp.blogspot.com/drive-storage/blankXYloading=w700"
+                 src="https://mangavyvy.net/web/img/loading.gif">
+          </div>
+        </div></div>
+        """
+        patch_html(scraper, html)
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        assert pages == [
+            "https://2.bp.blogspot.com/drive-storage/AAiconBBlogoCC=w700",
+            "https://2.bp.blogspot.com/drive-storage/blankXYloading=w700",
+        ]
+
+    def test_skips_gif_placeholder_when_no_datasrc(self, scraper, patch_html):
+        # A slide that never lazy-loaded (only the loading.gif in src) is skipped
+        # rather than emitted as a bogus page.
+        html = """
+        <div id="carousel" class="carousel slide"><div class="vview carousel-inner">
+          <div class="carousel-item active">
+            <img class="d-block w-100" src="https://mangavyvy.net/web/img/loading.gif">
+          </div>
+          <div class="carousel-item">
+            <img class="d-block w-100" data-src="https://2.bp.blogspot.com/drive-storage/REAL=w700"
+                 src="https://mangavyvy.net/web/img/loading.gif">
+          </div>
+        </div></div>
+        """
+        patch_html(scraper, html)
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        assert pages == ["https://2.bp.blogspot.com/drive-storage/REAL=w700"]
+
+    def test_no_pages(self, scraper, patch_html):
+        patch_html(scraper, "<html><body><p>no reader here</p></body></html>")
+        assert scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==") == []
 
 
 class TestDownloadImage:
@@ -99,6 +188,35 @@ class TestDownloadImage:
 
 
 class TestRegistry:
-    @pytest.mark.parametrize("domain", ["mangavyvy.net", "vymanga.net", "www.vymanga.net"])
+    @pytest.mark.parametrize("domain", [
+        "mangavyvy.net",
+        "vymanga.net",
+        "vyvymanga.net",
+    ])
     def test_domains_resolve(self, domain):
         assert isinstance(get_scraper(domain), VyMangaScraper)
+
+    @pytest.mark.parametrize("domain", [
+        "www.mangavyvy.net",
+        "www.vymanga.net",
+        "www.vyvymanga.net",
+    ])
+    def test_www_prefix_resolves(self, domain):
+        # get_scraper strips the leading "www." before lookup.
+        assert isinstance(get_scraper(domain), VyMangaScraper)
+
+    @pytest.mark.parametrize("domain", [
+        "m.mangavyvy.net",
+        "read.vyvymanga.net",
+    ])
+    def test_subdomain_suffix_resolves(self, domain):
+        # Arbitrary subdomains suffix-match their registered base host.
+        assert isinstance(get_scraper(domain), VyMangaScraper)
+
+    def test_legacy_host_in_registry_matches_canonicaliser(self):
+        # Every host the scraper canonicalises must also resolve via the
+        # registry, so saved/manual entries reach a scraper before
+        # canonicalisation runs.
+        from memanga.scrapers.vymanga import _LEGACY_HOSTS
+        for host in _LEGACY_HOSTS:
+            assert isinstance(get_scraper(host), VyMangaScraper), host


### PR DESCRIPTION
## Summary

Add VY Manga scraper support and harden it for the currently observed production domains. The scraper now searches the canonical site, resolves chapters, follows the reader redirect chain, extracts only real chapter pages, and canonicalizes legacy VY Manga hosts before fetching manga pages so saved or manually added old-domain URLs still work.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #156

## Verification

- `venv/bin/python -m pytest tests/scrapers/test_vymanga.py tests/unit/scrapers/test_scraper_registry.py tests/scrapers/test_registry_coverage.py -q` passed locally: 1014 passed.
- Live registry proof resolved `mangavyvy.net`, `vymanga.net`, `www.vymanga.net`, `vyvymanga.net`, `www.vyvymanga.net`, and `read.vyvymanga.net` to `VyMangaScraper`.
- Live VY Manga proof: search returned 20 results, Naruto detail returned 748 chapters from canonical and legacy domains, chapter 0 returned 46 page images, recommendation covers were excluded, and page 1 downloaded as a valid JPEG.