### PR TITLE
fix(release): package macOS app downloads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,17 +16,20 @@ jobs:
           - os: windows-latest
             artifact_name: MeManga.exe
             asset_name: MeManga-windows-x64.exe
-          # macos-latest is an Apple Silicon (arm64) runner.
+          # macos-latest is an Apple Silicon (arm64) runner. The built
+          # binary ships wrapped in MeManga.app inside a .zip (issue #163)
+          # so the download is a normal double-clickable app, not a raw
+          # extensionless Mach-O that opens in TextEdit.
           - os: macos-latest
             artifact_name: MeManga
-            asset_name: MeManga-macos-arm64
+            asset_name: MeManga-macos-arm64.zip
             target_arch: arm64
           # macos-26-intel is GitHub's current standard x64 macOS runner
           # image, so the x86_64 slice is built natively rather than
           # cross-compiled from Apple Silicon.
           - os: macos-26-intel
             artifact_name: MeManga
-            asset_name: MeManga-macos-x64
+            asset_name: MeManga-macos-x64.zip
             target_arch: x86_64
           - os: ubuntu-latest
             artifact_name: MeManga
@@ -134,7 +137,40 @@ jobs:
             exit 1
           }
 
+      - name: Package macOS app bundle (MeManga.app in .zip)
+        # Root-cause fix for issue #163. GitHub serves the raw one-file
+        # Mach-O as application/octet-stream, so a browser download lands
+        # as an extensionless document (opens in TextEdit) and loses its
+        # executable bit (mode 0644). Wrap the just-verified binary in a
+        # minimal MeManga.app and archive it with `ditto`, which preserves
+        # the exec bit and bundle layout, so users get a normal app to
+        # double-click. `ditto --keepParent` keeps MeManga.app as the
+        # top-level folder inside the zip.
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          python packaging/macos_app.py build \
+            --exe "release/${{ matrix.artifact_name }}" \
+            --dest release \
+            --icon packaging/icon.icns
+          ditto -c -k --keepParent "release/MeManga.app" "${{ matrix.asset_name }}"
+
+      - name: Validate packaged macOS app bundle
+        # Release gate: the uploaded .zip must contain a launchable
+        # MeManga.app/Contents/MacOS/MeManga (exec bit set), a valid
+        # Info.plist, and the CPU slice this matrix leg targets — not just
+        # a raw Mach-O. Fails the release before anything reaches the page.
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          python packaging/macos_app.py validate \
+            --path "${{ matrix.asset_name }}" \
+            --arch "${{ matrix.target_arch }}"
+
       - name: Rename artifact for upload
+        # Windows/Linux ship the raw one-file exe directly; macOS already
+        # produced its .zip asset in the packaging step above.
+        if: runner.os != 'macOS'
         shell: bash
         run: mv "release/${{ matrix.artifact_name }}" "${{ matrix.asset_name }}"
 

--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ Works offline once chapters are downloaded.
 
 ## Download
 
-The fastest path is the release binary. Just double-click and you're in.
+The fastest path is the release download for your platform.
 
 | OS | File |
 |---|---|
 | Windows | [`MeManga-windows-x64.exe`](https://github.com/meellm/MeManga/releases/latest) |
-| macOS (Apple Silicon) | [`MeManga-macos-arm64`](https://github.com/meellm/MeManga/releases/latest) |
-| macOS (Intel) | [`MeManga-macos-x64`](https://github.com/meellm/MeManga/releases/latest) |
+| macOS (Apple Silicon) | [`MeManga-macos-arm64.zip`](https://github.com/meellm/MeManga/releases/latest) |
+| macOS (Intel) | [`MeManga-macos-x64.zip`](https://github.com/meellm/MeManga/releases/latest) |
 | Linux (x86_64) | [`MeManga-linux-x64`](https://github.com/meellm/MeManga/releases/latest) |
+
+On macOS the download is a `.zip` — unzip it to get `MeManga.app`, then double-click.
 
 > **First launch downloads Firefox** (~80 MB download, one-time.)
 > Playwright uses it under the hood to scrape JS-heavy sources like MangaFire and WeebCentral.

--- a/packaging/macos_app.py
+++ b/packaging/macos_app.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""macOS `.app` packaging for the MeManga RELEASE build (issue #163).
+
+`build_app.py` + PyInstaller produce a single-file Mach-O executable
+(`release/MeManga`). GitHub serves that extensionless file as
+`application/octet-stream`, so a browser download lands as a raw document
+that opens in TextEdit instead of a runnable app — and the executable bit
+is lost over the download (mode 0644). This module turns that verified
+binary into a normal, double-clickable macOS app:
+
+    release/MeManga            (one-file exe from build_app.py)
+      -> release/MeManga.app   (minimal bundle wrapping the exe)
+      -> MeManga-macos-<arch>.zip
+
+The bundle is intentionally the smallest thing Launch Services accepts as
+an application:
+
+    MeManga.app/
+      Contents/
+        Info.plist             (CFBundleExecutable = MeManga, APPL)
+        PkgInfo                 ("APPL????")
+        MacOS/MeManga           (the one-file exe, mode 0755)
+        Resources/icon.icns     (optional app icon)
+
+We wrap the already-built binary rather than switching the PyInstaller
+spec to a BUNDLE target: the one-file exe is the artifact the release
+already verifies (arch via `lipo`, Playwright self-test), so wrapping it
+keeps the launch behaviour identical and adds nothing that only a real
+macOS run could prove.
+
+Everything here is pure stdlib and platform-independent so the whole
+`build -> zip -> validate` pipeline is exercised by the unit tests on the
+Linux CI leg — the arch check reads the Mach-O header directly instead of
+shelling out to `lipo`. On the macOS release leg the workflow archives the
+bundle with Apple's `ditto` (bulletproof permission/layout fidelity) and
+then runs `validate` on the real `.zip` as a release gate.
+
+CLI:
+    python packaging/macos_app.py build    --exe release/MeManga --dest release
+    python packaging/macos_app.py zip      --app release/MeManga.app --out out.zip
+    python packaging/macos_app.py validate --path out.zip --arch x86_64
+"""
+
+from __future__ import annotations
+
+import argparse
+import plistlib
+import shutil
+import stat
+import struct
+import sys
+import zipfile
+from pathlib import Path
+
+APP_NAME = "MeManga"
+# Reverse-DNS bundle id. The app is unsigned, so this is cosmetic (shown in
+# Finder "Get Info"); it only needs to be stable and unique.
+BUNDLE_IDENTIFIER = "com.memanga.MeManga"
+
+# ── Mach-O architecture detection ───────────────────────────────────────
+# Parsing the header ourselves keeps the arch check identical on the Linux
+# test leg and the macOS release leg (no dependency on `lipo`, which only
+# exists on macOS). Only the leading 8 bytes matter: a 4-byte magic that
+# encodes 32/64-bit + endianness, followed by the 4-byte CPU type.
+_MH_MAGIC = 0xFEEDFACE      # 32-bit, big-endian file
+_MH_CIGAM = 0xCEFAEDFE      # 32-bit, little-endian file
+_MH_MAGIC_64 = 0xFEEDFACF   # 64-bit, big-endian file
+_MH_CIGAM_64 = 0xCFFAEDFE   # 64-bit, little-endian file (normal on x86_64/arm64)
+_FAT_MAGIC = 0xCAFEBABE     # universal ("fat") archive
+_FAT_CIGAM = 0xBEBAFECA
+
+_CPU_TYPE_X86_64 = 0x01000007
+_CPU_TYPE_ARM64 = 0x0100000C
+_CPU_NAMES = {_CPU_TYPE_X86_64: "x86_64", _CPU_TYPE_ARM64: "arm64"}
+
+
+def read_macho_arch(header: bytes) -> str | None:
+    """Return "x86_64", "arm64", "universal", or None for the given Mach-O
+    header bytes (the first 8 are enough). None means "not a Mach-O" — i.e.
+    something that would not launch as an app at all."""
+    if len(header) < 8:
+        return None
+    # The magic is endianness-defining, so read it big-endian and match the
+    # constant; that tells us how to read the CPU type that follows.
+    magic = struct.unpack(">I", header[:4])[0]
+    if magic in (_FAT_MAGIC, _FAT_CIGAM):
+        return "universal"
+    if magic in (_MH_MAGIC, _MH_MAGIC_64):
+        cputype = struct.unpack(">I", header[4:8])[0]
+    elif magic in (_MH_CIGAM, _MH_CIGAM_64):
+        cputype = struct.unpack("<I", header[4:8])[0]
+    else:
+        return None
+    return _CPU_NAMES.get(cputype)
+
+
+# ── Building the .app bundle ────────────────────────────────────────────
+def _source_version() -> str:
+    """Read `__version__` from memanga/__init__.py — the same string the app
+    shows in its title bar — so Finder's "Get Info" matches the release."""
+    init = Path(__file__).resolve().parent.parent / "memanga" / "__init__.py"
+    try:
+        for line in init.read_text(encoding="utf-8").splitlines():
+            if line.startswith("__version__"):
+                return line.split("=", 1)[1].strip().strip('"').strip("'")
+    except OSError:
+        pass
+    return "0.0.0"
+
+
+def _info_plist(app_name: str, version: str, has_icon: bool) -> bytes:
+    info = {
+        "CFBundleName": app_name,
+        "CFBundleDisplayName": app_name,
+        # The launcher runs Contents/MacOS/<CFBundleExecutable>; it must
+        # name the binary we drop in there or the app won't start.
+        "CFBundleExecutable": app_name,
+        "CFBundleIdentifier": BUNDLE_IDENTIFIER,
+        "CFBundlePackageType": "APPL",
+        "CFBundleInfoDictionaryVersion": "6.0",
+        "CFBundleShortVersionString": version,
+        "CFBundleVersion": version,
+        "LSMinimumSystemVersion": "10.13.0",
+        "NSHighResolutionCapable": True,
+        "LSApplicationCategoryType": "public.app-category.utilities",
+    }
+    if has_icon:
+        info["CFBundleIconFile"] = "icon.icns"
+    return plistlib.dumps(info)
+
+
+def build_app_bundle(
+    exe_path,
+    dest_dir,
+    *,
+    icon_path=None,
+    version: str | None = None,
+    app_name: str = APP_NAME,
+) -> Path:
+    """Wrap the one-file executable `exe_path` in `<dest_dir>/<app_name>.app`
+    and return the bundle path. The inner binary is written mode 0755 — that
+    executable bit is the whole point of #163."""
+    exe_path = Path(exe_path)
+    dest_dir = Path(dest_dir)
+    if not exe_path.is_file():
+        raise FileNotFoundError(f"executable not found: {exe_path}")
+
+    app = dest_dir / f"{app_name}.app"
+    contents = app / "Contents"
+    macos = contents / "MacOS"
+    resources = contents / "Resources"
+    # Start clean so a rerun never leaves stale files inside the bundle.
+    if app.exists():
+        shutil.rmtree(app)
+    macos.mkdir(parents=True)
+    resources.mkdir(parents=True)
+
+    inner = macos / app_name
+    shutil.copyfile(exe_path, inner)
+    inner.chmod(0o755)  # rwxr-xr-x — launchable
+
+    has_icon = False
+    if icon_path:
+        icon_path = Path(icon_path)
+        if icon_path.is_file():
+            shutil.copyfile(icon_path, resources / "icon.icns")
+            has_icon = True
+
+    (contents / "Info.plist").write_bytes(
+        _info_plist(app_name, version or _source_version(), has_icon)
+    )
+    # Legacy 8-byte type/creator record. Modern macOS reads Info.plist, but
+    # a well-formed bundle still carries it: 'APPL' type, '????' creator.
+    (contents / "PkgInfo").write_bytes(b"APPL????")
+    return app
+
+
+# ── Zipping the bundle ──────────────────────────────────────────────────
+# The release leg archives with `ditto` (canonical macOS tool). This
+# portable zipper produces an equivalent archive for the unit tests and for
+# any host without `ditto`. A one-file wrapper bundle contains no symlinks
+# or resource forks, so a plain zip is a faithful representation — the only
+# thing that must survive is the exec bit, stored in each entry's Unix mode.
+_DIR_MODE = 0o755
+_EXEC_MODE = 0o755
+_DATA_MODE = 0o644
+
+
+def _write_entry(zf, arcname, data, mode, *, is_dir=False):
+    zi = zipfile.ZipInfo(arcname)
+    type_bits = stat.S_IFDIR if is_dir else stat.S_IFREG
+    # Unix permission bits live in the top 16 bits of external_attr, and
+    # extractors only honour them when "version made by" says Unix (3).
+    # Without this the unzipped binary is rw-r--r-- and the app can't
+    # launch — exactly the #163 failure mode.
+    zi.external_attr = ((type_bits | mode) & 0xFFFF) << 16
+    zi.create_system = 3
+    if is_dir:
+        zi.external_attr |= 0x10  # MS-DOS directory attribute
+        zf.writestr(zi, b"")
+    else:
+        zi.compress_type = zipfile.ZIP_DEFLATED
+        zf.writestr(zi, data)
+
+
+def zip_app_bundle(app_dir, zip_path, *, app_name: str = APP_NAME) -> Path:
+    """Zip `<app_dir>` (a `*.app`) into `zip_path` with the bundle kept as the
+    top-level `<app_name>.app/` folder and Unix exec bits preserved."""
+    app_dir = Path(app_dir)
+    zip_path = Path(zip_path)
+    top = f"{app_name}.app"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        _write_entry(zf, top + "/", b"", _DIR_MODE, is_dir=True)
+        for path in sorted(app_dir.rglob("*")):
+            rel = f"{top}/{path.relative_to(app_dir).as_posix()}"
+            if path.is_symlink():
+                # A one-file wrapper has no symlinks; refuse to silently
+                # flatten one if the layout ever grows to include them.
+                raise ValueError(f"unexpected symlink in bundle: {path}")
+            if path.is_dir():
+                _write_entry(zf, rel + "/", b"", _DIR_MODE, is_dir=True)
+            else:
+                exec_bit = path.stat().st_mode & stat.S_IXUSR
+                _write_entry(zf, rel, path.read_bytes(),
+                             _EXEC_MODE if exec_bit else _DATA_MODE)
+    return zip_path
+
+
+# ── Validation (the release gate) ───────────────────────────────────────
+def _check_arch(header: bytes, expected_arch: str | None) -> list[str]:
+    arch = read_macho_arch(header)
+    if arch is None:
+        return ["MacOS/{0} is not a Mach-O binary — the app won't launch"
+                .format(APP_NAME)]
+    if expected_arch and arch != expected_arch:
+        return [f"architecture is {arch!r}, expected {expected_arch!r}"]
+    return []
+
+
+def _check_plist(data: bytes | None, app_name: str) -> list[str]:
+    if data is None:
+        return [f"missing {app_name}.app/Contents/Info.plist"]
+    try:
+        info = plistlib.loads(data)
+    except Exception:
+        return [f"{app_name}.app/Contents/Info.plist is not a valid plist"]
+    problems = []
+    if info.get("CFBundleExecutable") != app_name:
+        problems.append(
+            "Info.plist CFBundleExecutable is "
+            f"{info.get('CFBundleExecutable')!r}, expected {app_name!r}"
+        )
+    if info.get("CFBundlePackageType") != "APPL":
+        problems.append("Info.plist CFBundlePackageType is not 'APPL'")
+    return problems
+
+
+def _validate_dir(app: Path, app_name: str, expected_arch) -> list[str]:
+    problems: list[str] = []
+    exe = app / "Contents" / "MacOS" / app_name
+    plist = app / "Contents" / "Info.plist"
+
+    if not exe.is_file():
+        problems.append(f"missing {app_name}.app/Contents/MacOS/{app_name}")
+    else:
+        if not (exe.stat().st_mode & stat.S_IXUSR):
+            problems.append(
+                f"{app_name}.app/Contents/MacOS/{app_name} is not executable")
+        problems += _check_arch(exe.read_bytes()[:8], expected_arch)
+
+    problems += _check_plist(plist.read_bytes() if plist.is_file() else None,
+                             app_name)
+    return problems
+
+
+def _validate_zip(zip_path: Path, app_name: str, expected_arch) -> list[str]:
+    exe_rel = f"{app_name}.app/Contents/MacOS/{app_name}"
+    plist_rel = f"{app_name}.app/Contents/Info.plist"
+    problems: list[str] = []
+    with zipfile.ZipFile(zip_path) as zf:
+        by_name = {zi.filename: zi for zi in zf.infolist()}
+
+        if exe_rel not in by_name:
+            problems.append(f"missing {exe_rel}")
+        else:
+            # Read the exec bit from the stored Unix mode, not from an
+            # extraction — Python's zipfile drops permission bits on
+            # extract, so checking the archive entry is what matters.
+            mode = (by_name[exe_rel].external_attr >> 16) & 0o7777
+            if not (mode & stat.S_IXUSR):
+                problems.append(
+                    f"{exe_rel} is not executable (mode {mode:04o})")
+            problems += _check_arch(zf.read(exe_rel)[:8], expected_arch)
+
+        if plist_rel not in by_name:
+            problems.append(f"missing {plist_rel}")
+        else:
+            problems += _check_plist(zf.read(plist_rel), app_name)
+    return problems
+
+
+def validate_app_bundle(path, *, app_name: str = APP_NAME,
+                        expected_arch: str | None = None) -> list[str]:
+    """Return a list of problems (empty == a launchable app package) for a
+    `.app` directory or a `.zip` archive of one. Checks the launcher binary
+    exists with its exec bit, the Info.plist names it, and — when
+    `expected_arch` is given — the Mach-O architecture matches."""
+    path = Path(path)
+    if path.is_dir():
+        app = path if path.suffix == ".app" else path / f"{app_name}.app"
+        if not app.is_dir():
+            return [f"{path} contains no {app_name}.app"]
+        return _validate_dir(app, app_name, expected_arch)
+    if zipfile.is_zipfile(path):
+        return _validate_zip(path, app_name, expected_arch)
+    return [f"{path} is neither a {app_name}.app bundle nor a zip archive"]
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+def _cmd_build(args) -> int:
+    app = build_app_bundle(args.exe, args.dest, icon_path=args.icon,
+                           version=args.version)
+    print(f"built {app}")
+    if args.zip:
+        zip_app_bundle(app, args.zip)
+        print(f"zipped {args.zip}")
+    return 0
+
+
+def _cmd_zip(args) -> int:
+    zip_app_bundle(args.app, args.out)
+    print(f"zipped {args.out}")
+    return 0
+
+
+def _cmd_validate(args) -> int:
+    problems = validate_app_bundle(args.path, expected_arch=args.arch)
+    if problems:
+        print(f"INVALID macOS app package: {args.path}")
+        for p in problems:
+            print(f"  - {p}")
+        return 1
+    suffix = f" ({args.arch})" if args.arch else ""
+    print(f"OK: {args.path} is a launchable {APP_NAME}.app{suffix}")
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Package the MeManga release binary as a macOS .app.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    b = sub.add_parser("build", help="wrap the one-file exe into MeManga.app")
+    b.add_argument("--exe", required=True, help="path to the one-file binary")
+    b.add_argument("--dest", required=True, help="dir to create the .app in")
+    b.add_argument("--icon", help="optional .icns for Contents/Resources")
+    b.add_argument("--version", help="override CFBundleShortVersionString")
+    b.add_argument("--zip", help="also write a .zip of the built bundle here")
+    b.set_defaults(func=_cmd_build)
+
+    z = sub.add_parser("zip", help="zip an existing .app, preserving exec bits")
+    z.add_argument("--app", required=True)
+    z.add_argument("--out", required=True)
+    z.set_defaults(func=_cmd_zip)
+
+    v = sub.add_parser("validate", help="check a .app or .zip is launchable")
+    v.add_argument("--path", required=True)
+    v.add_argument("--arch", help="required Mach-O arch, e.g. x86_64 / arm64")
+    v.set_defaults(func=_cmd_validate)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_release_packaging.py
+++ b/tests/unit/test_release_packaging.py
@@ -1,16 +1,30 @@
-"""Static guards for the macOS release packaging (issue #146).
+"""Static guards for the macOS release packaging (issues #146 and #163).
 
-The release binary's CPU architecture follows PyInstaller's `target_arch`
-in `packaging/memanga-release.spec`. Left unset it silently follows the
-build host, so a run on an Apple Silicon runner shipped an arm64-only
-binary and left Intel Mac users with nothing to run. The fix pins the
-arch per-runner via the `MEMANGA_TARGET_ARCH` env var and ships two
-distinct macOS assets. These are cheap text/YAML checks because the real
-build only runs on a macOS CI runner and can't be exercised here.
+#146: The release binary's CPU architecture follows PyInstaller's
+`target_arch` in `packaging/memanga-release.spec`. Left unset it silently
+follows the build host, so a run on an Apple Silicon runner shipped an
+arm64-only binary and left Intel Mac users with nothing to run. The fix
+pins the arch per-runner via the `MEMANGA_TARGET_ARCH` env var and ships
+two distinct macOS assets.
+
+#163: those assets shipped as raw extensionless Mach-O executables, which
+GitHub serves as application/octet-stream — a browser download opens them
+in TextEdit and drops the exec bit. The fix wraps the binary in a
+`MeManga.app` bundle inside a `.zip` via `packaging/macos_app.py`.
+
+The workflow/spec assertions are cheap text/YAML checks because the real
+build only runs on a macOS CI runner. The `packaging/macos_app.py` helper,
+by contrast, is pure stdlib and fully exercised here — its whole reason for
+existing that way is to make the #163 fix verifiable off macOS.
 """
 
 from __future__ import annotations
 
+import importlib.util
+import plistlib
+import stat
+import struct
+import zipfile
 from pathlib import Path
 
 import yaml
@@ -18,10 +32,31 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SPEC = REPO_ROOT / "packaging" / "memanga-release.spec"
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+MACOS_APP = REPO_ROOT / "packaging" / "macos_app.py"
 
 # The GitHub Actions expression the workflow uses to thread the matrix
 # arch into both the build env and the verification step.
 ARCH_EXPR = '${{ matrix.target_arch }}'
+
+
+def _load_macos_app():
+    """Import packaging/macos_app.py by path — `packaging/` is a scripts dir,
+    not an importable package."""
+    spec = importlib.util.spec_from_file_location("memanga_macos_app", MACOS_APP)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+macos_app = _load_macos_app()
+
+
+def _fake_macho(arch: str) -> bytes:
+    """Minimal little-endian 64-bit Mach-O header (magic + cputype) padded
+    out, enough for the header-only arch check."""
+    cpu = {"x86_64": macos_app._CPU_TYPE_X86_64,
+           "arm64": macos_app._CPU_TYPE_ARM64}[arch]
+    return b"\xcf\xfa\xed\xfe" + struct.pack("<I", cpu) + b"\x00" * 64
 
 
 def test_spec_parameterizes_target_arch_from_env():
@@ -44,21 +79,33 @@ def _build_matrix():
 
 def test_workflow_ships_both_macos_arch_assets():
     """Release must produce clearly named Intel and Apple Silicon assets,
-    each pinned to its own architecture."""
+    each pinned to its own architecture and shipped as a .zip app package
+    (issue #163) rather than a raw extensionless Mach-O."""
     include = _build_matrix()
     by_asset = {e["asset_name"]: e for e in include}
 
-    assert "MeManga-macos-arm64" in by_asset, "Apple Silicon asset dropped"
-    assert "MeManga-macos-x64" in by_asset, "Intel macOS asset missing"
+    assert "MeManga-macos-arm64.zip" in by_asset, "Apple Silicon asset dropped"
+    assert "MeManga-macos-x64.zip" in by_asset, "Intel macOS asset missing"
 
-    arm = by_asset["MeManga-macos-arm64"]
-    intel = by_asset["MeManga-macos-x64"]
+    arm = by_asset["MeManga-macos-arm64.zip"]
+    intel = by_asset["MeManga-macos-x64.zip"]
     assert arm["target_arch"] == "arm64"
     assert intel["target_arch"] == "x86_64"
     # Intel slice must be built natively on an Intel runner image
     # (macos-26-intel is GitHub's current standard x64 macOS runner),
     # not cross-compiled from Apple Silicon.
     assert intel["os"] == "macos-26-intel"
+
+
+def test_macos_assets_are_zip_app_packages():
+    """Every macOS asset must be a .zip (an app package), and no macOS asset
+    may ship as a bare extensionless binary — the #163 regression."""
+    macos = [e for e in _build_matrix()
+             if str(e.get("os", "")).startswith("macos")]
+    assert macos, "no macOS build legs found"
+    for leg in macos:
+        assert leg["asset_name"].endswith(".zip"), \
+            f"macOS asset {leg['asset_name']} is not a .zip app package"
 
 
 def _step_named(fragment):
@@ -86,3 +133,158 @@ def test_workflow_verifies_architecture_before_upload():
     run = step.get("run", "")
     assert "lipo -archs" in run
     assert ARCH_EXPR in run
+
+
+# ── issue #163: macOS assets ship as launchable .app packages ───────────
+def test_workflow_packages_macos_app_bundle():
+    """A macOS-gated step must build the .app via the helper and archive it
+    into the .zip asset with `ditto` (preserves the exec bit + layout)."""
+    step = _step_named("Package macOS app bundle")
+    assert step is not None, "macOS .app packaging step missing"
+    assert step.get("if") == "runner.os == 'macOS'"
+    run = step.get("run", "")
+    assert "packaging/macos_app.py build" in run
+    assert "ditto -c -k --keepParent" in run
+    # The archived asset is the matrix's .zip asset_name.
+    assert '"${{ matrix.asset_name }}"' in run
+
+
+def test_workflow_validates_packaged_macos_app():
+    """A macOS-gated gate must validate the packaged .zip (launchable bundle
+    + expected arch) before it can be uploaded."""
+    step = _step_named("Validate packaged macOS app bundle")
+    assert step is not None, "macOS app validation gate missing"
+    assert step.get("if") == "runner.os == 'macOS'"
+    run = step.get("run", "")
+    assert "packaging/macos_app.py validate" in run
+    assert ARCH_EXPR in run
+
+
+def test_rename_step_skips_macos():
+    """The raw-binary rename is Windows/Linux only; macOS produces its .zip
+    in the packaging step, so renaming would clobber or miss it."""
+    step = _step_named("Rename artifact for upload")
+    assert step is not None
+    assert step.get("if") == "runner.os != 'macOS'"
+
+
+# ── issue #163: packaging/macos_app.py behaviour (runs off macOS) ────────
+def test_read_macho_arch_identifies_slices():
+    assert macos_app.read_macho_arch(_fake_macho("x86_64")) == "x86_64"
+    assert macos_app.read_macho_arch(_fake_macho("arm64")) == "arm64"
+    # Big-endian FAT magic -> universal.
+    assert macos_app.read_macho_arch(b"\xca\xfe\xba\xbe" + b"\x00" * 8) \
+        == "universal"
+    # Not a Mach-O at all (e.g. a text file opened in TextEdit).
+    assert macos_app.read_macho_arch(b"hello world!!") is None
+    assert macos_app.read_macho_arch(b"\x00\x00") is None
+
+
+def test_build_app_bundle_layout(tmp_path):
+    exe = tmp_path / "MeManga"
+    exe.write_bytes(_fake_macho("arm64"))
+    icon = tmp_path / "icon.icns"
+    icon.write_bytes(b"icns-bytes")
+
+    app = macos_app.build_app_bundle(exe, tmp_path / "out", icon_path=icon,
+                                     version="9.9.9")
+
+    inner = app / "Contents" / "MacOS" / "MeManga"
+    assert inner.is_file()
+    assert inner.stat().st_mode & stat.S_IXUSR, "inner binary not executable"
+    assert (app / "Contents" / "PkgInfo").read_bytes() == b"APPL????"
+    assert (app / "Contents" / "Resources" / "icon.icns").is_file()
+
+    info = plistlib.loads((app / "Contents" / "Info.plist").read_bytes())
+    assert info["CFBundleExecutable"] == "MeManga"
+    assert info["CFBundlePackageType"] == "APPL"
+    assert info["CFBundleShortVersionString"] == "9.9.9"
+    assert info["CFBundleIconFile"] == "icon.icns"
+
+
+def test_build_app_bundle_without_icon_omits_icon_key(tmp_path):
+    exe = tmp_path / "MeManga"
+    exe.write_bytes(_fake_macho("x86_64"))
+
+    app = macos_app.build_app_bundle(exe, tmp_path / "out")
+
+    info = plistlib.loads((app / "Contents" / "Info.plist").read_bytes())
+    assert "CFBundleIconFile" not in info
+    assert not (app / "Contents" / "Resources" / "icon.icns").exists()
+    # Default version falls back to the source __version__ (non-empty).
+    assert info["CFBundleShortVersionString"]
+
+
+def test_build_app_bundle_missing_exe_raises(tmp_path):
+    try:
+        macos_app.build_app_bundle(tmp_path / "nope", tmp_path / "out")
+    except FileNotFoundError:
+        return
+    raise AssertionError("expected FileNotFoundError for a missing exe")
+
+
+def _build_and_zip(tmp_path, arch="x86_64"):
+    exe = tmp_path / "MeManga"
+    exe.write_bytes(_fake_macho(arch))
+    app = macos_app.build_app_bundle(exe, tmp_path / "out", version="1.0.0")
+    zip_path = tmp_path / f"MeManga-macos-{arch}.zip"
+    macos_app.zip_app_bundle(app, zip_path)
+    return app, zip_path
+
+
+def test_validate_roundtrip_dir_and_zip(tmp_path):
+    app, zip_path = _build_and_zip(tmp_path, "x86_64")
+    assert macos_app.validate_app_bundle(app, expected_arch="x86_64") == []
+    assert macos_app.validate_app_bundle(zip_path, expected_arch="x86_64") == []
+
+
+def test_zip_preserves_executable_bit(tmp_path):
+    """The exec bit must survive into the archive — its loss is the #163
+    failure mode. Read it from the stored Unix mode, as macOS does."""
+    _, zip_path = _build_and_zip(tmp_path, "arm64")
+    with zipfile.ZipFile(zip_path) as zf:
+        zi = zf.getinfo("MeManga.app/Contents/MacOS/MeManga")
+    mode = (zi.external_attr >> 16) & 0o777
+    assert mode & stat.S_IXUSR, f"inner binary archived without exec bit ({mode:04o})"
+
+
+def test_validate_flags_wrong_architecture(tmp_path):
+    _, zip_path = _build_and_zip(tmp_path, "arm64")
+    problems = macos_app.validate_app_bundle(zip_path, expected_arch="x86_64")
+    assert any("architecture" in p for p in problems), problems
+
+
+def test_validate_flags_missing_exec_bit(tmp_path):
+    """A zip that stores the binary as rw-r--r-- (the raw-download bug) must
+    be rejected by the release gate."""
+    app, _ = _build_and_zip(tmp_path, "x86_64")
+    bad_zip = tmp_path / "bad.zip"
+    with zipfile.ZipFile(bad_zip, "w") as zf:
+        for path in sorted(app.rglob("*")):
+            if path.is_file():
+                rel = f"MeManga.app/{path.relative_to(app).as_posix()}"
+                zi = zipfile.ZipInfo(rel)
+                zi.external_attr = (0o644 & 0xFFFF) << 16  # no exec bit
+                zi.create_system = 3
+                zf.writestr(zi, path.read_bytes())
+    problems = macos_app.validate_app_bundle(bad_zip, expected_arch="x86_64")
+    assert any("not executable" in p for p in problems), problems
+
+
+def test_validate_flags_non_macho_binary(tmp_path):
+    """A wrapper around a non-Mach-O file (e.g. a text doc) is not a
+    launchable app and must be flagged."""
+    exe = tmp_path / "MeManga"
+    exe.write_bytes(b"this is not a mach-o binary\n")
+    app = macos_app.build_app_bundle(exe, tmp_path / "out")
+    problems = macos_app.validate_app_bundle(app, expected_arch="x86_64")
+    assert any("Mach-O" in p for p in problems), problems
+
+
+def test_validate_rejects_raw_binary(tmp_path):
+    """Passing the bare executable (not an app package) must fail — this is
+    literally the shape of the v0.4.2 asset that broke."""
+    raw = tmp_path / "MeManga-macos-x64"
+    raw.write_bytes(_fake_macho("x86_64"))
+    problems = macos_app.validate_app_bundle(raw)
+    assert problems  # non-empty == rejected


### PR DESCRIPTION
## Summary

Packages macOS release downloads as `.zip` files containing `MeManga.app` instead of uploading raw extensionless Mach-O binaries. Adds a macOS release validation gate for bundle layout, executable permissions, and architecture before upload, and updates the README download table.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [x] Build / CI

## Checklist

- [ ] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [ ] If you touched a scraper, you ran the live probe at least once

## Verification

- `venv/bin/python -m pytest tests/unit/test_release_packaging.py -q`
- `venv/bin/python -m py_compile packaging/macos_app.py tests/unit/test_release_packaging.py`
- Synthetic package smoke check covering build, zip, validate, unzip permission preservation, and raw-binary rejection

## Related issues

Closes #163
