### PR TITLE
fix(release): package Linux app archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,15 +134,54 @@ jobs:
             exit 1
           }
 
-      - name: Rename artifact for upload
+      - name: Package artifact for upload
+        # Windows and macOS upload the raw binary as-is; only the Linux
+        # asset is repackaged. A GitHub release asset is raw bytes with
+        # no Unix mode, and browsers save the download without the
+        # executable bit, so a raw Linux ELF lands as `-rw-r--r--` and
+        # dies with "Permission denied" before the app starts
+        # (issue #167). Wrapping the Linux binary in a gzip tarball — the
+        # format Linux users already reach for — records the +x bit
+        # *inside* the archive, so `tar xzf` restores a runnable file.
+        id: package
         shell: bash
-        run: mv "release/${{ matrix.artifact_name }}" "${{ matrix.asset_name }}"
+        run: |
+          bin="release/${{ matrix.artifact_name }}"
+          asset="${{ matrix.asset_name }}"
+          mv "$bin" "$asset"
+          if [ "${{ runner.os }}" = "Linux" ]; then
+            chmod +x "$asset"
+            tar -czf "${asset}.tar.gz" "$asset"
+            echo "upload_path=${asset}.tar.gz" >> "$GITHUB_OUTPUT"
+          else
+            echo "upload_path=${asset}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify Linux archive preserves the executable bit
+        # Release gate for issue #167: prove the tarball actually restores
+        # a runnable binary before it can reach the release page. Extract
+        # into a scratch dir and assert the extracted file is executable;
+        # a dropped +x bit fails the build instead of shipping a download
+        # users cannot launch.
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          asset="${{ matrix.asset_name }}"
+          workdir="$(mktemp -d)"
+          tar -xzf "${asset}.tar.gz" -C "$workdir"
+          extracted="$workdir/$asset"
+          ls -l "$extracted"
+          if [ ! -x "$extracted" ]; then
+            echo "::error::Extracted Linux binary is not executable — release would ship an unlaunchable file"
+            exit 1
+          fi
+          echo "OK: extracted binary is executable"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset_name }}
-          path: ${{ matrix.asset_name }}
+          path: ${{ steps.package.outputs.upload_path }}
           retention-days: 7
 
   release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+- #167 Linux release downloads now ship as `MeManga-linux-x64.tar.gz` so
+  the executable bit survives download and extraction. A raw ELF asset
+  saved through a browser lost its `+x` bit and failed to launch with
+  "Permission denied"; the tarball records the executable bit inside the
+  archive, so `tar xzf` restores a runnable binary.
+
 ## [0.4.2] - 2026-08-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Works offline once chapters are downloaded.
 
 ## Download
 
-The fastest path is the release binary. Just double-click and you're in.
+The fastest path is the release binary. On Windows and macOS, just double-click and you're in.
 
 | OS | File |
 |---|---|
 | Windows | [`MeManga-windows-x64.exe`](https://github.com/meellm/MeManga/releases/latest) |
 | macOS (Apple Silicon) | [`MeManga-macos-arm64`](https://github.com/meellm/MeManga/releases/latest) |
 | macOS (Intel) | [`MeManga-macos-x64`](https://github.com/meellm/MeManga/releases/latest) |
-| Linux (x86_64) | [`MeManga-linux-x64`](https://github.com/meellm/MeManga/releases/latest) |
+| Linux (x86_64) | [`MeManga-linux-x64.tar.gz`](https://github.com/meellm/MeManga/releases/latest) |
 
 > **First launch downloads Firefox** (~80 MB download, one-time.)
 > Playwright uses it under the hood to scrape JS-heavy sources like MangaFire and WeebCentral.
@@ -53,6 +53,17 @@ The fastest path is the release binary. Just double-click and you're in.
 > The app is not yet code-signed.
 >
 > **macOS Gatekeeper** — right-click → Open the first time; future launches are normal.
+>
+> **Linux** ships as a `.tar.gz` so the executable bit survives the download —
+> a bare binary saves as non-executable and won't launch. Extract, then run:
+>
+> ```bash
+> tar xzf MeManga-linux-x64.tar.gz
+> ./MeManga-linux-x64
+> ```
+>
+> If a file manager still clears the permission, restore it with
+> `chmod +x MeManga-linux-x64`.
 
 You can also build from the source following [Build from source](#-build-from-source) below.
 

--- a/docs/Guide.md
+++ b/docs/Guide.md
@@ -6,9 +6,11 @@ PDF / EPUB / CBZ / ZIP / JPG / PNG / WEBP, and optionally email
 them to your Kindle.
 
 > This guide covers the CLI flow only. For the desktop app, grab the
-> latest `MeManga.exe` / `MeManga` from the
-> [GitHub releases page](https://github.com/meellm/MeManga/releases)
-> and double-click — there's nothing to configure up front.
+> latest build from the
+> [GitHub releases page](https://github.com/meellm/MeManga/releases) —
+> double-click on Windows/macOS, or on Linux extract the `.tar.gz` and
+> run the binary. See the [README download section](../README.md#download)
+> for the file to pick and how to launch it. Nothing to configure up front.
 
 ---
 

--- a/tests/unit/test_release_packaging.py
+++ b/tests/unit/test_release_packaging.py
@@ -1,12 +1,22 @@
-"""Static guards for the macOS release packaging (issue #146).
+"""Static guards for the release packaging (issues #146 and #167).
 
-The release binary's CPU architecture follows PyInstaller's `target_arch`
-in `packaging/memanga-release.spec`. Left unset it silently follows the
-build host, so a run on an Apple Silicon runner shipped an arm64-only
-binary and left Intel Mac users with nothing to run. The fix pins the
-arch per-runner via the `MEMANGA_TARGET_ARCH` env var and ships two
-distinct macOS assets. These are cheap text/YAML checks because the real
-build only runs on a macOS CI runner and can't be exercised here.
+macOS (#146): the release binary's CPU architecture follows PyInstaller's
+`target_arch` in `packaging/memanga-release.spec`. Left unset it silently
+follows the build host, so a run on an Apple Silicon runner shipped an
+arm64-only binary and left Intel Mac users with nothing to run. The fix
+pins the arch per-runner via the `MEMANGA_TARGET_ARCH` env var and ships
+two distinct macOS assets.
+
+Linux (#167): a GitHub release asset is raw bytes with no Unix mode, and
+browsers save the download without the executable bit, so a bare ELF
+lands as `-rw-r--r--` and fails with "Permission denied" before the app
+starts. The fix ships Linux as a `.tar.gz`, which records the +x bit
+inside the archive so `tar xzf` restores a runnable binary, and the
+workflow gates the release on that bit surviving extraction.
+
+Most of these are cheap text/YAML checks because the real build only runs
+on CI runners and can't be exercised here; the one round-trip test proves
+the archive format itself preserves the executable bit.
 """
 
 from __future__ import annotations
@@ -18,6 +28,7 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SPEC = REPO_ROOT / "packaging" / "memanga-release.spec"
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+README = REPO_ROOT / "README.md"
 
 # The GitHub Actions expression the workflow uses to thread the matrix
 # arch into both the build env and the verification step.
@@ -86,3 +97,128 @@ def test_workflow_verifies_architecture_before_upload():
     run = step.get("run", "")
     assert "lipo -archs" in run
     assert ARCH_EXPR in run
+
+
+# ── Linux archive packaging (issue #167) ──────────────────────────────
+
+def _build_steps():
+    data = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return data["jobs"]["build"]["steps"]
+
+
+def _step_index(fragment):
+    for i, step in enumerate(_build_steps()):
+        if fragment in step.get("name", ""):
+            return i
+    return -1
+
+
+def test_workflow_ships_linux_x64_from_ubuntu_runner():
+    """The Linux leg must build the x86_64 asset on the Ubuntu runner."""
+    by_asset = {e["asset_name"]: e for e in _build_matrix()}
+    assert "MeManga-linux-x64" in by_asset, "Linux x64 asset dropped"
+    assert by_asset["MeManga-linux-x64"]["os"] == "ubuntu-latest"
+
+
+def test_linux_binary_is_packaged_as_targz():
+    """Linux must upload a gzip tarball, not a bare ELF. The archive is
+    what preserves the executable bit through a GitHub release download
+    (issue #167); the packaging step marks the binary +x and tars it,
+    then exposes the tarball path for the upload step."""
+    step = _step_named("Package artifact for upload")
+    assert step is not None, "packaging step missing"
+    assert step.get("id") == "package", "upload step can't reference the path"
+    run = step.get("run", "")
+    # Linux-only branch: make it executable, then wrap it in a tarball.
+    assert "runner.os" in run and "Linux" in run
+    assert "chmod +x" in run
+    assert "tar -czf" in run
+    assert ".tar.gz" in run
+    # The final upload path is threaded out as a step output so a single
+    # upload step serves every OS.
+    assert 'upload_path=' in run
+    assert '"$GITHUB_OUTPUT"' in run or "$GITHUB_OUTPUT" in run
+
+
+def test_upload_step_uses_packaged_path():
+    """The upload must ship whatever the packaging step produced (the
+    tarball on Linux, the raw binary elsewhere), not a hard-coded name."""
+    step = _step_named("Upload artifact")
+    assert step is not None
+    path = step.get("with", {}).get("path", "")
+    assert path == "${{ steps.package.outputs.upload_path }}", \
+        f"upload path not wired to the packaging output: {path!r}"
+
+
+def test_workflow_gates_linux_executable_bit_before_upload():
+    """A Linux-gated step must extract the tarball and assert the binary
+    is executable, so a dropped +x bit fails the build instead of
+    shipping an unlaunchable download."""
+    step = _step_named("Verify Linux archive preserves the executable bit")
+    assert step is not None, "Linux executable-bit gate missing"
+    assert step.get("if") == "runner.os == 'Linux'"
+    run = step.get("run", "")
+    assert "tar -xzf" in run, "gate does not extract the shipped tarball"
+    # `test -x` (via `[ ! -x ... ]`) is the actual assertion that the
+    # extracted file carries the execute bit.
+    assert "-x " in run
+    assert "::error::" in run, "gate does not fail loudly"
+
+
+def test_package_and_gate_precede_upload():
+    """Ordering guard: the tarball must be built and verified before the
+    upload step consumes it."""
+    pkg = _step_index("Package artifact for upload")
+    gate = _step_index("Verify Linux archive preserves the executable bit")
+    upload = _step_index("Upload artifact")
+    assert -1 not in (pkg, gate, upload), "a packaging step is missing"
+    assert pkg < gate < upload, \
+        f"steps out of order: package={pkg} gate={gate} upload={upload}"
+
+
+def test_targz_roundtrip_preserves_executable_bit(tmp_path):
+    """Mechanism check for issue #167: the format the workflow ships
+    (`tar czf` / `tar xzf`) records the Unix mode inside the archive, so
+    an executable binary extracts back as executable. This is the whole
+    reason Linux ships as a tarball instead of a bare ELF — a raw release
+    asset carries no mode and downloads as `-rw-r--r--`."""
+    import stat
+    import tarfile
+
+    binary = tmp_path / "MeManga-linux-x64"
+    binary.write_bytes(b"\x7fELF fake binary")
+    binary.chmod(0o755)
+
+    archive = tmp_path / "MeManga-linux-x64.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(binary, arcname="MeManga-linux-x64")
+
+    # The archived member itself must carry the owner-execute bit — that
+    # is the byte-level guarantee a bare release asset cannot make.
+    with tarfile.open(archive, "r:gz") as tar:
+        member = tar.getmember("MeManga-linux-x64")
+        assert member.mode & stat.S_IXUSR, "tar member lost the +x bit"
+
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with tarfile.open(archive, "r:gz") as tar:
+        # `data` is the extraction filter Python 3.14 makes the default;
+        # it keeps an executable file at 0o755, so the +x bit survives.
+        tar.extractall(dest, filter="data")
+
+    extracted = dest / "MeManga-linux-x64"
+    assert extracted.stat().st_mode & stat.S_IXUSR, \
+        "extracted binary is not owner-executable"
+
+
+def test_readme_documents_linux_targz_launch_path():
+    """README must point Linux users at the tarball and show how to run
+    it, so the download has a clear launch path (issue #167)."""
+    text = README.read_text(encoding="utf-8")
+    # Download table links to the archive, not the bare binary.
+    assert "MeManga-linux-x64.tar.gz" in text
+    # Concrete extract + run instructions.
+    assert "tar xzf MeManga-linux-x64.tar.gz" in text
+    assert "./MeManga-linux-x64" in text
+    # The chmod fallback for file managers that still strip the bit.
+    assert "chmod +x MeManga-linux-x64" in text


### PR DESCRIPTION
## Summary

Package the Linux release download as `MeManga-linux-x64.tar.gz` so the executable bit survives download and extraction. The release workflow now marks the built Linux binary executable, wraps it in a tarball, extracts the tarball back, and fails before upload if the extracted binary is not executable.

The README and CLI guide now point Linux users at the tarball and show the extract/run path.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Docs
- [ ] Scraper added or fixed
- [x] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Closes #167

## Verification

- `venv/bin/python -m pytest tests/unit/test_release_packaging.py -q` passed locally: 25 passed.
- `venv/bin/python -W error::DeprecationWarning -m pytest tests/unit/test_release_packaging.py -q` passed locally: 25 passed.
- `venv/bin/python -m compileall -q memanga tests packaging` passed locally.
- `venv/bin/python -m pytest --collect-only -q` passed locally: 2426/2672 tests collected, 246 deselected, 0 import errors.
- `.github/workflows/release.yml` parsed successfully as YAML.
- Reproduced the v0.4.2 Linux asset symptom: a freshly downloaded raw ELF landed as `-rw-r--r--` and direct execution failed with `Permission denied`.
- Local tarball round-trip proof: an executable `MeManga-linux-x64` archived with `tar -czf` and extracted with `tar -xzf` came back executable.

## Notes

The final x86_64 GUI binary launch still needs the real tag-triggered Linux release job or an x86_64 desktop environment. This change gates the executable-bit invariant that caused the reported pre-startup failure.