### PR TITLE
docs(changelog): complete v0.4.3 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,22 @@ All notable changes are recorded here. Format loosely follows
 
 ## [0.4.3] - 2026-08-19
 
+### Added
+- #153 Atsumaru is now available as a supported source through the site's
+  Typesense and reader APIs.
+- #156 VyManga is now available as a supported source, including legacy
+  host canonicalization for saved or manually added entries.
+- #157 Mangadot is now available as a supported source through its rendered
+  search pages and JSON chapter/image APIs.
+
 ### Fixed
+- #150 MangaBall search and reader extraction now use the current API flow.
+- #151 Mangago connection failures now fail quickly on blocked networks
+  instead of hanging the multi-source search sweep.
+- #152 MangaTaro page extraction now uses the current reader/API flow again.
+- #163 macOS release downloads now ship as `.zip` archives containing
+  `MeManga.app`, so users get a normal launchable app bundle instead of a
+  raw extensionless binary.
 - #167 Linux release downloads now ship as `MeManga-linux-x64.tar.gz` so
   the executable bit survives download and extraction. A raw ELF asset
   saved through a browser lost its `+x` bit and failed to launch with


### PR DESCRIPTION
## Summary

Complete the `v0.4.3` changelog section with the scraper and macOS packaging changes that also landed after `v0.4.2` and are included in this release.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Docs
- [ ] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Release notes for v0.4.3.

## Verification

- `git diff --check` passed locally.
- Changelog section check passed: v0.4.3 mentions #150, #151, #152, #153, #156, #157, #163, and #167.
- No code tests rerun for this docs-only follow-up; the release packaging and version checks already passed before this changelog-only change.