### PR TITLE
feat(scrapers): add Mangadot source

### DIFF
--- a/memanga/scrapers/__init__.py
+++ b/memanga/scrapers/__init__.py
@@ -17,6 +17,7 @@ Working sources:
 - Manganato (manganato.com) - Same network as Kakalot
 - Mangago (mangago.me) - Large yaoi/shoujo collection
 - MangaTaro (mangataro.org) - ComicK replacement, popular aggregator
+- Mangadot (mangadot.net) - Multi-language aggregator (SSR + JSON API)
 - MangaFire (mangafire.to) - VRF bypass + image descrambling (Playwright)
 - Plus ~80 template-based scrapers via registry (Nuxt SSR, OG Image Meta, Madara, Laiond CDN, Mangosm)
 """
@@ -41,6 +42,7 @@ from .mangakakalot import MangakakalotScraper
 from .manganato import ManganatoScraper
 from .mangago import MangagoScraper
 from .mangataro import MangaTaroScraper
+from .mangadot import MangadotScraper
 from .flamecomics import FlameComicsScraper
 from .luminousscans import LuminousScansScraper
 from .mangahere import MangaHereScraper
@@ -222,6 +224,9 @@ SCRAPERS = {
 
     # MangaTaro (ComicK replacement)
     "mangataro.org": MangaTaroScraper,
+
+    # Mangadot - Multi-language aggregator (React Router SSR + JSON API)
+    "mangadot.net": MangadotScraper,
 
     # FlameComics
     "flamecomics.xyz": FlameComicsScraper,

--- a/memanga/scrapers/mangadot.py
+++ b/memanga/scrapers/mangadot.py
@@ -1,0 +1,235 @@
+"""
+Mangadot scraper - Multi-language manga aggregator
+Site: mangadot.net
+
+Mangadot is a React-Router SSR app behind Cloudflare, but the data that
+matters is reachable over plain HTTP without a browser:
+
+* search   -> GET /search?search=<query> renders manga cards server-side.
+* chapters -> GET /api/manga/<id>/chapters/list returns a JSON array with one
+              entry per language/scanlation group.
+* pages    -> the reader loads page images from /api/uploads/<id>/images for
+              user uploads and /api/chapters/<id>/images for everything else;
+              both return an ordered ``images`` list of site-relative URLs.
+
+Page images are served directly (no Referer/token needed), so the base-class
+``download_image`` handles the actual downloads.
+"""
+
+import re
+import time
+from typing import List, Optional
+from urllib.parse import quote_plus, urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+from .base import BaseScraper, Chapter, Manga, _retry
+
+
+class MangadotScraper(BaseScraper):
+    """Scraper for Mangadot (mangadot.net)."""
+
+    name = "mangadot"
+    base_url = "https://mangadot.net"
+
+    # URL helpers
+
+    def _abs_url(self, href: str) -> str:
+        """Absolutize a site-relative URL against the base host."""
+        return urljoin(self.base_url + "/", href or "")
+
+    @staticmethod
+    def _manga_id(url: str) -> Optional[str]:
+        match = re.search(r"/manga/(\d+)", url or "")
+        return match.group(1) if match else None
+
+    @staticmethod
+    def _chapter_id(url: str) -> Optional[str]:
+        match = re.search(r"/chapter/(\d+)", url or "")
+        return match.group(1) if match else None
+
+    # Search
+
+    def search(self, query: str) -> List[Manga]:
+        """Search for manga by title."""
+        html = self._get_html(f"{self.base_url}/search?search={quote_plus(query)}")
+        return self._parse_search(html)
+
+    def _parse_search(self, html: str) -> List[Manga]:
+        """Parse the search page into Manga results.
+
+        Each result card is an ``<a href="/manga/<id>">`` wrapping a cover
+        ``<img>`` plus a ``div.line-clamp-2`` holding the clean title (the
+        anchor's raw text also carries the "Manga" type badge and a star
+        rating, so the title div is used instead).
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        results = []
+        seen = set()
+        for anchor in soup.select('a[href^="/manga/"]'):
+            manga_id = self._manga_id(anchor.get("href", ""))
+            if not manga_id or manga_id in seen:
+                continue
+
+            title_el = anchor.select_one("div.line-clamp-2")
+            title = (title_el.get_text(strip=True) if title_el else "").strip()
+            if not title:
+                continue
+            seen.add(manga_id)
+
+            cover_url = None
+            img = anchor.find("img")
+            if img:
+                src = img.get("src") or img.get("data-src")
+                cover_url = self._abs_url(src) if src else None
+
+            results.append(Manga(
+                title=title,
+                url=f"{self.base_url}/manga/{manga_id}",
+                cover_url=cover_url,
+            ))
+
+        return results[:20]
+
+    # Chapters
+
+    def get_chapters(self, manga_url: str) -> List[Chapter]:
+        """Get all chapters for a manga via the chapters-list API."""
+        manga_id = self._manga_id(manga_url)
+        if not manga_id:
+            return []
+        data = self._get_json(f"{self.base_url}/api/manga/{manga_id}/chapters/list")
+        return self._parse_chapters(data)
+
+    def _parse_chapters(self, data) -> List[Chapter]:
+        """Parse the chapters-list JSON into Chapter objects.
+
+        A chapter number can appear once per language and scanlation group;
+        keep a single readable release per number, preferring English so the
+        downloader gets one clean list instead of duplicate rows.
+        """
+        if not isinstance(data, list):
+            return []
+
+        best = {}
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("id") is None or entry.get("chapter_number") is None:
+                continue
+            key = self._chapter_number(entry)
+            current = best.get(key)
+            if current is None or (
+                self._is_english(entry) and not self._is_english(current)
+            ):
+                best[key] = entry
+
+        chapters = []
+        for entry in best.values():
+            number = self._chapter_number(entry)
+            title = (entry.get("chapter_title") or "").strip() or f"Chapter {number}"
+            chapters.append(Chapter(
+                number=number,
+                title=title,
+                url=f"{self.base_url}/chapter/{entry['id']}",
+                date=self._clean_date(entry.get("date_added")),
+            ))
+
+        return sorted(chapters, key=lambda ch: ch.numeric)
+
+    @staticmethod
+    def _is_english(entry: dict) -> bool:
+        return (entry.get("language") or "").lower().startswith("en")
+
+    @staticmethod
+    def _chapter_number(entry: dict) -> str:
+        """Derive a clean chapter-number string from a listing entry."""
+        raw = entry.get("chapter_number")
+        try:
+            num = float(raw)
+            return str(int(num)) if num.is_integer() else str(num)
+        except (TypeError, ValueError):
+            match = re.search(r"(\d+(?:\.\d+)?)", str(raw or ""))
+            return match.group(1) if match else "0"
+
+    @staticmethod
+    def _clean_date(raw) -> Optional[str]:
+        """Reduce ``2026-08-10 14:31:28.120232+00`` to a plain ``YYYY-MM-DD``.
+
+        The downloader's ComicInfo date parser reads ``%Y-%m-%d`` cleanly,
+        whereas the raw ``+00`` offset is not a valid ISO offset.
+        """
+        if not raw:
+            return None
+        return str(raw).split(" ", 1)[0].strip() or None
+
+    # Pages
+
+    def get_pages(self, chapter_url: str) -> List[str]:
+        """Get all page image URLs for a chapter."""
+        chapter_id = self._chapter_id(chapter_url)
+        if not chapter_id:
+            return []
+        payload = self._get_images_payload(chapter_id)
+        return self._parse_pages(payload)
+
+    def _get_images_payload(self, chapter_id: str) -> Optional[dict]:
+        """Fetch a chapter's page-image payload from whichever endpoint applies.
+
+        The reader serves user uploads from ``/api/uploads/<id>/images`` and
+        other chapters from ``/api/chapters/<id>/images``; the wrong endpoint
+        returns 404, so try the upload endpoint first (the common case) and
+        fall back to the other.
+        """
+        for path in (
+            f"/api/uploads/{chapter_id}/images",
+            f"/api/chapters/{chapter_id}/images",
+        ):
+            payload = self._get_json_optional(self.base_url + path)
+            if payload and payload.get("images"):
+                return payload
+        return None
+
+    def _get_json_optional(self, url: str) -> Optional[dict]:
+        """Rate-limited JSON GET that tolerates a 404.
+
+        Returns ``None`` (instead of raising) when the endpoint does not apply
+        to this chapter, so ``_get_images_payload`` can try the alternate one
+        without paying the retry back-off a real error would trigger. Transient
+        failures still retry via ``_retry``.
+        """
+        def _do_get():
+            with self._rate_lock:
+                elapsed = time.time() - self._last_request
+                if elapsed < self._rate_limit:
+                    time.sleep(self._rate_limit - elapsed)
+                self._last_request = time.time()
+
+            resp = self.session.get(
+                url,
+                headers={"Accept": "application/json"},
+                timeout=30,
+            )
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            return resp.json()
+
+        return _retry(
+            _do_get,
+            max_attempts=3,
+            base_delay=1.0,
+            exceptions=(requests.RequestException,),
+        )
+
+    def _parse_pages(self, payload: Optional[dict]) -> List[str]:
+        """Extract ordered, absolute page image URLs from an images payload."""
+        images = (payload or {}).get("images") or []
+        pages = []
+        for image in images:
+            url = image.get("url") if isinstance(image, dict) else image
+            if not isinstance(url, str) or not url.strip():
+                continue
+            pages.append(self._abs_url(url.strip()))
+        return pages

--- a/tests/scrapers/test_mangadot.py
+++ b/tests/scrapers/test_mangadot.py
@@ -1,0 +1,252 @@
+"""HTML/JSON-fixture tests for the Mangadot scraper.
+
+The network-facing helpers (``_get_html`` / ``_get_json`` / ``_get_json_optional``)
+are never invoked here - these tests exercise only the pure parsing and
+normalisation layer, using payloads shaped after the live ``mangadot.net``
+search page and ``/api`` responses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import get_scraper
+from memanga.scrapers.mangadot import MangadotScraper
+
+
+@pytest.fixture
+def md():
+    return MangadotScraper()
+
+
+# Smoke
+
+
+def test_instantiates_and_has_required_api():
+    s = get_scraper("mangadot.net")
+    assert isinstance(s, MangadotScraper)
+    for method in ("search", "get_chapters", "get_pages", "download_image"):
+        assert callable(getattr(s, method))
+
+
+# URL helpers
+
+
+class TestUrlHelpers:
+    def test_manga_id(self):
+        assert MangadotScraper._manga_id("https://mangadot.net/manga/25867") == "25867"
+        assert MangadotScraper._manga_id("/manga/41") == "41"
+
+    def test_manga_id_missing(self):
+        assert MangadotScraper._manga_id("https://mangadot.net/search?search=x") is None
+
+    def test_chapter_id(self):
+        assert MangadotScraper._chapter_id("https://mangadot.net/chapter/1263396") == "1263396"
+
+    def test_chapter_id_missing(self):
+        assert MangadotScraper._chapter_id("https://mangadot.net/manga/41") is None
+
+    def test_abs_url_relative(self, md):
+        assert md._abs_url("/uploads/thumbs/320/a.webp") == \
+            "https://mangadot.net/uploads/thumbs/320/a.webp"
+
+    def test_abs_url_absolute_passthrough(self, md):
+        assert md._abs_url("https://mangadot.net/chapters/manga_41/x/001.jpg") == \
+            "https://mangadot.net/chapters/manga_41/x/001.jpg"
+
+
+# Search
+
+
+SEARCH_HTML = """
+<html><body>
+  <a class="group flex flex-col" href="/manga/41">
+    <div class="relative">
+      <img src="/uploads/thumbs/320/onepiece.webp.webp"/>
+      <span>Manga</span><span>&#9733; 9.3</span>
+    </div>
+    <div class="line-clamp-2 text-[12px]">ONE PIECE</div>
+  </a>
+  <a class="group flex flex-col" href="/manga/37534">
+    <div class="relative"><img src="/uploads/thumbs/320/side.jpg.webp"/></div>
+    <div class="line-clamp-2">One Piece: Mugiwara Daigekijou</div>
+  </a>
+  <!-- Duplicate manga id must be dropped. -->
+  <a href="/manga/41"><div class="line-clamp-2">One Piece (dup)</div></a>
+  <!-- Card without a title div is ignored (e.g. a nav/section link). -->
+  <a href="/manga/999"><img src="/uploads/x.webp"/></a>
+</body></html>
+"""
+
+
+class TestSearch:
+    def test_parses_cards_with_titles_and_covers(self, md):
+        results = md._parse_search(SEARCH_HTML)
+        assert [r.title for r in results] == [
+            "ONE PIECE",
+            "One Piece: Mugiwara Daigekijou",
+        ]
+        assert results[0].url == "https://mangadot.net/manga/41"
+        # Cover made absolute.
+        assert results[0].cover_url == \
+            "https://mangadot.net/uploads/thumbs/320/onepiece.webp.webp"
+
+    def test_empty_page_returns_empty(self, md):
+        assert md._parse_search("<html><body></body></html>") == []
+
+    def test_search_fetches_query_url(self, monkeypatch, md):
+        seen = {}
+
+        def fake_get_html(url, *a, **k):
+            seen["url"] = url
+            return SEARCH_HTML
+
+        monkeypatch.setattr(md, "_get_html", fake_get_html)
+        results = md.search("one piece")
+        assert seen["url"] == "https://mangadot.net/search?search=one+piece"
+        assert len(results) == 2
+
+
+# Chapters
+
+
+def _entry(cid, number, language="en", title=None, date="2026-08-10 14:31:28.120232+00"):
+    return {
+        "id": cid,
+        "chapter_number": number,
+        "chapter_title": title if title is not None else f"Chapter {number}",
+        "language": language,
+        "group_id": 14972,
+        "page_count": 12,
+        "source": "user",
+        "date_added": date,
+    }
+
+
+CHAPTERS_DATA = [
+    # Chapter 1 exists in French then English -> English release wins.
+    _entry(500, 1, language="fr", title="Ch 1 FR"),
+    _entry(501, 1, language="en", title="Ch 1 EN"),
+    # A decimal chapter, English only.
+    _entry(510, "1.5"),
+    # Chapter 2 has no English release -> the sole French release is kept.
+    _entry(520, 2, language="fr", title="Ch 2 FR"),
+    # Rows with missing id / number are dropped.
+    {"id": None, "chapter_number": 3},
+    {"id": 530, "chapter_number": None},
+]
+
+
+class TestChapters:
+    def test_dedupes_prefers_english_sorts_and_normalises(self, md):
+        chapters = md._parse_chapters(CHAPTERS_DATA)
+        # One chapter per number, sorted ascending.
+        assert [c.number for c in chapters] == ["1", "1.5", "2"]
+        # English release chosen for chapter 1 (id 501, not the French 500).
+        first = chapters[0]
+        assert first.url == "https://mangadot.net/chapter/501"
+        assert first.title == "Ch 1 EN"
+        # Chapter 2 falls back to the only (French) release.
+        two = next(c for c in chapters if c.number == "2")
+        assert two.url == "https://mangadot.net/chapter/520"
+        # Date trimmed to YYYY-MM-DD.
+        assert first.date == "2026-08-10"
+
+    def test_non_list_returns_empty(self, md):
+        assert md._parse_chapters({"error": "nope"}) == []
+        assert md._parse_chapters(None) == []
+
+    def test_chapter_number_from_int_float_and_text(self):
+        assert MangadotScraper._chapter_number({"chapter_number": 0}) == "0"
+        assert MangadotScraper._chapter_number({"chapter_number": 726}) == "726"
+        assert MangadotScraper._chapter_number({"chapter_number": "11.0"}) == "11"
+        assert MangadotScraper._chapter_number({"chapter_number": 725.5}) == "725.5"
+        assert MangadotScraper._chapter_number({"chapter_number": "Vol 2 Ch 42"}) == "2"
+        assert MangadotScraper._chapter_number({"chapter_number": None}) == "0"
+
+    def test_clean_date(self):
+        assert MangadotScraper._clean_date("2026-08-10 14:31:28.120232+00") == "2026-08-10"
+        assert MangadotScraper._clean_date("") is None
+        assert MangadotScraper._clean_date(None) is None
+
+    def test_get_chapters_invalid_url_returns_empty(self, md):
+        assert md.get_chapters("https://mangadot.net/search?search=x") == []
+
+    def test_get_chapters_fetches_list_endpoint(self, monkeypatch, md):
+        seen = {}
+
+        def fake_get_json(url, *a, **k):
+            seen["url"] = url
+            return CHAPTERS_DATA
+
+        monkeypatch.setattr(md, "_get_json", fake_get_json)
+        chapters = md.get_chapters("https://mangadot.net/manga/25867")
+        assert seen["url"] == "https://mangadot.net/api/manga/25867/chapters/list"
+        assert len(chapters) == 3
+
+
+# Pages
+
+
+IMAGES_PAYLOAD = {
+    "chapter": {"id": 121126, "manga_id": 46, "page_count": 3},
+    "images": [
+        {"url": "/chapters/manga_46/chapter_232_g10712/001.jpg", "w": 0, "h": 0},
+        {"url": "/chapters/manga_46/chapter_232_g10712/002.jpg", "w": 0, "h": 0},
+        {"url": "/chapters/manga_41/user_8_ch1190_en_abc/003.webp", "w": 0, "h": 0},
+    ],
+}
+
+
+class TestPages:
+    def test_parses_images_to_absolute_urls(self, md):
+        pages = md._parse_pages(IMAGES_PAYLOAD)
+        assert pages == [
+            "https://mangadot.net/chapters/manga_46/chapter_232_g10712/001.jpg",
+            "https://mangadot.net/chapters/manga_46/chapter_232_g10712/002.jpg",
+            "https://mangadot.net/chapters/manga_41/user_8_ch1190_en_abc/003.webp",
+        ]
+
+    def test_empty_or_missing_images(self, md):
+        assert md._parse_pages(None) == []
+        assert md._parse_pages({}) == []
+        assert md._parse_pages({"images": []}) == []
+
+    def test_skips_malformed_image_entries(self, md):
+        payload = {"images": [{"url": ""}, {"nope": 1}, {"url": "/a/001.jpg"}]}
+        assert md._parse_pages(payload) == ["https://mangadot.net/a/001.jpg"]
+
+    def test_get_pages_invalid_url_returns_empty(self, md):
+        assert md.get_pages("https://mangadot.net/manga/46") == []
+
+    def test_get_pages_uses_upload_endpoint_first(self, monkeypatch, md):
+        calls = []
+
+        def fake_optional(url):
+            calls.append(url)
+            if url.endswith("/api/uploads/121126/images"):
+                return IMAGES_PAYLOAD
+            raise AssertionError("should not reach the chapters endpoint")
+
+        monkeypatch.setattr(md, "_get_json_optional", fake_optional)
+        pages = md.get_pages("https://mangadot.net/chapter/121126")
+        assert calls == ["https://mangadot.net/api/uploads/121126/images"]
+        assert len(pages) == 3
+
+    def test_get_pages_falls_back_to_chapters_endpoint(self, monkeypatch, md):
+        calls = []
+
+        def fake_optional(url):
+            calls.append(url)
+            # Upload endpoint doesn't apply (404 -> None); chapters one does.
+            if url.endswith("/api/uploads/26329/images"):
+                return None
+            return IMAGES_PAYLOAD
+
+        monkeypatch.setattr(md, "_get_json_optional", fake_optional)
+        pages = md.get_pages("https://mangadot.net/chapter/26329")
+        assert calls == [
+            "https://mangadot.net/api/uploads/26329/images",
+            "https://mangadot.net/api/chapters/26329/images",
+        ]
+        assert len(pages) == 3


### PR DESCRIPTION
## Summary

Adds Mangadot scraper support for `mangadot.net` using the server-rendered search page and JSON chapter/image APIs. The scraper handles both user-upload image payloads and normal chapter image payloads, then returns direct page image URLs for downloading.

Live probe covered search, chapter discovery, page extraction, and actual image download for both image API paths.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #157