### PR TITLE
chore(release): prepare v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-08-19
+
 ### Fixed
 - #167 Linux release downloads now ship as `MeManga-linux-x64.tar.gz` so
   the executable bit survives download and extraction. A raw ELF asset

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.4.2"
+version = "0.4.3"
 description = "Automatic manga downloader with Kindle support"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Prepare the `v0.4.3` release by bumping package metadata and moving the current unreleased changelog entry into a dated release section.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [ ] Docs
- [ ] Scraper added or fixed
- [x] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Release prep for v0.4.3.

## Verification

- `venv/bin/python -m pytest tests/unit/test_release_packaging.py -q` passed locally: 25 passed.
- `venv/bin/python -m compileall -q memanga tests packaging` passed locally.
- Version metadata check passed: `pyproject.toml`, `memanga.__version__`, and changelog all point to `0.4.3` / `v0.4.3`.