### PR TITLE
chore(release): sync cli for v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ All notable changes are recorded here. Format loosely follows
 
 ## [Unreleased]
 
+## [0.4.3] - 2026-08-19
+
+### Added
+- #153 Atsumaru is now available as a supported CLI source through the site's
+  Typesense and reader APIs.
+- #156 VyManga is now available as a supported CLI source, including legacy
+  host canonicalization for saved or manually added entries.
+- #157 Mangadot is now available as a supported CLI source through its rendered
+  search pages and JSON chapter/image APIs.
+
+### Changed
+- Version metadata synchronized for the v0.4.3 release.
+
+### Fixed
+- #150 MangaBall search and reader extraction now use the current API flow.
+- #151 Mangago connection failures now fail quickly on blocked networks
+  instead of hanging the multi-source search sweep.
+- #152 MangaTaro page extraction now uses the current reader/API flow again.
+
 ## [0.4.2] - 2026-08-06
 
 ### Changed

--- a/memanga/__init__.py
+++ b/memanga/__init__.py
@@ -1,3 +1,3 @@
 """MeManga - Automatic manga downloader with Kindle support."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/memanga/scrapers/__init__.py
+++ b/memanga/scrapers/__init__.py
@@ -17,6 +17,7 @@ Working sources:
 - Manganato (manganato.com) - Same network as Kakalot
 - Mangago (mangago.me) - Large yaoi/shoujo collection
 - MangaTaro (mangataro.org) - ComicK replacement, popular aggregator
+- Mangadot (mangadot.net) - Multi-language aggregator (SSR + JSON API)
 - MangaFire (mangafire.to) - VRF bypass + image descrambling (Playwright)
 - Plus ~80 template-based scrapers via registry (Nuxt SSR, OG Image Meta, Madara, Laiond CDN, Mangosm)
 """
@@ -41,6 +42,7 @@ from .mangakakalot import MangakakalotScraper
 from .manganato import ManganatoScraper
 from .mangago import MangagoScraper
 from .mangataro import MangaTaroScraper
+from .mangadot import MangadotScraper
 from .flamecomics import FlameComicsScraper
 from .luminousscans import LuminousScansScraper
 from .mangahere import MangaHereScraper
@@ -76,6 +78,7 @@ from .mangayy import MangaYYScraper
 from .manga4life import Manga4LifeScraper
 from .zazamanga import ZazaMangaScraper
 from .mangaball import MangaBallScraper
+from .atsumaru import AtsumaruScraper
 from .manytoon import ManyToonScraper
 from .pururin import PururinScraper
 from .hentairead import HentaiReadScraper
@@ -161,6 +164,7 @@ from .bakirahen import BakiRahenScraper
 from .blamemanga import BlameMangaScraper
 from .jjkmanga import JJKMangaScraper
 from .kagane import KaganeScraper
+from .vymanga import VyMangaScraper
 
 # ── Scrapers kept as individual files (unique domain mappings) ──
 
@@ -222,6 +226,9 @@ SCRAPERS = {
 
     # MangaTaro (ComicK replacement)
     "mangataro.org": MangaTaroScraper,
+
+    # Mangadot - Multi-language aggregator (React Router SSR + JSON API)
+    "mangadot.net": MangadotScraper,
 
     # FlameComics
     "flamecomics.xyz": FlameComicsScraper,
@@ -390,8 +397,11 @@ SCRAPERS = {
     "readhellsing.com": ZazaMangaScraper,
     "readoverlord.com": ZazaMangaScraper,
 
-    # MangaBall - Multi-language aggregator (Playwright, limited search)
+    # MangaBall - Multi-language aggregator (HTTP JSON API)
     "mangaball.net": MangaBallScraper,
+
+    # Atsumaru - Manga aggregator (Typesense search + REST API)
+    "atsu.moe": AtsumaruScraper,
 
     # MangaClash - Manga aggregator (Playwright + Madara + CF)
     "mangaclash.com": MangaClashScraper,
@@ -617,6 +627,14 @@ SCRAPERS = {
     # Kagane - Multi-manga REST API + Playwright for DRM-protected images
     "kagane.org": KaganeScraper,
     "www.kagane.org": KaganeScraper,
+
+    # VyManga - General aggregator (chapter links via ad-redirect -> Blogger CDN)
+    # Legacy hosts (vymanga.net / vyvymanga.net) 403 on their own /manga/ pages
+    # but the scraper canonicalises them to mangavyvy.net; register them so
+    # saved/manual entries resolve to a scraper before canonicalisation runs.
+    "mangavyvy.net": VyMangaScraper,
+    "vymanga.net": VyMangaScraper,
+    "vyvymanga.net": VyMangaScraper,
 }
 
 # Merge template-based scrapers into SCRAPERS dict

--- a/memanga/scrapers/atsumaru.py
+++ b/memanga/scrapers/atsumaru.py
@@ -1,0 +1,200 @@
+"""
+Atsumaru scraper - Manga aggregator
+Site: atsu.moe
+
+Atsumaru is a React SPA backed by a Typesense search endpoint and REST APIs.
+This scraper uses the APIs directly:
+
+* search   -> GET /collections/manga/documents/search?q=...
+* chapters -> GET /api/manga/allChapters?mangaId=...
+* pages    -> GET /api/read/chapter?mangaId=...&chapterId=...
+"""
+
+import re
+from datetime import datetime, timezone
+from typing import List, Optional
+from urllib.parse import urlparse, parse_qs, urlencode
+
+from .base import BaseScraper, Chapter, Manga
+
+
+class AtsumaruScraper(BaseScraper):
+    """Scraper for Atsumaru (atsu.moe)."""
+
+    name = "atsumaru"
+    base_url = "https://atsu.moe"
+
+    # IDs are short randomly-generated identifiers whose alphabet can include
+    # "-" and "_" (e.g. "9L82jefe"), so match those too. The class stops at
+    # "/", "?" or "#", so a trailing path or query is still excluded.
+    _MANGA_ID_RE = re.compile(r"/manga/([A-Za-z0-9_-]+)")
+    _READ_RE = re.compile(r"/read/([A-Za-z0-9_-]+)/([A-Za-z0-9_-]+)")
+
+    def __init__(self):
+        super().__init__()
+        self.session.headers.update({
+            "Accept": "application/json, text/plain, */*",
+            "Referer": self.base_url + "/",
+        })
+
+    def _abs_static_url(self, path: str) -> str:
+        """Absolutize a static/CDN path, using cdn.atsu.moe directly."""
+        if not path:
+            return ""
+        if path.startswith("http://") or path.startswith("https://"):
+            return path
+        if not path.startswith("/"):
+            path = "/" + path
+        return "https://cdn.atsu.moe" + path
+
+    @classmethod
+    def _extract_manga_id(cls, url: str) -> Optional[str]:
+        """Extract manga ID from a manga URL like /manga/<id>."""
+        match = cls._MANGA_ID_RE.search(url or "")
+        return match.group(1) if match else None
+
+    @classmethod
+    def _extract_read_ids(cls, url: str) -> tuple:
+        """Extract (manga_id, chapter_id) from a read URL like /read/<manga>/<chapter>."""
+        match = cls._READ_RE.search(url or "")
+        if match:
+            return match.group(1), match.group(2)
+        return None, None
+
+    def search(self, query: str) -> List[Manga]:
+        """Search for manga by title via Typesense endpoint."""
+        params = urlencode({
+            "q": query,
+            "query_by": "title,otherNames",
+            "per_page": "20",
+        })
+        url = f"{self.base_url}/collections/manga/documents/search?{params}"
+        try:
+            data = self._get_json(url)
+        except Exception:
+            return []
+        return self._parse_search(data)
+
+    def _parse_search(self, data: dict) -> List[Manga]:
+        """Parse Typesense search response into Manga objects."""
+        results = []
+        seen = set()
+        for hit in (data or {}).get("hits") or []:
+            doc = hit.get("document") or {}
+            manga_id = doc.get("id")
+            title = (doc.get("title") or "").strip()
+            if not manga_id or not title:
+                continue
+            if manga_id in seen:
+                continue
+            seen.add(manga_id)
+
+            cover = doc.get("posterMedium") or doc.get("poster") or doc.get("posterSmall")
+            cover_url = self._abs_static_url(cover) if cover else None
+
+            results.append(Manga(
+                title=title,
+                url=f"{self.base_url}/manga/{manga_id}",
+                cover_url=cover_url,
+                description=doc.get("synopsis"),
+            ))
+
+        return results[:20]
+
+    def get_chapters(self, manga_url: str) -> List[Chapter]:
+        """Get all chapters for a manga via the allChapters API."""
+        manga_id = self._extract_manga_id(manga_url)
+        if not manga_id:
+            return []
+
+        url = f"{self.base_url}/api/manga/allChapters?mangaId={manga_id}"
+        try:
+            data = self._get_json(url)
+        except Exception:
+            return []
+        return self._parse_chapters(data, manga_id)
+
+    def _parse_chapters(self, data: dict, manga_id: str) -> List[Chapter]:
+        """Parse allChapters response into Chapter objects, sorted ascending."""
+        chapters = []
+        seen = set()
+
+        for entry in (data or {}).get("chapters") or []:
+            chapter_id = entry.get("id")
+            if not chapter_id or chapter_id in seen:
+                continue
+            seen.add(chapter_id)
+
+            number = self._chapter_number(entry)
+            title = (entry.get("title") or "").strip() or f"Chapter {number}"
+
+            date = None
+            ts = entry.get("createdAt")
+            if ts:
+                try:
+                    date = datetime.fromtimestamp(ts / 1000, timezone.utc).strftime("%Y-%m-%d")
+                except Exception:
+                    pass
+
+            chapters.append(Chapter(
+                number=number,
+                title=title,
+                url=f"{self.base_url}/read/{manga_id}/{chapter_id}",
+                date=date,
+            ))
+
+        return sorted(chapters, key=lambda ch: ch.numeric)
+
+    @staticmethod
+    def _chapter_number(entry: dict) -> str:
+        """Extract clean chapter number from an allChapters entry."""
+        raw = entry.get("number")
+        if raw is not None:
+            try:
+                num = float(raw)
+                return str(int(num)) if num.is_integer() else str(num)
+            except (TypeError, ValueError):
+                pass
+
+        index = entry.get("index")
+        if index is not None:
+            try:
+                return str(int(index) + 1)
+            except (TypeError, ValueError):
+                pass
+
+        title = entry.get("title") or ""
+        match = re.search(r"(\d+(?:\.\d+)?)", title)
+        return match.group(1) if match else "0"
+
+    def get_pages(self, chapter_url: str) -> List[str]:
+        """Get all page image URLs for a chapter via the read API."""
+        manga_id, chapter_id = self._extract_read_ids(chapter_url)
+
+        if not manga_id or not chapter_id:
+            parsed = urlparse(chapter_url)
+            qs = parse_qs(parsed.query)
+            manga_id = manga_id or (qs.get("mangaId") or [None])[0]
+            chapter_id = chapter_id or (qs.get("chapterId") or [None])[0]
+
+        if not manga_id or not chapter_id:
+            return []
+
+        url = f"{self.base_url}/api/read/chapter?mangaId={manga_id}&chapterId={chapter_id}"
+        try:
+            data = self._get_json(url)
+        except Exception:
+            return []
+        return self._parse_pages(data)
+
+    def _parse_pages(self, data: dict) -> List[str]:
+        """Parse read/chapter response into ordered page URLs."""
+        pages_list = ((data or {}).get("readChapter") or {}).get("pages") or []
+
+        pages = []
+        for page in sorted(pages_list, key=lambda p: p.get("number", 0)):
+            img = page.get("image")
+            if img:
+                pages.append(self._abs_static_url(img))
+
+        return pages

--- a/memanga/scrapers/mangaball.py
+++ b/memanga/scrapers/mangaball.py
@@ -2,153 +2,261 @@
 MangaBall scraper - Multi-language manga aggregator
 Site: mangaball.net
 
-Uses Playwright for JS rendering.
-Note: Search is broken (redirects to 404), but direct manga URLs work.
-Users must provide manga URL directly.
+MangaBall is an API-driven SPA (Laravel backend). The homepage and title
+pages ship only skeleton placeholders and pull their real data from JSON
+``/api/v1/`` endpoints guarded by a per-session CSRF token, while reader
+pages embed the page-image list as a JSON blob. This scraper talks to those
+endpoints directly over HTTP instead of rendering the SPA in a browser:
+
+* search  -> POST /api/v1/smart-search/search/
+* chapters -> POST /api/v1/chapter/chapter-listing-by-title-id/
+* pages   -> the ``chapterImages`` JSON array embedded in the reader page
 """
 
+import json
 import re
-from typing import List
+import time
+from typing import List, Optional
+from urllib.parse import urljoin
+
+import requests
 from bs4 import BeautifulSoup
 
-from .playwright_base import PlaywrightScraper
-from .base import Chapter, Manga
+from .base import BaseScraper, Chapter, Manga, _retry
 
 
-class MangaBallScraper(PlaywrightScraper):
+class MangaBallScraper(BaseScraper):
     """Scraper for MangaBall."""
-    
+
     name = "mangaball"
     base_url = "https://mangaball.net"
-    
-    def search(self, query: str) -> List[Manga]:
+
+    # Every /title-detail/<slug>-<id>/ URL ends in a 24-hex-char title id,
+    # which the chapter-listing API keys off. Anchor to the trailing
+    # "-<id>" segment so a hex-looking run earlier in the slug is ignored;
+    # allow an optional trailing slash, query, or fragment after it.
+    _TITLE_ID_RE = re.compile(r"-([0-9a-f]{24})(?:[/?#]|$)")
+
+    # Reader pages inline the ordered page list as `chapterImages = JSON.parse(`...`)`.
+    _CHAPTER_IMAGES_RE = re.compile(
+        r"chapterImages\s*=\s*JSON\.parse\(\s*`(.*?)`\s*\)", re.S
+    )
+
+    def __init__(self):
+        super().__init__()
+        self._csrf_token: Optional[str] = None
+
+    # CSRF / POST helpers
+
+    def _get_csrf_token(self, force: bool = False) -> Optional[str]:
+        """Fetch and cache the per-session CSRF token.
+
+        The /api/v1 endpoints validate an ``X-CSRF-TOKEN`` header against the
+        session cookie, so both are primed by loading a normal page once and
+        reading ``<meta name="csrf-token">``. The token is stable for the life
+        of the session cookie, so it is cached and only refreshed on demand.
         """
-        Search for manga.
-        Note: MangaBall's search is JS-heavy and often fails.
-        Returns results from homepage instead.
-        """
-        html = self._get_page_content(self.base_url, wait_time=3000)
+        if self._csrf_token and not force:
+            return self._csrf_token
+        html = self._get_html(self.base_url + "/")
         soup = BeautifulSoup(html, "html.parser")
-        
+        meta = soup.find("meta", attrs={"name": "csrf-token"})
+        self._csrf_token = meta.get("content") if meta else None
+        return self._csrf_token
+
+    def _api_post(self, path: str, data: dict) -> dict:
+        """Rate-limited form POST to an /api/v1 endpoint, returning JSON.
+
+        A stale session makes Laravel answer HTTP 419; on that we refresh the
+        CSRF token so the retry (driven by ``_retry``) posts a valid one.
+        """
+        url = urljoin(self.base_url, path)
+
+        def _do_post():
+            with self._rate_lock:
+                elapsed = time.time() - self._last_request
+                if elapsed < self._rate_limit:
+                    time.sleep(self._rate_limit - elapsed)
+                self._last_request = time.time()
+
+            resp = self.session.post(
+                url,
+                data=data,
+                headers={
+                    "X-CSRF-TOKEN": self._get_csrf_token() or "",
+                    "X-Requested-With": "XMLHttpRequest",
+                    "Referer": self.base_url + "/",
+                },
+                timeout=30,
+            )
+            if resp.status_code == 419:
+                # CSRF/session expired - refresh so the retry sends a fresh one.
+                self._get_csrf_token(force=True)
+            resp.raise_for_status()
+            return resp.json()
+
+        return _retry(
+            _do_post,
+            max_attempts=3,
+            base_delay=1.0,
+            exceptions=(requests.RequestException,),
+        )
+
+    # URL helpers
+
+    def _abs_url(self, href: str) -> str:
+        """Absolutize a site-relative URL and force https.
+
+        The chapter API returns ``http://`` links even though the site serves
+        https, so normalise the scheme to avoid a needless redirect per page.
+        """
+        url = urljoin(self.base_url + "/", href or "")
+        if url.startswith("http://"):
+            url = "https://" + url[len("http://"):]
+        return url
+
+    @classmethod
+    def _extract_title_id(cls, url: str) -> Optional[str]:
+        match = cls._TITLE_ID_RE.search(url or "")
+        return match.group(1) if match else None
+
+    # Search
+
+    def search(self, query: str) -> List[Manga]:
+        """Search for manga by title via the smart-search API."""
+        payload = self._api_post(
+            "/api/v1/smart-search/search/", {"search_input": query}
+        )
+        return self._parse_search(payload)
+
+    def _parse_search(self, payload: dict) -> List[Manga]:
+        """Parse a smart-search JSON response into Manga results."""
+        if (payload or {}).get("code") != 200:
+            return []
+
         results = []
         seen = set()
-        
-        # Find manga links on homepage
-        for link in soup.select('a[href*="title-detail"]'):
-            href = link.get('href', '')
-            if not href or href in seen:
+        for item in (payload.get("data") or {}).get("manga") or []:
+            href = item.get("url") or ""
+            title = (item.get("title") or "").strip()
+            if not href or not title:
                 continue
-            
-            # Normalize URL
-            if href.startswith('/'):
-                href = self.base_url + href
-            elif href.startswith('http://'):
-                href = href.replace('http://', 'https://')
-            
-            seen.add(href)
-            
-            # Get title
-            title = link.get('title', '') or link.get_text(strip=True)
-            if not title or len(title) < 2:
+
+            url = self._abs_url(href)
+            if url in seen:
                 continue
-            
-            # Filter by query if provided
-            if query and query.lower() not in title.lower():
-                continue
-            
-            # Get cover
-            img = link.select_one('img')
-            cover_url = None
-            if img:
-                cover_url = img.get('src') or img.get('data-src')
-            
+            seen.add(url)
+
             results.append(Manga(
                 title=title,
-                url=href,
-                cover_url=cover_url,
+                url=url,
+                cover_url=item.get("img") or None,
             ))
-        
+
         return results[:20]
-    
+
+    # Chapters
+
     def get_chapters(self, manga_url: str) -> List[Chapter]:
-        """Get all chapters for a manga."""
-        # Normalize URL
-        if manga_url.startswith('http://'):
-            manga_url = manga_url.replace('http://', 'https://')
-        
-        html = self._get_page_content(manga_url, wait_time=4000)
-        soup = BeautifulSoup(html, "html.parser")
-        
+        """Get all chapters for a manga via the chapter-listing API."""
+        title_id = self._extract_title_id(manga_url)
+        if not title_id:
+            return []
+
+        payload = self._api_post(
+            "/api/v1/chapter/chapter-listing-by-title-id/",
+            {"title_id": title_id, "userSettingsEnabled": "false"},
+        )
+        return self._parse_chapters(payload)
+
+    def _parse_chapters(self, payload: dict) -> List[Chapter]:
+        """Parse a chapter-listing JSON response into Chapter objects.
+
+        Each entry groups the same chapter number across translation groups and
+        languages; pick one readable translation per chapter (English first).
+        """
+        if (payload or {}).get("code") != 200:
+            return []
+
         chapters = []
         seen = set()
-        
-        # MangaBall structure: .chapter-block contains .chapter-number and links
-        for block in soup.select('.chapter-block'):
-            # Get chapter number from .chapter-number element
-            num_el = block.select_one('.chapter-number')
-            if not num_el:
+        for entry in payload.get("ALL_CHAPTERS") or []:
+            translation = self._pick_translation(entry.get("translations") or [])
+            if not translation:
                 continue
-            
-            num_text = num_el.get_text(strip=True)
-            match = re.search(r'ch\.?\s*(\d+\.?\d*)', num_text, re.I)
-            if not match:
-                match = re.search(r'(\d+\.?\d*)', num_text)
-            
-            chapter_num = match.group(1) if match else None
-            if not chapter_num:
+
+            url = self._abs_url(translation.get("url") or "")
+            if not translation.get("url") or url in seen:
                 continue
-            
-            # Get the first chapter-detail link in this block
-            link = block.select_one('a[href*="/chapter-detail/"]')
-            if not link:
-                continue
-            
-            href = link.get('href', '')
-            if not href or href in seen:
-                continue
-            
-            # Normalize URL
-            if href.startswith('/'):
-                href = self.base_url + href
-            elif href.startswith('http://'):
-                href = href.replace('http://', 'https://')
-            
-            seen.add(href)
-            
+            seen.add(url)
+
+            number = self._chapter_number(entry)
+            title = (entry.get("title") or "").strip() or f"Chapter {number}"
             chapters.append(Chapter(
-                number=chapter_num,
-                title=f"Chapter {chapter_num}",
-                url=href,
+                number=number,
+                title=title,
+                url=url,
+                date=translation.get("date"),
             ))
-        
-        # Remove duplicates by chapter number (keep first)
-        unique = {}
-        for ch in chapters:
-            if ch.number not in unique:
-                unique[ch.number] = ch
-        
-        return sorted(unique.values(), key=lambda x: x.numeric)
-    
+
+        return sorted(chapters, key=lambda ch: ch.numeric)
+
+    @staticmethod
+    def _pick_translation(translations: list) -> Optional[dict]:
+        """Choose one readable translation per chapter, preferring English."""
+        usable = [t for t in translations if t.get("url")]
+        if not usable:
+            return None
+        for t in usable:
+            if (t.get("language") or "").lower().startswith("en"):
+                return t
+        return usable[0]
+
+    @staticmethod
+    def _chapter_number(entry: dict) -> str:
+        """Derive a clean chapter-number string from a listing entry."""
+        raw = entry.get("number_float")
+        try:
+            num = float(raw)
+            return str(int(num)) if num.is_integer() else str(num)
+        except (TypeError, ValueError):
+            pass
+        text = str(entry.get("number") or entry.get("title") or "")
+        match = re.search(r"(\d+(?:\.\d+)?)", text)
+        return match.group(1) if match else "0"
+
+    # Pages
+
     def get_pages(self, chapter_url: str) -> List[str]:
         """Get all page image URLs for a chapter."""
-        # Normalize URL
-        if chapter_url.startswith('http://'):
-            chapter_url = chapter_url.replace('http://', 'https://')
-        
-        html = self._get_page_content(chapter_url, wait_time=4000)
+        html = self._get_html(self._abs_url(chapter_url))
+        return self._parse_pages(html)
+
+    def _parse_pages(self, html: str) -> List[str]:
+        """Extract ordered page image URLs from a reader page.
+
+        The reader embeds the list as ``chapterImages = JSON.parse(`[...]`)``;
+        fall back to scraping CDN ``<img>`` tags if that shape ever changes.
+        """
+        match = self._CHAPTER_IMAGES_RE.search(html)
+        if match:
+            try:
+                urls = json.loads(match.group(1))
+                pages = [self._abs_url(u.strip()) for u in urls
+                         if isinstance(u, str) and u.strip()]
+                if pages:
+                    return pages
+            except (ValueError, TypeError):
+                pass
+
         soup = BeautifulSoup(html, "html.parser")
-        
         pages = []
-        
-        # Find manga page images
-        for img in soup.select('img'):
-            src = img.get('src') or img.get('data-src')
+        for img in soup.select("img"):
+            src = img.get("src") or img.get("data-src")
             if not src:
                 continue
-            
-            # Filter for actual manga pages (from CDN)
-            if 'poke-black-and-white.net' in src or re.search(r'-\d{3}\.webp', src):
+            if "poke-black-and-white.net" in src or re.search(r"-\d{3}\.(webp|jpg|png)", src):
+                src = src.strip()
                 if src not in pages:
-                    pages.append(src.strip())
-        
+                    pages.append(src)
         return pages

--- a/memanga/scrapers/mangadot.py
+++ b/memanga/scrapers/mangadot.py
@@ -1,0 +1,235 @@
+"""
+Mangadot scraper - Multi-language manga aggregator
+Site: mangadot.net
+
+Mangadot is a React-Router SSR app behind Cloudflare, but the data that
+matters is reachable over plain HTTP without a browser:
+
+* search   -> GET /search?search=<query> renders manga cards server-side.
+* chapters -> GET /api/manga/<id>/chapters/list returns a JSON array with one
+              entry per language/scanlation group.
+* pages    -> the reader loads page images from /api/uploads/<id>/images for
+              user uploads and /api/chapters/<id>/images for everything else;
+              both return an ordered ``images`` list of site-relative URLs.
+
+Page images are served directly (no Referer/token needed), so the base-class
+``download_image`` handles the actual downloads.
+"""
+
+import re
+import time
+from typing import List, Optional
+from urllib.parse import quote_plus, urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+from .base import BaseScraper, Chapter, Manga, _retry
+
+
+class MangadotScraper(BaseScraper):
+    """Scraper for Mangadot (mangadot.net)."""
+
+    name = "mangadot"
+    base_url = "https://mangadot.net"
+
+    # URL helpers
+
+    def _abs_url(self, href: str) -> str:
+        """Absolutize a site-relative URL against the base host."""
+        return urljoin(self.base_url + "/", href or "")
+
+    @staticmethod
+    def _manga_id(url: str) -> Optional[str]:
+        match = re.search(r"/manga/(\d+)", url or "")
+        return match.group(1) if match else None
+
+    @staticmethod
+    def _chapter_id(url: str) -> Optional[str]:
+        match = re.search(r"/chapter/(\d+)", url or "")
+        return match.group(1) if match else None
+
+    # Search
+
+    def search(self, query: str) -> List[Manga]:
+        """Search for manga by title."""
+        html = self._get_html(f"{self.base_url}/search?search={quote_plus(query)}")
+        return self._parse_search(html)
+
+    def _parse_search(self, html: str) -> List[Manga]:
+        """Parse the search page into Manga results.
+
+        Each result card is an ``<a href="/manga/<id>">`` wrapping a cover
+        ``<img>`` plus a ``div.line-clamp-2`` holding the clean title (the
+        anchor's raw text also carries the "Manga" type badge and a star
+        rating, so the title div is used instead).
+        """
+        soup = BeautifulSoup(html, "html.parser")
+        results = []
+        seen = set()
+        for anchor in soup.select('a[href^="/manga/"]'):
+            manga_id = self._manga_id(anchor.get("href", ""))
+            if not manga_id or manga_id in seen:
+                continue
+
+            title_el = anchor.select_one("div.line-clamp-2")
+            title = (title_el.get_text(strip=True) if title_el else "").strip()
+            if not title:
+                continue
+            seen.add(manga_id)
+
+            cover_url = None
+            img = anchor.find("img")
+            if img:
+                src = img.get("src") or img.get("data-src")
+                cover_url = self._abs_url(src) if src else None
+
+            results.append(Manga(
+                title=title,
+                url=f"{self.base_url}/manga/{manga_id}",
+                cover_url=cover_url,
+            ))
+
+        return results[:20]
+
+    # Chapters
+
+    def get_chapters(self, manga_url: str) -> List[Chapter]:
+        """Get all chapters for a manga via the chapters-list API."""
+        manga_id = self._manga_id(manga_url)
+        if not manga_id:
+            return []
+        data = self._get_json(f"{self.base_url}/api/manga/{manga_id}/chapters/list")
+        return self._parse_chapters(data)
+
+    def _parse_chapters(self, data) -> List[Chapter]:
+        """Parse the chapters-list JSON into Chapter objects.
+
+        A chapter number can appear once per language and scanlation group;
+        keep a single readable release per number, preferring English so the
+        downloader gets one clean list instead of duplicate rows.
+        """
+        if not isinstance(data, list):
+            return []
+
+        best = {}
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("id") is None or entry.get("chapter_number") is None:
+                continue
+            key = self._chapter_number(entry)
+            current = best.get(key)
+            if current is None or (
+                self._is_english(entry) and not self._is_english(current)
+            ):
+                best[key] = entry
+
+        chapters = []
+        for entry in best.values():
+            number = self._chapter_number(entry)
+            title = (entry.get("chapter_title") or "").strip() or f"Chapter {number}"
+            chapters.append(Chapter(
+                number=number,
+                title=title,
+                url=f"{self.base_url}/chapter/{entry['id']}",
+                date=self._clean_date(entry.get("date_added")),
+            ))
+
+        return sorted(chapters, key=lambda ch: ch.numeric)
+
+    @staticmethod
+    def _is_english(entry: dict) -> bool:
+        return (entry.get("language") or "").lower().startswith("en")
+
+    @staticmethod
+    def _chapter_number(entry: dict) -> str:
+        """Derive a clean chapter-number string from a listing entry."""
+        raw = entry.get("chapter_number")
+        try:
+            num = float(raw)
+            return str(int(num)) if num.is_integer() else str(num)
+        except (TypeError, ValueError):
+            match = re.search(r"(\d+(?:\.\d+)?)", str(raw or ""))
+            return match.group(1) if match else "0"
+
+    @staticmethod
+    def _clean_date(raw) -> Optional[str]:
+        """Reduce ``2026-08-10 14:31:28.120232+00`` to a plain ``YYYY-MM-DD``.
+
+        The downloader's ComicInfo date parser reads ``%Y-%m-%d`` cleanly,
+        whereas the raw ``+00`` offset is not a valid ISO offset.
+        """
+        if not raw:
+            return None
+        return str(raw).split(" ", 1)[0].strip() or None
+
+    # Pages
+
+    def get_pages(self, chapter_url: str) -> List[str]:
+        """Get all page image URLs for a chapter."""
+        chapter_id = self._chapter_id(chapter_url)
+        if not chapter_id:
+            return []
+        payload = self._get_images_payload(chapter_id)
+        return self._parse_pages(payload)
+
+    def _get_images_payload(self, chapter_id: str) -> Optional[dict]:
+        """Fetch a chapter's page-image payload from whichever endpoint applies.
+
+        The reader serves user uploads from ``/api/uploads/<id>/images`` and
+        other chapters from ``/api/chapters/<id>/images``; the wrong endpoint
+        returns 404, so try the upload endpoint first (the common case) and
+        fall back to the other.
+        """
+        for path in (
+            f"/api/uploads/{chapter_id}/images",
+            f"/api/chapters/{chapter_id}/images",
+        ):
+            payload = self._get_json_optional(self.base_url + path)
+            if payload and payload.get("images"):
+                return payload
+        return None
+
+    def _get_json_optional(self, url: str) -> Optional[dict]:
+        """Rate-limited JSON GET that tolerates a 404.
+
+        Returns ``None`` (instead of raising) when the endpoint does not apply
+        to this chapter, so ``_get_images_payload`` can try the alternate one
+        without paying the retry back-off a real error would trigger. Transient
+        failures still retry via ``_retry``.
+        """
+        def _do_get():
+            with self._rate_lock:
+                elapsed = time.time() - self._last_request
+                if elapsed < self._rate_limit:
+                    time.sleep(self._rate_limit - elapsed)
+                self._last_request = time.time()
+
+            resp = self.session.get(
+                url,
+                headers={"Accept": "application/json"},
+                timeout=30,
+            )
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            return resp.json()
+
+        return _retry(
+            _do_get,
+            max_attempts=3,
+            base_delay=1.0,
+            exceptions=(requests.RequestException,),
+        )
+
+    def _parse_pages(self, payload: Optional[dict]) -> List[str]:
+        """Extract ordered, absolute page image URLs from an images payload."""
+        images = (payload or {}).get("images") or []
+        pages = []
+        for image in images:
+            url = image.get("url") if isinstance(image, dict) else image
+            if not isinstance(url, str) or not url.strip():
+                continue
+            pages.append(self._abs_url(url.strip()))
+        return pages

--- a/memanga/scrapers/mangago.py
+++ b/memanga/scrapers/mangago.py
@@ -6,17 +6,62 @@ Large yaoi/shoujo collection, general manga too.
 """
 
 import re
+import time
 from typing import List
 from pathlib import Path
-from .base import BaseScraper, Chapter, Manga
+
+import requests
+
+from .base import BaseScraper, Chapter, Manga, _retry
 
 
 class MangagoScraper(BaseScraper):
     """Scraper for Mangago.me"""
-    
+
     name = "mangago"
     base_url = "https://www.mangago.me"
-    
+
+    # mangago.me is periodically DNS-poisoned and SNI-filtered in some
+    # regions (hence its place in search.BROKEN_SEARCH_SOURCES). On such a
+    # network every connect() stalls without an RST, so BaseScraper's 30s
+    # timeout x 3 retries makes a direct search()/get_chapters() call hang
+    # ~90-180s. Bound the connect wait and skip retries for connection
+    # failures -- a blocked host won't recover inside a retry window -- so
+    # direct calls fail in seconds. Only transient ReadTimeout / HTTPError
+    # responses (i.e. we did connect) keep the full read budget + retries.
+    _CONNECT_TIMEOUT = 8    # seconds to establish TCP + TLS
+    _READ_TIMEOUT = 30      # seconds to receive the response body
+
+    def _request(self, url: str, **kwargs) -> requests.Response:
+        """Rate-limited GET with a bounded connect timeout.
+
+        Overrides BaseScraper._request so a region-blocked mangago.me
+        fails fast instead of hanging: connection errors propagate on the
+        first attempt, while transient read/HTTP errors still get retried.
+        """
+        kwargs.setdefault("timeout", (self._CONNECT_TIMEOUT, self._READ_TIMEOUT))
+
+        def _do_request():
+            with self._rate_lock:
+                elapsed = time.time() - self._last_request
+                if elapsed < self._rate_limit:
+                    time.sleep(self._rate_limit - elapsed)
+                self._last_request = time.time()
+            response = self.session.get(url, **kwargs)
+            response.raise_for_status()
+            return response
+
+        # ConnectionError / ConnectTimeout mean the host is unreachable
+        # from here; retrying only multiplies the wait, so let them raise
+        # on the first attempt. Only post-connect hiccups are retried.
+        return _retry(
+            _do_request,
+            max_attempts=3,
+            base_delay=1.0,
+            exceptions=(requests.exceptions.ReadTimeout,
+                        requests.exceptions.HTTPError),
+        )
+
     def search(self, query: str) -> List[Manga]:
         """Search for manga by title."""
         from bs4 import BeautifulSoup
@@ -126,7 +171,9 @@ class MangagoScraper(BaseScraper):
                 "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
                 "Referer": f"{self.base_url}/",
             }
-            response = self.session.get(url, headers=headers, timeout=30)
+            response = self.session.get(
+                url, headers=headers,
+                timeout=(self._CONNECT_TIMEOUT, self._READ_TIMEOUT))
             response.raise_for_status()
             Path(path).parent.mkdir(parents=True, exist_ok=True)
             Path(path).write_bytes(response.content)

--- a/memanga/scrapers/mangataro.py
+++ b/memanga/scrapers/mangataro.py
@@ -3,12 +3,22 @@ MangaTaro scraper
 https://mangataro.org
 
 Popular ComicK replacement. Simple requests-based scraper - no protection.
-CDN images at bx1.mangapeak.me
+
+The reader is JS-driven: its static HTML carries only the first page, and
+the ordered page list comes from a JSON endpoint keyed by the numeric
+chapter id embedded in the reader URL (``.../chN-<id>``):
+
+    GET /auth/chapter-content?chapter_id=<id>  -> {"images": [<cdn url>, ...]}
+
+Page images are served from a rotating CDN host (currently
+``mangataro.yachts``); we always use whatever host that endpoint returns
+instead of assuming a fixed CDN.
 """
 
 import re
-from typing import List
+from typing import List, Optional
 from pathlib import Path
+from urllib.parse import urlparse
 from .base import BaseScraper, Chapter, Manga
 
 
@@ -17,8 +27,23 @@ class MangaTaroScraper(BaseScraper):
     
     name = "mangataro"
     base_url = "https://mangataro.org"
-    cdn_base = "https://bx1.mangapeak.me"
-    
+
+    # Reader URLs end in the numeric chapter id: /read/<slug>/ch<n>-<id>.
+    # The <n> part may itself contain dashes (e.g. ch56-5 for chapter 56.5),
+    # so match lazily up to the final "-<id>" of the chapter segment.
+    _CHAPTER_ID_RE = re.compile(r"/ch[^/]*?-(\d+)(?:[/?#]|$)")
+
+    # The chapter *number* part sits between "ch" and that final "-<id>".
+    # It may be dotted (ch10.5-<id>) or - as the live site encodes it -
+    # dashed (ch7-5-<id> meaning chapter 7.5).
+    _CHAPTER_NUM_RE = re.compile(r"/ch([\d.-]+?)-\d+(?:[/?#]|$)")
+
+    # CDN page images: <host>/storage/chapters/<hash>/<zero-padded page>.<ext>
+    _PAGE_IMG_RE = re.compile(
+        r"https?://[^\s\"'<>\\]+/storage/chapters/[a-f0-9]+/\d+\.(?:webp|jpe?g|png)",
+        re.I,
+    )
+
     def search(self, query: str) -> List[Manga]:
         """Search for manga by title.
         
@@ -115,16 +140,9 @@ class MangaTaroScraper(BaseScraper):
                         
                         chapter_url = href if href.startswith("http") else f"{self.base_url}{href}"
                         chapter_text = option.get_text(strip=True)
-                        
-                        # Extract chapter number from URL: /read/manga/ch1-8788
-                        match = re.search(r'/ch(\d+\.?\d*)-(\d+)', href)
-                        if match:
-                            chapter_num = match.group(1)
-                        else:
-                            # Extract from text: "Ch. 1" or "Chapter 1"
-                            text_match = re.search(r'(?:ch\.?|chapter)\s*(\d+\.?\d*)', chapter_text, re.I)
-                            chapter_num = text_match.group(1) if text_match else "0"
-                        
+
+                        chapter_num = self._parse_chapter_number(href, chapter_text)
+
                         if chapter_url not in [c.url for c in chapters]:
                             chapters.append(Chapter(
                                 number=chapter_num,
@@ -144,14 +162,14 @@ class MangaTaroScraper(BaseScraper):
                     continue
                 
                 chapter_url = href if href.startswith("http") else f"{self.base_url}{href}"
-                
-                match = re.search(r'/ch(\d+\.?\d*)-(\d+)', href)
-                chapter_num = match.group(1) if match else "0"
-                
+
+                link_text = link.get_text(strip=True)
+                chapter_num = self._parse_chapter_number(href, link_text)
+
                 if chapter_url not in [c.url for c in chapters]:
                     chapters.append(Chapter(
                         number=chapter_num,
-                        title=link.get_text(strip=True) or None,
+                        title=link_text or None,
                         url=chapter_url,
                         date=None,
                     ))
@@ -159,51 +177,134 @@ class MangaTaroScraper(BaseScraper):
         return sorted(chapters, key=lambda x: x.numeric)
     
     def get_pages(self, chapter_url: str) -> List[str]:
-        """Get all page image URLs for a chapter."""
+        """Get all page image URLs for a chapter.
+
+        The reader loads its pages from a JSON endpoint keyed by the
+        numeric chapter id in the URL, so we call that directly - the
+        static reader HTML only carries the first page. If the id or
+        endpoint ever changes shape we fall back to scraping whatever CDN
+        image URLs the reader HTML does contain.
+        """
+        chapter_id = self._extract_chapter_id(chapter_url)
+        if chapter_id:
+            pages = self._pages_from_api(chapter_id)
+            if pages:
+                return pages
+
+        # Fallback: recover the id from the page markup if the URL shape
+        # changed, retry the API, then scrape inline image URLs.
         html = self._get_html(chapter_url)
-        
-        # Extract CDN image URLs from the page
-        # Pattern: https://bx1.mangapeak.me/storage/chapters/{hash}/{page}.webp
-        cdn_pattern = r'https?://[^\s"\'<>\\]+mangapeak\.me/storage/chapters/[a-f0-9]+/\d+\.webp'
-        cdn_urls = re.findall(cdn_pattern, html)
-        
-        if not cdn_urls:
-            # Try alternate pattern for mangataro.org URLs
-            alt_pattern = r'https?://[^\s"\'<>\\]+/storage/chapters/[a-f0-9]+/\d+\.webp'
-            cdn_urls = re.findall(alt_pattern, html)
-        
-        if not cdn_urls:
+        if not chapter_id:
+            chapter_id = self._chapter_id_from_html(html)
+            if chapter_id:
+                pages = self._pages_from_api(chapter_id)
+                if pages:
+                    return pages
+        return self._pages_from_html(html)
+
+    @classmethod
+    def _extract_chapter_id(cls, url: str) -> Optional[str]:
+        """Pull the numeric chapter id out of a reader URL."""
+        match = cls._CHAPTER_ID_RE.search(url or "")
+        return match.group(1) if match else None
+
+    @classmethod
+    def _chapter_number_from_url(cls, url: str) -> Optional[str]:
+        """Parse the chapter number from a reader URL's ``ch<n>-<id>`` shape.
+
+        Handles plain (``ch1-547229`` -> "1"), dotted
+        (``ch10.5-999888`` -> "10.5") and dashed-decimal
+        (``ch7-5-547254`` -> "7.5") numbers - the live site writes the
+        decimal point as a dash. Returns None if there's no chapter segment.
+        """
+        match = cls._CHAPTER_NUM_RE.search(url or "")
+        if not match:
+            return None
+        return match.group(1).replace("-", ".")
+
+    @classmethod
+    def _parse_chapter_number(cls, url: str, text: str = "") -> str:
+        """Derive a chapter number for a reader link.
+
+        Prefers a clear decimal in the visible text (e.g. "Ch. 7.5"), then
+        falls back to the URL shape (see ``_chapter_number_from_url``, which
+        understands the dashed-decimal ``ch7-5-<id>`` form). Returns "0" when
+        neither yields a number.
+        """
+        text_match = re.search(
+            r'(?:ch\.?|chapter)\s*(\d+(?:\.\d+)?)', text or "", re.I)
+        if text_match:
+            return text_match.group(1)
+        from_url = cls._chapter_number_from_url(url)
+        return from_url if from_url is not None else "0"
+
+    @staticmethod
+    def _chapter_id_from_html(html: str) -> Optional[str]:
+        """Recover the chapter id from the reader page's body markup."""
+        match = re.search(r'data-chapter-id=["\'](\d+)["\']', html)
+        return match.group(1) if match else None
+
+    def _pages_from_api(self, chapter_id: str) -> List[str]:
+        """Fetch the ordered page image URLs from the chapter-content API.
+
+        Returns the absolute CDN URLs exactly as the site serves them, so
+        no host rewriting is needed.
+        """
+        url = f"{self.base_url}/auth/chapter-content?chapter_id={chapter_id}"
+        try:
+            data = self._get_json(url, headers={
+                "Referer": f"{self.base_url}/",
+                "X-Requested-With": "XMLHttpRequest",
+            })
+        except Exception:
             return []
-        
-        # Get the base URL (chapter hash) from first image
-        first_url = cdn_urls[0]
-        base_url = first_url.rsplit('/', 1)[0]
-        
-        # Use CDN domain for better reliability
-        if 'mangapeak.me' not in base_url:
-            hash_part = base_url.split('/storage/chapters/')[-1]
-            base_url = f"{self.cdn_base}/storage/chapters/{hash_part}"
-        
-        # Enumerate pages by checking which ones exist
+        return self._pages_from_api_payload(data)
+
+    @staticmethod
+    def _pages_from_api_payload(data) -> List[str]:
+        """Parse a chapter-content JSON response into ordered page URLs.
+
+        Returns [] on any error or for chapters with no image list
+        (e.g. text/novel chapters). URLs are kept exactly as served.
+        """
+        if not isinstance(data, dict) or not data.get("success"):
+            return []
+        images = data.get("images")
+        if not isinstance(images, list):
+            return []
+
         pages = []
-        for i in range(1, 200):  # Max 200 pages
-            page_url = f"{base_url}/{str(i).zfill(3)}.webp"
-            try:
-                resp = self.session.head(page_url, timeout=5)
-                if resp.status_code == 200:
+        for img in images:
+            if isinstance(img, str) and img.strip():
+                page_url = img.strip()
+                if page_url not in pages:
                     pages.append(page_url)
-                else:
-                    # Check without zero padding
-                    page_url2 = f"{base_url}/{i}.webp"
-                    resp2 = self.session.head(page_url2, timeout=5)
-                    if resp2.status_code == 200:
-                        pages.append(page_url2)
-                    else:
-                        break  # No more pages
-            except:
-                break
-        
         return pages
+
+    def _pages_from_html(self, html: str) -> List[str]:
+        """Fallback: scrape CDN page-image URLs from the reader HTML.
+
+        Uses whatever host the page references (never rewrites it), and
+        when the same page number appears on both the site's own domain
+        and a CDN host, prefers the CDN one - the on-site /storage path
+        404s. Ordered by page number.
+        """
+        base_host = urlparse(self.base_url).netloc
+        by_page = {}
+        for match in self._PAGE_IMG_RE.findall(html):
+            num = self._page_number(match)
+            if num not in by_page:
+                by_page[num] = match
+            elif (urlparse(by_page[num]).netloc == base_host
+                    and urlparse(match).netloc != base_host):
+                by_page[num] = match
+        return [by_page[num] for num in sorted(by_page)]
+
+    @staticmethod
+    def _page_number(url: str) -> int:
+        """Sort key: the zero-padded page number in a CDN image URL."""
+        match = re.search(r'/(\d+)\.(?:webp|jpe?g|png)(?:[?#]|$)', url, re.I)
+        return int(match.group(1)) if match else 0
     
     def download_image(self, url: str, path) -> bool:
         """Download image with proper headers."""

--- a/memanga/scrapers/vymanga.py
+++ b/memanga/scrapers/vymanga.py
@@ -1,0 +1,149 @@
+"""
+VyManga scraper
+https://mangavyvy.net (formerly vymanga.net / vyvymanga.net)
+
+General manga aggregator. Search and detail pages live on the main site,
+but each chapter link routes through an encrypted ad-redirect chain
+(aovheroes.com -> aov-news.com / summonersky.com; the exact ad domains
+rotate per request) that resolves to a reader page. The reader page's
+images are served from Blogger/Google storage and need no Referer.
+requests follows the redirect chain automatically, so get_pages just
+parses the reader HTML the chain lands on -- taking care to keep only the
+carousel slide images and drop the "same author" recommendation cover
+thumbnails the reader embeds inside that same carousel.
+"""
+
+import re
+from typing import List
+from urllib.parse import quote, urlparse, urlunparse
+from .base import BaseScraper, Chapter, Manga
+
+# Old hosts still handed to us by the registry / saved libraries. Their
+# /manga/ pages now 403; the identical path resolves on the canonical host.
+_LEGACY_HOSTS = {"vymanga.net", "vyvymanga.net"}
+
+
+class VyMangaScraper(BaseScraper):
+    """Scraper for VyManga (mangavyvy.net)."""
+
+    name = "vymanga"
+    base_url = "https://mangavyvy.net"
+    _canonical_host = "mangavyvy.net"
+
+    def _canonical_url(self, url: str) -> str:
+        """Rewrite legacy vymanga.net / vyvymanga.net hosts to the canonical
+        host so direct old-domain manga URLs don't 403."""
+        parsed = urlparse(url)
+        host = parsed.netloc.lower()
+        if host.startswith("www."):
+            host = host[4:]
+        if host in _LEGACY_HOSTS:
+            return urlunparse(parsed._replace(netloc=self._canonical_host))
+        return url
+
+    def search(self, query: str) -> List[Manga]:
+        from bs4 import BeautifulSoup
+
+        url = f"{self.base_url}/search?q={quote(query)}"
+        soup = BeautifulSoup(self._get_html(url), "html.parser")
+
+        results = []
+        seen = set()
+
+        for item in soup.select("div.comic-item"):
+            link = item.select_one('a[href*="/manga/"]')
+            if not link:
+                continue
+            href = link.get("href", "")
+            if not href or href in seen:
+                continue
+            seen.add(href)
+
+            img = item.select_one("img")
+
+            title_el = item.select_one(".comic-title")
+            title = title_el.get_text(strip=True) if title_el else ""
+            if not title and img:
+                title = img.get("title") or img.get("alt") or ""
+            title = title.strip()
+            if not title:
+                continue
+
+            cover_url = None
+            if img:
+                cover_url = img.get("data-src") or img.get("src")
+
+            manga_url = href if href.startswith("http") else f"{self.base_url}{href}"
+            results.append(Manga(title=title, url=manga_url, cover_url=cover_url))
+
+        return results[:20]
+
+    def get_chapters(self, manga_url: str) -> List[Chapter]:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(self._get_html(self._canonical_url(manga_url)), "html.parser")
+
+        chapters = []
+        seen = set()
+
+        for link in soup.select("a.list-chapter"):
+            href = link.get("href", "")
+            if not href or href in seen:
+                continue
+
+            span = link.select_one("span")
+            label = span.get_text(strip=True) if span else ""
+
+            # Chapter number lives in id="chapter-<num>"; fall back to label.
+            match = re.search(r"chapter-([\d.]+)", link.get("id", ""), re.I)
+            if not match:
+                match = re.search(r"chapter\s*([\d.]+)", label, re.I)
+            number = match.group(1).rstrip(".") if match else label
+
+            seen.add(href)
+            chapters.append(Chapter(
+                number=number,
+                title=label or f"Chapter {number}",
+                url=href,
+            ))
+
+        return sorted(chapters, key=lambda c: c.numeric)
+
+    def get_pages(self, chapter_url: str) -> List[str]:
+        from bs4 import BeautifulSoup
+
+        # The chapter link routes through an ad-redirect chain (rotating ad
+        # domains such as aovheroes.com -> aov-news.com / summonersky.com) that
+        # requests follows automatically to the reader page holding the images.
+        soup = BeautifulSoup(self._get_html(chapter_url), "html.parser")
+
+        # Page images are the reader carousel slides: a single <img> directly
+        # inside each .carousel-item. The reader also embeds a "same author"
+        # recommendation table *inside* the same carousel whose cover thumbnails
+        # (<img class="img-recommend">, served from the site's own cover CDN)
+        # would otherwise be scraped as pages, so take only the direct slide
+        # images and skip anything flagged as a recommendation thumbnail.
+        images = soup.select(".carousel-item > img")
+        if not images:
+            container = soup.select_one("#carousel, .vview, .carousel-inner")
+            images = container.select("img") if container else []
+
+        pages = []
+        seen = set()
+        for img in images:
+            if "img-recommend" in (img.get("class") or []):
+                continue
+            src = (img.get("data-src") or img.get("src") or "").strip()
+            if not src or src in seen:
+                continue
+            # Skip the lazy-load placeholder (loading.gif / blank.gif). Test the
+            # filename only, never the whole URL: reader page IDs are opaque
+            # base64 blobs that can coincidentally contain "icon"/"logo"/etc.,
+            # so a substring scan over the full URL would silently drop pages.
+            name = urlparse(src).path.rsplit("/", 1)[-1].lower()
+            if src.startswith("data:") or name.endswith(".gif"):
+                continue
+            seen.add(src)
+            pages.append(src)
+
+        return pages

--- a/memanga/search.py
+++ b/memanga/search.py
@@ -111,6 +111,11 @@ BROKEN_SEARCH_SOURCES = {
     "manhwa18.cc",
     "mangafreak.me", "mangafreak.ws", "ww2.mangafreak.me",
     "bato.to", "batoto.to",
+    # region-blocked (DNS poison + SNI filter) on some networks, where
+    # connect() stalls and the 30s-timeout x 3-retry sweep slot hangs
+    # ~90s+, so drop it from the sweep. Reachable elsewhere, so it stays
+    # usable by direct URL.
+    "mangago.me", "www.mangago.me",
     # NEEDS_JS_API — static HTML returns 0 hits, real search is client-side
     "asuracomic.net", "asurascans.com", "asuratoon.com",
     "mgeko.cc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "memanga"
-version = "0.4.2"
+version = "0.4.3"
 description = "Automatic manga downloader with Kindle support (CLI)"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/scrapers/fixtures/vymanga/chapter.html
+++ b/tests/scrapers/fixtures/vymanga/chapter.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div class="col-lg-8 col-md-12">
+    <div class="carousel slide" id="carousel">
+      <div class="vview carousel-inner">
+        <div class="carousel-item active">
+          <img class="d-block w-100 lozad" data-src="https://2.bp.blogspot.com/drive-storage/PAGE-001=w700" src="https://mangavyvy.net/web/img/loading.gif">
+        </div>
+        <div class="carousel-item">
+          <img class="d-block w-100 lozad" data-src="https://2.bp.blogspot.com/drive-storage/PAGE-002=w700" src="https://mangavyvy.net/web/img/loading.gif">
+        </div>
+        <div class="carousel-item">
+          <img class="d-block w-100 lozad" data-src="https://2.bp.blogspot.com/drive-storage/PAGE-003=w700" src="https://mangavyvy.net/web/img/loading.gif">
+        </div>
+
+        <!-- "Same author" recommendation table embedded INSIDE the carousel
+             (this is how the live reader ships it). The cover thumbnails are
+             nested in a table, not direct slide children, and carry the
+             img-recommend class: they must NOT be scraped as pages. -->
+        <div class="carousel-item">
+          <div class="p-5"><div class="mt-2"><div class="table table-same_author info-area">
+            <table class="table-responsive-md same-author"><tbody>
+              <tr>
+                <td><a href="/manga/other-1"><div class="div-hover-zoom-outer img-md img-same-author">
+                  <img class="img-recommend lozad" data-src="https://cdnxyz.xyz/web/cover/19394/thumbnail.png" src="https://mangavyvy.net/web/img/loading.gif">
+                </div></a></td>
+                <td><a href="/manga/other-2"><div class="div-hover-zoom-outer img-md img-same-author">
+                  <img class="img-recommend lozad" data-src="https://cdnxyz.xyz/storage/collections/8616-1657985705.jpg" src="https://mangavyvy.net/web/img/loading.gif">
+                </div></a></td>
+              </tr>
+            </tbody></table>
+          </div></div></div>
+        </div>
+
+        <!-- Defense-in-depth: a recommendation cover promoted to a direct
+             slide child is still excluded by its img-recommend class. -->
+        <div class="carousel-item">
+          <img class="img-recommend lozad" data-src="https://cdnxyz.xyz/web/cover/66281/thumbnail.png" src="https://mangavyvy.net/web/img/loading.gif">
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Related manga block OUTSIDE the reader carousel: must NOT be scraped. -->
+  <div class="row book-list">
+    <div class="comic-item">
+      <img class="image lozad" data-src="https://cdnxyz.xyz/storage/collections/8616-1657985705.jpg">
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/scrapers/fixtures/vymanga/manga.html
+++ b/tests/scrapers/fixtures/vymanga/manga.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head><meta property="og:image" content="https://cdnxyz.xyz/web/cover/841/thumbnail.png"/></head>
+<body>
+  <div class="list-group">
+    <!-- Newest first on the page; scraper sorts ascending. Decimal + volume prefix cases. -->
+    <a class="list-group-item list-group-item-action list-chapter"
+       href="https://aovheroes.com/rds/br/rdsd?data=AAA%3D%3D"
+       id="chapter-700.5" rel="noopener noreferrer nofollow" target="_blank">
+      <span>Chapter 700.5 : Uzumaki Naruto</span>
+      <p class="text-right font-italic small">Dec 26, 2021</p>
+    </a>
+    <a class="list-group-item list-group-item-action list-chapter"
+       href="https://aovheroes.com/rds/br/rdsd?data=BBB%3D%3D"
+       id="chapter-700" rel="noopener noreferrer nofollow" target="_blank">
+      <span>Vol.72 Chapter 700 : Uzumaki Naruto!!</span>
+      <p class="text-right font-italic small">Dec 26, 2021</p>
+    </a>
+    <a class="list-group-item list-group-item-action list-chapter"
+       href="https://aovheroes.com/rds/br/rdsd?data=CCC%3D%3D"
+       id="chapter-1" rel="noopener noreferrer nofollow" target="_blank">
+      <span>Vol.1 Chapter 1 : Uzumaki Naruto</span>
+      <p class="text-right font-italic small">Jan 01, 2000</p>
+    </a>
+    <!-- duplicate href: must be de-duped -->
+    <a class="list-group-item list-group-item-action list-chapter"
+       href="https://aovheroes.com/rds/br/rdsd?data=CCC%3D%3D"
+       id="chapter-1" rel="noopener noreferrer nofollow" target="_blank">
+      <span>Vol.1 Chapter 1 : Uzumaki Naruto</span>
+    </a>
+  </div>
+</body>
+</html>

--- a/tests/scrapers/fixtures/vymanga/search.html
+++ b/tests/scrapers/fixtures/vymanga/search.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <div class="row book-list">
+    <div class="col-lg-2 col-md-3 col-4">
+      <div class="comic-item">
+        <a href="/manga/naruto-bc8">
+          <div class="comic-image">
+            <img alt="Naruto" class="image lozad" data-src="https://cdnxyz.xyz/web/cover/841/thumbnail.png" src="/web/img/blank.gif" title="Naruto">
+            <span class="tray-item">Chapter 700.5 : Uzumaki Naruto</span>
+          </div>
+          <div class="comic-title">Naruto</div>
+        </a>
+      </div>
+    </div>
+
+    <!-- duplicate href: must be de-duped -->
+    <div class="col-lg-2 col-md-3 col-4">
+      <div class="comic-item">
+        <a href="/manga/naruto-bc8">
+          <div class="comic-image">
+            <img class="image lozad" data-src="https://cdnxyz.xyz/web/cover/841/thumbnail.png" src="/web/img/blank.gif">
+          </div>
+          <div class="comic-title">Naruto</div>
+        </a>
+      </div>
+    </div>
+
+    <!-- absolute href + title only via img alt (no .comic-title) -->
+    <div class="col-lg-2 col-md-3 col-4">
+      <div class="comic-item">
+        <a href="https://mangavyvy.net/manga/boruto-naruto-next-generations-2f">
+          <div class="comic-image">
+            <img class="image lozad" alt="Boruto: Naruto Next Generations" data-src="https://cdnxyz.xyz/web/cover/22508/thumbnail.png" src="/web/img/blank.gif">
+          </div>
+        </a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/tests/scrapers/live/test_live_parsing.py
+++ b/tests/scrapers/live/test_live_parsing.py
@@ -81,6 +81,15 @@ PARSING_PROBES = {
     "manganato.com": ProbeSpec("Manganato", query="naruto"),
     "mangahub.io": ProbeSpec("MangaHub", query="one piece"),
     "comix.to": ProbeSpec("Comix.to", query="kubera"),
+    # Pages come from a JSON API keyed by the chapter id in the URL
+    # (issue #152) - this probe catches that endpoint/host changing.
+    "mangataro.org": ProbeSpec("MangaTaro (JSON page API)",
+                                query="koi to yobu"),
+    # Search is a Typesense collection endpoint; chapters and pages come
+    # from separate REST APIs keyed by the ids in the manga/read URLs.
+    # This probe catches any of those three endpoints changing shape.
+    "atsu.moe": ProbeSpec("Atsumaru (Typesense search + REST API)",
+                           query="one piece"),
 
     # ── One representative per template family ──
     "dddmanga.com": ProbeSpec("NuxtSSR template (single-manga)"),

--- a/tests/scrapers/test_atsumaru_api.py
+++ b/tests/scrapers/test_atsumaru_api.py
@@ -1,0 +1,334 @@
+"""JSON-fixture tests for Atsumaru's API-driven scraper.
+
+The network-facing helpers (``_get_json``) are never invoked here - these tests
+exercise only the pure parsing/normalisation layer, using payloads shaped after
+the live Typesense and REST API responses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import get_scraper
+from memanga.scrapers.atsumaru import AtsumaruScraper
+
+
+@pytest.fixture
+def scraper():
+    return AtsumaruScraper()
+
+
+# Smoke
+
+
+def test_instantiates_and_has_required_api():
+    s = get_scraper("atsu.moe")
+    assert isinstance(s, AtsumaruScraper)
+    for method in ("search", "get_chapters", "get_pages", "download_image"):
+        assert callable(getattr(s, method))
+
+
+# URL helpers
+
+
+class TestUrlHelpers:
+    def test_extract_manga_id(self):
+        assert AtsumaruScraper._extract_manga_id(
+            "https://atsu.moe/manga/sVC2A"
+        ) == "sVC2A"
+
+    def test_extract_manga_id_missing(self):
+        assert AtsumaruScraper._extract_manga_id("https://atsu.moe/foo/bar") is None
+
+    def test_extract_manga_id_with_trailing_path(self):
+        assert AtsumaruScraper._extract_manga_id(
+            "https://atsu.moe/manga/sVC2A/chapters"
+        ) == "sVC2A"
+
+    def test_extract_manga_id_with_query_string(self):
+        assert AtsumaruScraper._extract_manga_id(
+            "https://atsu.moe/manga/sVC2A?ref=home"
+        ) == "sVC2A"
+
+    def test_extract_manga_id_allows_dash_and_underscore(self):
+        # IDs are nanoid-style identifiers whose alphabet may include "-"/"_".
+        assert AtsumaruScraper._extract_manga_id(
+            "https://atsu.moe/manga/9L8-2j_efe"
+        ) == "9L8-2j_efe"
+
+    def test_extract_read_ids(self):
+        manga_id, chapter_id = AtsumaruScraper._extract_read_ids(
+            "https://atsu.moe/read/sVC2A/Nd6vV"
+        )
+        assert manga_id == "sVC2A"
+        assert chapter_id == "Nd6vV"
+
+    def test_extract_read_ids_allows_dash_and_underscore(self):
+        manga_id, chapter_id = AtsumaruScraper._extract_read_ids(
+            "https://atsu.moe/read/sV-C2A/Nd_6vV"
+        )
+        assert manga_id == "sV-C2A"
+        assert chapter_id == "Nd_6vV"
+
+    def test_extract_read_ids_missing(self):
+        manga_id, chapter_id = AtsumaruScraper._extract_read_ids(
+            "https://atsu.moe/manga/sVC2A"
+        )
+        assert manga_id is None
+        assert chapter_id is None
+
+    def test_abs_static_url(self, scraper):
+        path = "/static/pages/abc123/Nd6vV/0.webp"
+        assert scraper._abs_static_url(path) == "https://cdn.atsu.moe" + path
+
+    def test_abs_static_url_already_absolute(self, scraper):
+        url = "https://cdn.atsu.moe/static/pages/abc123/Nd6vV/0.webp"
+        assert scraper._abs_static_url(url) == url
+
+    def test_abs_static_url_no_leading_slash(self, scraper):
+        path = "static/pages/abc123/Nd6vV/0.webp"
+        assert scraper._abs_static_url(path) == "https://cdn.atsu.moe/static/pages/abc123/Nd6vV/0.webp"
+
+
+# Search
+
+
+SEARCH_PAYLOAD = {
+    "found": 2,
+    "hits": [
+        {
+            "document": {
+                "id": "sVC2A",
+                "title": "One Piece",
+                "otherNames": ["OP", "Wan Piisu"],
+                "chapterCount": 1189,
+                "poster": "/static/posters/sVC2A/poster.webp",
+                "posterMedium": "/static/posters/sVC2A/poster_medium.webp",
+                "posterSmall": "/static/posters/sVC2A/poster_small.webp",
+                "synopsis": "Monkey D. Luffy sets off on an adventure...",
+            }
+        },
+        {
+            "document": {
+                "id": "xYZ12",
+                "title": "One Punch Man",
+                "otherNames": ["OPM"],
+                "chapterCount": 200,
+                "poster": "/static/posters/xYZ12/poster.webp",
+                "synopsis": "Saitama is a hero who defeats everyone...",
+            }
+        },
+        # Duplicate ID should be dropped
+        {
+            "document": {
+                "id": "sVC2A",
+                "title": "One Piece (Duplicate)",
+            }
+        },
+        # Missing title should be dropped
+        {
+            "document": {
+                "id": "noTitle",
+                "title": "",
+            }
+        },
+    ],
+}
+
+
+class TestSearch:
+    def test_parses_manga_with_covers(self, scraper):
+        results = scraper._parse_search(SEARCH_PAYLOAD)
+        assert len(results) == 2
+        assert results[0].title == "One Piece"
+        assert results[0].url == "https://atsu.moe/manga/sVC2A"
+        assert results[0].cover_url == "https://cdn.atsu.moe/static/posters/sVC2A/poster_medium.webp"
+        assert results[0].description == "Monkey D. Luffy sets off on an adventure..."
+
+    def test_deduplicates_manga_ids(self, scraper):
+        results = scraper._parse_search(SEARCH_PAYLOAD)
+        ids = [r.url.split("/")[-1] for r in results]
+        assert ids == ["sVC2A", "xYZ12"]
+
+    def test_empty_response_returns_empty(self, scraper):
+        assert scraper._parse_search({}) == []
+        assert scraper._parse_search({"hits": []}) == []
+        assert scraper._parse_search(None) == []
+
+    def test_search_calls_api_and_parses(self, monkeypatch, scraper):
+        captured = {}
+
+        def fake_get_json(url):
+            captured["url"] = url
+            return SEARCH_PAYLOAD
+
+        monkeypatch.setattr(scraper, "_get_json", fake_get_json)
+        results = scraper.search("one piece")
+        assert "q=one+piece" in captured["url"]
+        assert "query_by=title" in captured["url"]
+        assert "otherNames" in captured["url"]
+        assert "per_page=20" in captured["url"]
+        assert len(results) == 2
+
+    def test_search_encodes_special_characters(self, monkeypatch, scraper):
+        captured = {}
+
+        def fake_get_json(url):
+            captured["url"] = url
+            return {"hits": []}
+
+        monkeypatch.setattr(scraper, "_get_json", fake_get_json)
+        scraper.search("kaguya-sama & love is war")
+        assert "q=kaguya-sama+%26+love+is+war" in captured["url"]
+        assert "query_by=title" in captured["url"]
+        assert "otherNames" in captured["url"]
+        assert "per_page=20" in captured["url"]
+
+
+# Chapters
+
+
+CHAPTERS_PAYLOAD = {
+    "chapters": [
+        {
+            "id": "zSZfP",
+            "title": "Chapter 1189",
+            "number": 1189,
+            "createdAt": 1722880800000,  # 2024-08-05T18:00:00Z
+            "index": 1188,
+            "pageCount": 15,
+            "scanlationMangaId": "sVC2A",
+        },
+        {
+            "id": "Nd6vV",
+            "title": "Chapter 1188",
+            "number": 1188,
+            "createdAt": 1722276000000,  # 2024-07-29T18:00:00Z
+            "index": 1187,
+            "pageCount": 18,
+            "scanlationMangaId": "sVC2A",
+        },
+        {
+            "id": "abc12",
+            "title": "Chapter 1",
+            "number": 1,
+            "createdAt": 1600000000000,
+            "index": 0,
+            "pageCount": 20,
+            "scanlationMangaId": "sVC2A",
+        },
+        # Half chapter
+        {
+            "id": "half1",
+            "title": "Chapter 1.5",
+            "number": 1.5,
+            "createdAt": 1600100000000,
+            "index": 1,
+            "pageCount": 10,
+        },
+    ]
+}
+
+
+class TestChapters:
+    def test_parses_chapters_sorted_ascending(self, scraper):
+        chapters = scraper._parse_chapters(CHAPTERS_PAYLOAD, "sVC2A")
+        assert [c.number for c in chapters] == ["1", "1.5", "1188", "1189"]
+
+    def test_chapter_urls_include_both_ids(self, scraper):
+        chapters = scraper._parse_chapters(CHAPTERS_PAYLOAD, "sVC2A")
+        first = chapters[0]
+        assert first.url == "https://atsu.moe/read/sVC2A/abc12"
+
+    def test_chapter_dates_parsed(self, scraper):
+        chapters = scraper._parse_chapters(CHAPTERS_PAYLOAD, "sVC2A")
+        latest = chapters[-1]
+        assert latest.date == "2024-08-05"
+
+    def test_empty_response_returns_empty(self, scraper):
+        assert scraper._parse_chapters({}, "sVC2A") == []
+        assert scraper._parse_chapters({"chapters": []}, "sVC2A") == []
+
+    def test_get_chapters_invalid_url_returns_empty(self, scraper):
+        assert scraper.get_chapters("https://atsu.moe/unknown/path") == []
+
+    def test_chapter_number_extraction(self):
+        assert AtsumaruScraper._chapter_number({"number": 42}) == "42"
+        assert AtsumaruScraper._chapter_number({"number": 42.5}) == "42.5"
+        assert AtsumaruScraper._chapter_number({"index": 9}) == "10"
+        assert AtsumaruScraper._chapter_number({"title": "Ch. 100"}) == "100"
+        assert AtsumaruScraper._chapter_number({}) == "0"
+
+
+# Pages
+
+
+PAGES_PAYLOAD = {
+    "readChapter": {
+        "id": "Nd6vV",
+        "mangaId": "sVC2A",
+        "pages": [
+            {"number": 0, "image": "/static/pages/cmgzkjxs70k8hm191srm4qxf9/Nd6vV/0.webp", "width": 784, "height": 1145},
+            {"number": 1, "image": "/static/pages/cmgzkjxs70k8hm191srm4qxf9/Nd6vV/1.webp", "width": 784, "height": 1145},
+            {"number": 2, "image": "/static/pages/cmgzkjxs70k8hm191srm4qxf9/Nd6vV/2.avif", "width": 784, "height": 1145},
+        ],
+    }
+}
+
+
+class TestPages:
+    def test_extracts_ordered_pages(self, scraper):
+        pages = scraper._parse_pages(PAGES_PAYLOAD)
+        assert len(pages) == 3
+        assert pages[0] == "https://cdn.atsu.moe/static/pages/cmgzkjxs70k8hm191srm4qxf9/Nd6vV/0.webp"
+        assert pages[1].endswith("/1.webp")
+        assert pages[2].endswith("/2.avif")  # AVIF preserved
+
+    def test_pages_sorted_by_number(self, scraper):
+        data = {
+            "readChapter": {
+                "pages": [
+                    {"number": 2, "image": "/static/page2.webp"},
+                    {"number": 0, "image": "/static/page0.webp"},
+                    {"number": 1, "image": "/static/page1.webp"},
+                ]
+            }
+        }
+        pages = scraper._parse_pages(data)
+        assert [p.split("/")[-1] for p in pages] == ["page0.webp", "page1.webp", "page2.webp"]
+
+    def test_empty_response_returns_empty(self, scraper):
+        assert scraper._parse_pages({}) == []
+        assert scraper._parse_pages({"readChapter": {}}) == []
+        assert scraper._parse_pages({"readChapter": {"pages": []}}) == []
+
+    def test_get_pages_from_read_url(self, monkeypatch, scraper):
+        captured = {}
+
+        def fake_get_json(url):
+            captured["url"] = url
+            return PAGES_PAYLOAD
+
+        monkeypatch.setattr(scraper, "_get_json", fake_get_json)
+        pages = scraper.get_pages("https://atsu.moe/read/sVC2A/Nd6vV")
+        assert "mangaId=sVC2A" in captured["url"]
+        assert "chapterId=Nd6vV" in captured["url"]
+        assert len(pages) == 3
+
+    def test_get_pages_from_api_query_url(self, monkeypatch, scraper):
+        captured = {}
+
+        def fake_get_json(url):
+            captured["url"] = url
+            return PAGES_PAYLOAD
+
+        monkeypatch.setattr(scraper, "_get_json", fake_get_json)
+        pages = scraper.get_pages(
+            "https://atsu.moe/api/read/chapter?mangaId=sVC2A&chapterId=Nd6vV"
+        )
+        assert "mangaId=sVC2A" in captured["url"]
+        assert "chapterId=Nd6vV" in captured["url"]
+        assert len(pages) == 3
+
+    def test_get_pages_invalid_url_returns_empty(self, scraper):
+        assert scraper.get_pages("https://atsu.moe/unknown/path") == []

--- a/tests/scrapers/test_mangaball_api.py
+++ b/tests/scrapers/test_mangaball_api.py
@@ -1,0 +1,254 @@
+"""JSON/HTML-fixture tests for MangaBall's API-driven scraper.
+
+The network-facing helpers (``_api_post`` / ``_get_html``) are never invoked
+here - these tests exercise only the pure parsing/normalisation layer, using
+payloads shaped after the live ``/api/v1`` responses and reader pages.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import get_scraper
+from memanga.scrapers.mangaball import MangaBallScraper
+
+
+@pytest.fixture
+def mb():
+    return MangaBallScraper()
+
+
+# Smoke
+
+
+def test_instantiates_and_has_required_api():
+    s = get_scraper("mangaball.net")
+    assert isinstance(s, MangaBallScraper)
+    for method in ("search", "get_chapters", "get_pages", "download_image"):
+        assert callable(getattr(s, method))
+
+
+# URL helpers
+
+
+class TestUrlHelpers:
+    def test_extract_title_id(self):
+        assert MangaBallScraper._extract_title_id(
+            "https://mangaball.net/title-detail/kubera-official-6889f402e00aa4d41d07e044/"
+        ) == "6889f402e00aa4d41d07e044"
+
+    def test_extract_title_id_missing(self):
+        assert MangaBallScraper._extract_title_id("https://mangaball.net/foo/bar") is None
+
+    def test_extract_title_id_ignores_earlier_hex_run(self):
+        # A slug containing an earlier 24-hex-looking run must not shadow the
+        # real trailing title id.
+        url = (
+            "https://mangaball.net/title-detail/"
+            "deadbeefcafebabefacefeed0042-6889f402e00aa4d41d07e044/"
+        )
+        assert MangaBallScraper._extract_title_id(url) == "6889f402e00aa4d41d07e044"
+
+    def test_extract_title_id_with_query_and_fragment(self):
+        url = "https://mangaball.net/title-detail/x-6889f402e00aa4d41d07e044?a=1#top"
+        assert MangaBallScraper._extract_title_id(url) == "6889f402e00aa4d41d07e044"
+
+    def test_abs_url_relative(self, mb):
+        assert mb._abs_url("/title-detail/x-abc/") == \
+            "https://mangaball.net/title-detail/x-abc/"
+
+    def test_abs_url_forces_https(self, mb):
+        # The chapter API hands back http:// links.
+        assert mb._abs_url("http://mangaball.net/chapter-detail/deadbeef/") == \
+            "https://mangaball.net/chapter-detail/deadbeef/"
+
+
+# Search
+
+
+SEARCH_PAYLOAD = {
+    "code": 200,
+    "message": "Search smart success",
+    "data": {
+        "manga": [
+            {
+                "img": "https://cdn.poke-black-and-white.net/covers/a/cover.jpg",
+                "title": "Kubera (Official)",
+                "url": "/title-detail/kubera-official-6889f402e00aa4d41d07e044/",
+            },
+            {
+                "img": "https://cdn.poke-black-and-white.net/covers/b/cover.jpg",
+                "title": "KubeRag Arena",
+                "url": "/title-detail/kuberag-arena-68525476048c12fa14c40b6c/",
+            },
+            # Duplicate URL + a blank-title row must be dropped.
+            {"img": None, "title": "dup", "url": "/title-detail/kubera-official-6889f402e00aa4d41d07e044/"},
+            {"img": None, "title": "", "url": "/title-detail/nameless-000000000000000000000000/"},
+        ],
+        "authors": "",
+        "tags": "",
+    },
+}
+
+
+class TestSearch:
+    def test_parses_manga_with_covers(self, mb):
+        results = mb._parse_search(SEARCH_PAYLOAD)
+        assert [r.title for r in results] == ["Kubera (Official)", "KubeRag Arena"]
+        assert results[0].url == \
+            "https://mangaball.net/title-detail/kubera-official-6889f402e00aa4d41d07e044/"
+        assert results[0].cover_url.endswith("cover.jpg")
+
+    def test_non_200_returns_empty(self, mb):
+        assert mb._parse_search({"code": 419, "message": "expired"}) == []
+        assert mb._parse_search({}) == []
+
+    def test_search_calls_api_and_parses(self, monkeypatch, mb):
+        captured = {}
+
+        def fake_post(path, data):
+            captured["path"] = path
+            captured["data"] = data
+            return SEARCH_PAYLOAD
+
+        monkeypatch.setattr(mb, "_api_post", fake_post)
+        results = mb.search("kubera")
+        assert captured["path"] == "/api/v1/smart-search/search/"
+        assert captured["data"] == {"search_input": "kubera"}
+        assert len(results) == 2
+
+
+# Chapters
+
+
+def _translation(url, language="en", date="2026-08-03 05:07:13"):
+    return {"url": url, "language": language, "languageName": language, "date": date}
+
+
+CHAPTERS_PAYLOAD = {
+    "code": 200,
+    "ALL_CHAPTERS": [
+        {
+            "number": "Ch. 726",
+            "number_float": 726,
+            "title": "Ch. 726",
+            "translations": [
+                _translation("http://mangaball.net/chapter-detail/en726a/"),
+                _translation("http://mangaball.net/chapter-detail/en726b/"),
+            ],
+        },
+        {
+            "number": "Ch. 725.5",
+            "number_float": 725.5,
+            "title": "Ch. 725.5",
+            "translations": [
+                # No English -> fall back to first usable translation.
+                _translation("http://mangaball.net/chapter-detail/fr7255/", language="fr"),
+            ],
+        },
+        {
+            "number": "Ch. 10",
+            "number_float": 10,
+            "title": "Ch. 10",
+            "translations": [_translation("http://mangaball.net/chapter-detail/en10/")],
+        },
+        # Entry with no usable translation is skipped entirely.
+        {"number": "Ch. 9", "number_float": 9, "title": "Ch. 9", "translations": [{"language": "en"}]},
+    ],
+}
+
+
+class TestChapters:
+    def test_prefers_english_sorts_and_normalises(self, mb):
+        chapters = mb._parse_chapters(CHAPTERS_PAYLOAD)
+        # 3 entries yield chapters (the translation-less one is dropped).
+        assert [c.number for c in chapters] == ["10", "725.5", "726"]
+        # English translation chosen for 726 (first en URL, not the fr one).
+        top = chapters[-1]
+        assert top.url == "https://mangaball.net/chapter-detail/en726a/"
+        # http -> https normalisation applied.
+        assert all(c.url.startswith("https://") for c in chapters)
+        # Non-English chapter still resolved via fallback.
+        mid = next(c for c in chapters if c.number == "725.5")
+        assert mid.url.endswith("/fr7255/")
+        assert mid.date == "2026-08-03 05:07:13"
+
+    def test_non_200_returns_empty(self, mb):
+        assert mb._parse_chapters({"code": 500}) == []
+
+    def test_pick_translation_prefers_english(self):
+        picked = MangaBallScraper._pick_translation([
+            _translation("u1", language="es"),
+            _translation("u2", language="en"),
+        ])
+        assert picked["url"] == "u2"
+
+    def test_pick_translation_none_when_no_urls(self):
+        assert MangaBallScraper._pick_translation([{"language": "en"}]) is None
+
+    def test_chapter_number_from_float_and_text(self):
+        assert MangaBallScraper._chapter_number({"number_float": 726}) == "726"
+        assert MangaBallScraper._chapter_number({"number_float": 725.5}) == "725.5"
+        assert MangaBallScraper._chapter_number({"number": "Ch. 42"}) == "42"
+        assert MangaBallScraper._chapter_number({}) == "0"
+
+    def test_get_chapters_invalid_url_returns_empty(self, mb):
+        assert mb.get_chapters("https://mangaball.net/no-id-here/") == []
+
+
+# Pages
+
+
+READER_HTML = """
+<html><head><meta name="csrf-token" content="abc"></head><body>
+<script>
+    const chapterImages = JSON.parse(`["https://jigglypuff.poke-black-and-white.net/storage/x/0/726/en/aa-001.jpg","https://jigglypuff.poke-black-and-white.net/storage/x/0/726/en/aa-002.jpg"]`);
+</script>
+</body></html>
+"""
+
+READER_HTML_FALLBACK = """
+<html><body>
+<img src="https://mangaball.net/public/logo.png">
+<img data-src="https://jigglypuff.poke-black-and-white.net/storage/x/0/1/en/bb-001.jpg">
+<img src="https://jigglypuff.poke-black-and-white.net/storage/x/0/1/en/bb-002.jpg">
+</body></html>
+"""
+
+
+class TestPages:
+    def test_extracts_embedded_json(self, mb):
+        pages = mb._parse_pages(READER_HTML)
+        assert len(pages) == 2
+        assert pages[0].endswith("aa-001.jpg")
+        assert all("poke-black-and-white.net" in p for p in pages)
+
+    def test_embedded_json_normalises_http_to_https(self, mb):
+        html = (
+            "<script>const chapterImages = JSON.parse(`"
+            '["http://jigglypuff.poke-black-and-white.net/storage/x/0/726/en/aa-001.jpg"]'
+            "`);</script>"
+        )
+        pages = mb._parse_pages(html)
+        assert pages == [
+            "https://jigglypuff.poke-black-and-white.net/storage/x/0/726/en/aa-001.jpg"
+        ]
+
+    def test_falls_back_to_cdn_img_tags(self, mb):
+        pages = mb._parse_pages(READER_HTML_FALLBACK)
+        assert pages == [
+            "https://jigglypuff.poke-black-and-white.net/storage/x/0/1/en/bb-001.jpg",
+            "https://jigglypuff.poke-black-and-white.net/storage/x/0/1/en/bb-002.jpg",
+        ]
+
+    def test_get_pages_fetches_normalised_url(self, monkeypatch, mb):
+        seen = {}
+
+        def fake_get_html(url, *a, **k):
+            seen["url"] = url
+            return READER_HTML
+
+        monkeypatch.setattr(mb, "_get_html", fake_get_html)
+        pages = mb.get_pages("http://mangaball.net/chapter-detail/en726a/")
+        assert seen["url"] == "https://mangaball.net/chapter-detail/en726a/"
+        assert len(pages) == 2

--- a/tests/scrapers/test_mangadot.py
+++ b/tests/scrapers/test_mangadot.py
@@ -1,0 +1,252 @@
+"""HTML/JSON-fixture tests for the Mangadot scraper.
+
+The network-facing helpers (``_get_html`` / ``_get_json`` / ``_get_json_optional``)
+are never invoked here - these tests exercise only the pure parsing and
+normalisation layer, using payloads shaped after the live ``mangadot.net``
+search page and ``/api`` responses.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import get_scraper
+from memanga.scrapers.mangadot import MangadotScraper
+
+
+@pytest.fixture
+def md():
+    return MangadotScraper()
+
+
+# Smoke
+
+
+def test_instantiates_and_has_required_api():
+    s = get_scraper("mangadot.net")
+    assert isinstance(s, MangadotScraper)
+    for method in ("search", "get_chapters", "get_pages", "download_image"):
+        assert callable(getattr(s, method))
+
+
+# URL helpers
+
+
+class TestUrlHelpers:
+    def test_manga_id(self):
+        assert MangadotScraper._manga_id("https://mangadot.net/manga/25867") == "25867"
+        assert MangadotScraper._manga_id("/manga/41") == "41"
+
+    def test_manga_id_missing(self):
+        assert MangadotScraper._manga_id("https://mangadot.net/search?search=x") is None
+
+    def test_chapter_id(self):
+        assert MangadotScraper._chapter_id("https://mangadot.net/chapter/1263396") == "1263396"
+
+    def test_chapter_id_missing(self):
+        assert MangadotScraper._chapter_id("https://mangadot.net/manga/41") is None
+
+    def test_abs_url_relative(self, md):
+        assert md._abs_url("/uploads/thumbs/320/a.webp") == \
+            "https://mangadot.net/uploads/thumbs/320/a.webp"
+
+    def test_abs_url_absolute_passthrough(self, md):
+        assert md._abs_url("https://mangadot.net/chapters/manga_41/x/001.jpg") == \
+            "https://mangadot.net/chapters/manga_41/x/001.jpg"
+
+
+# Search
+
+
+SEARCH_HTML = """
+<html><body>
+  <a class="group flex flex-col" href="/manga/41">
+    <div class="relative">
+      <img src="/uploads/thumbs/320/onepiece.webp.webp"/>
+      <span>Manga</span><span>&#9733; 9.3</span>
+    </div>
+    <div class="line-clamp-2 text-[12px]">ONE PIECE</div>
+  </a>
+  <a class="group flex flex-col" href="/manga/37534">
+    <div class="relative"><img src="/uploads/thumbs/320/side.jpg.webp"/></div>
+    <div class="line-clamp-2">One Piece: Mugiwara Daigekijou</div>
+  </a>
+  <!-- Duplicate manga id must be dropped. -->
+  <a href="/manga/41"><div class="line-clamp-2">One Piece (dup)</div></a>
+  <!-- Card without a title div is ignored (e.g. a nav/section link). -->
+  <a href="/manga/999"><img src="/uploads/x.webp"/></a>
+</body></html>
+"""
+
+
+class TestSearch:
+    def test_parses_cards_with_titles_and_covers(self, md):
+        results = md._parse_search(SEARCH_HTML)
+        assert [r.title for r in results] == [
+            "ONE PIECE",
+            "One Piece: Mugiwara Daigekijou",
+        ]
+        assert results[0].url == "https://mangadot.net/manga/41"
+        # Cover made absolute.
+        assert results[0].cover_url == \
+            "https://mangadot.net/uploads/thumbs/320/onepiece.webp.webp"
+
+    def test_empty_page_returns_empty(self, md):
+        assert md._parse_search("<html><body></body></html>") == []
+
+    def test_search_fetches_query_url(self, monkeypatch, md):
+        seen = {}
+
+        def fake_get_html(url, *a, **k):
+            seen["url"] = url
+            return SEARCH_HTML
+
+        monkeypatch.setattr(md, "_get_html", fake_get_html)
+        results = md.search("one piece")
+        assert seen["url"] == "https://mangadot.net/search?search=one+piece"
+        assert len(results) == 2
+
+
+# Chapters
+
+
+def _entry(cid, number, language="en", title=None, date="2026-08-10 14:31:28.120232+00"):
+    return {
+        "id": cid,
+        "chapter_number": number,
+        "chapter_title": title if title is not None else f"Chapter {number}",
+        "language": language,
+        "group_id": 14972,
+        "page_count": 12,
+        "source": "user",
+        "date_added": date,
+    }
+
+
+CHAPTERS_DATA = [
+    # Chapter 1 exists in French then English -> English release wins.
+    _entry(500, 1, language="fr", title="Ch 1 FR"),
+    _entry(501, 1, language="en", title="Ch 1 EN"),
+    # A decimal chapter, English only.
+    _entry(510, "1.5"),
+    # Chapter 2 has no English release -> the sole French release is kept.
+    _entry(520, 2, language="fr", title="Ch 2 FR"),
+    # Rows with missing id / number are dropped.
+    {"id": None, "chapter_number": 3},
+    {"id": 530, "chapter_number": None},
+]
+
+
+class TestChapters:
+    def test_dedupes_prefers_english_sorts_and_normalises(self, md):
+        chapters = md._parse_chapters(CHAPTERS_DATA)
+        # One chapter per number, sorted ascending.
+        assert [c.number for c in chapters] == ["1", "1.5", "2"]
+        # English release chosen for chapter 1 (id 501, not the French 500).
+        first = chapters[0]
+        assert first.url == "https://mangadot.net/chapter/501"
+        assert first.title == "Ch 1 EN"
+        # Chapter 2 falls back to the only (French) release.
+        two = next(c for c in chapters if c.number == "2")
+        assert two.url == "https://mangadot.net/chapter/520"
+        # Date trimmed to YYYY-MM-DD.
+        assert first.date == "2026-08-10"
+
+    def test_non_list_returns_empty(self, md):
+        assert md._parse_chapters({"error": "nope"}) == []
+        assert md._parse_chapters(None) == []
+
+    def test_chapter_number_from_int_float_and_text(self):
+        assert MangadotScraper._chapter_number({"chapter_number": 0}) == "0"
+        assert MangadotScraper._chapter_number({"chapter_number": 726}) == "726"
+        assert MangadotScraper._chapter_number({"chapter_number": "11.0"}) == "11"
+        assert MangadotScraper._chapter_number({"chapter_number": 725.5}) == "725.5"
+        assert MangadotScraper._chapter_number({"chapter_number": "Vol 2 Ch 42"}) == "2"
+        assert MangadotScraper._chapter_number({"chapter_number": None}) == "0"
+
+    def test_clean_date(self):
+        assert MangadotScraper._clean_date("2026-08-10 14:31:28.120232+00") == "2026-08-10"
+        assert MangadotScraper._clean_date("") is None
+        assert MangadotScraper._clean_date(None) is None
+
+    def test_get_chapters_invalid_url_returns_empty(self, md):
+        assert md.get_chapters("https://mangadot.net/search?search=x") == []
+
+    def test_get_chapters_fetches_list_endpoint(self, monkeypatch, md):
+        seen = {}
+
+        def fake_get_json(url, *a, **k):
+            seen["url"] = url
+            return CHAPTERS_DATA
+
+        monkeypatch.setattr(md, "_get_json", fake_get_json)
+        chapters = md.get_chapters("https://mangadot.net/manga/25867")
+        assert seen["url"] == "https://mangadot.net/api/manga/25867/chapters/list"
+        assert len(chapters) == 3
+
+
+# Pages
+
+
+IMAGES_PAYLOAD = {
+    "chapter": {"id": 121126, "manga_id": 46, "page_count": 3},
+    "images": [
+        {"url": "/chapters/manga_46/chapter_232_g10712/001.jpg", "w": 0, "h": 0},
+        {"url": "/chapters/manga_46/chapter_232_g10712/002.jpg", "w": 0, "h": 0},
+        {"url": "/chapters/manga_41/user_8_ch1190_en_abc/003.webp", "w": 0, "h": 0},
+    ],
+}
+
+
+class TestPages:
+    def test_parses_images_to_absolute_urls(self, md):
+        pages = md._parse_pages(IMAGES_PAYLOAD)
+        assert pages == [
+            "https://mangadot.net/chapters/manga_46/chapter_232_g10712/001.jpg",
+            "https://mangadot.net/chapters/manga_46/chapter_232_g10712/002.jpg",
+            "https://mangadot.net/chapters/manga_41/user_8_ch1190_en_abc/003.webp",
+        ]
+
+    def test_empty_or_missing_images(self, md):
+        assert md._parse_pages(None) == []
+        assert md._parse_pages({}) == []
+        assert md._parse_pages({"images": []}) == []
+
+    def test_skips_malformed_image_entries(self, md):
+        payload = {"images": [{"url": ""}, {"nope": 1}, {"url": "/a/001.jpg"}]}
+        assert md._parse_pages(payload) == ["https://mangadot.net/a/001.jpg"]
+
+    def test_get_pages_invalid_url_returns_empty(self, md):
+        assert md.get_pages("https://mangadot.net/manga/46") == []
+
+    def test_get_pages_uses_upload_endpoint_first(self, monkeypatch, md):
+        calls = []
+
+        def fake_optional(url):
+            calls.append(url)
+            if url.endswith("/api/uploads/121126/images"):
+                return IMAGES_PAYLOAD
+            raise AssertionError("should not reach the chapters endpoint")
+
+        monkeypatch.setattr(md, "_get_json_optional", fake_optional)
+        pages = md.get_pages("https://mangadot.net/chapter/121126")
+        assert calls == ["https://mangadot.net/api/uploads/121126/images"]
+        assert len(pages) == 3
+
+    def test_get_pages_falls_back_to_chapters_endpoint(self, monkeypatch, md):
+        calls = []
+
+        def fake_optional(url):
+            calls.append(url)
+            # Upload endpoint doesn't apply (404 -> None); chapters one does.
+            if url.endswith("/api/uploads/26329/images"):
+                return None
+            return IMAGES_PAYLOAD
+
+        monkeypatch.setattr(md, "_get_json_optional", fake_optional)
+        pages = md.get_pages("https://mangadot.net/chapter/26329")
+        assert calls == [
+            "https://mangadot.net/api/uploads/26329/images",
+            "https://mangadot.net/api/chapters/26329/images",
+        ]
+        assert len(pages) == 3

--- a/tests/scrapers/test_mangago.py
+++ b/tests/scrapers/test_mangago.py
@@ -1,0 +1,137 @@
+"""Unit tests for MangagoScraper's region-block-resilient request path.
+
+mangago.me is DNS-poisoned / SNI-filtered in some regions (issue #151),
+so from a blocked network every connect() stalls. These tests prove a
+direct MangagoScraper call fails fast there instead of hanging through
+BaseScraper's 30s x 3-retry budget, while transient post-connect errors
+still get retried. All network is faked; nothing leaves the process.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+import requests
+
+from memanga.scrapers.mangago import MangagoScraper
+
+
+@pytest.fixture
+def scraper():
+    return MangagoScraper()
+
+
+@pytest.fixture(autouse=True)
+def no_real_sleep(monkeypatch):
+    """Record and neutralise every sleep so retries don't slow the suite."""
+    slept: list[float] = []
+    monkeypatch.setattr(time, "sleep", slept.append)
+    return slept
+
+
+class _FakeGet:
+    """session.get stand-in: counts calls, records the timeout kwarg,
+    and raises the supplied exception on every call."""
+
+    def __init__(self, raise_exc):
+        self.calls = 0
+        self.timeouts: list = []
+        self._raise = raise_exc
+
+    def __call__(self, url, **kwargs):
+        self.calls += 1
+        self.timeouts.append(kwargs.get("timeout"))
+        raise self._raise
+
+
+# -- connection failures must fail fast (no BaseScraper 3x retry) --
+
+
+class TestRegionBlockFailsFast:
+    # Every public read path routes through _request, so all three must
+    # fail fast, not just search().
+    OPS = {
+        "search": lambda s: s.search("one piece"),
+        "get_chapters": lambda s: s.get_chapters(
+            "https://www.mangago.me/read-manga/one_piece/"),
+        "get_pages": lambda s: s.get_pages(
+            "https://www.mangago.me/read-manga/one_piece/mr/nml_chapter-1/pg-1/"),
+    }
+
+    @pytest.mark.parametrize("op", list(OPS.values()), ids=list(OPS))
+    @pytest.mark.parametrize("exc", [
+        requests.exceptions.ConnectTimeout("connect timed out"),
+        requests.exceptions.ConnectionError("Connection reset by peer"),
+    ], ids=["connect_timeout", "connection_reset"])
+    def test_connection_error_not_retried(self, scraper, monkeypatch,
+                                          no_real_sleep, op, exc):
+        get = _FakeGet(exc)
+        monkeypatch.setattr(scraper.session, "get", get)
+
+        with pytest.raises(requests.exceptions.RequestException):
+            op(scraper)
+
+        # BaseScraper would call get() 3 times; the override stops at 1.
+        assert get.calls == 1
+        # Nothing to back off for, so no exponential-backoff sleep either.
+        assert no_real_sleep == []
+
+    def test_bounded_connect_timeout_passed(self, scraper, monkeypatch,
+                                            no_real_sleep):
+        get = _FakeGet(requests.exceptions.ConnectTimeout("x"))
+        monkeypatch.setattr(scraper.session, "get", get)
+
+        with pytest.raises(requests.exceptions.ConnectTimeout):
+            scraper.search("one piece")
+
+        assert get.timeouts == [
+            (scraper._CONNECT_TIMEOUT, scraper._READ_TIMEOUT)]
+        # The connect bound is well under BaseScraper's flat 30s.
+        assert scraper._CONNECT_TIMEOUT < 30
+
+
+# -- transient post-connect errors keep BaseScraper's resilience --
+
+
+class TestTransientErrorsStillRetry:
+    def test_read_timeout_is_retried(self, scraper, monkeypatch, no_real_sleep):
+        get = _FakeGet(requests.exceptions.ReadTimeout("slow body"))
+        monkeypatch.setattr(scraper.session, "get", get)
+
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            scraper.search("one piece")
+
+        # A read hiccup means we did connect, so retry as before: 3 tries.
+        assert get.calls == 3
+
+    def test_http_error_is_retried(self, scraper, monkeypatch, no_real_sleep):
+        get = _FakeGet(requests.exceptions.HTTPError("503"))
+        monkeypatch.setattr(scraper.session, "get", get)
+
+        with pytest.raises(requests.exceptions.HTTPError):
+            scraper.search("one piece")
+
+        assert get.calls == 3
+
+
+# -- download_image bypasses _request but must still bound connect --
+
+
+class TestDownloadImageBoundedTimeout:
+    def test_uses_bounded_timeout_and_swallows_block(self, scraper,
+                                                     monkeypatch, tmp_path):
+        seen = {}
+
+        def fake_get(url, **kwargs):
+            seen["timeout"] = kwargs.get("timeout")
+            raise requests.exceptions.ConnectTimeout("blocked")
+
+        monkeypatch.setattr(scraper.session, "get", fake_get)
+
+        ok = scraper.download_image(
+            "https://i.mangapicgallery.com/x.jpg", tmp_path / "x.jpg")
+
+        assert ok is False  # download_image swallows and reports failure
+        assert seen["timeout"] == (
+            scraper._CONNECT_TIMEOUT, scraper._READ_TIMEOUT)

--- a/tests/scrapers/test_mangataro.py
+++ b/tests/scrapers/test_mangataro.py
@@ -1,0 +1,346 @@
+"""Tests for the MangaTaro scraper.
+
+MangaTaro's reader is JS-driven: the ordered page list comes from a JSON
+endpoint (``/auth/chapter-content?chapter_id=<id>``) rather than the static
+HTML, which only carries the first page. These tests exercise the pure
+parsing/URL layer with payloads shaped after the live responses - the
+network-facing helpers (``_get_json`` / ``_get_html`` / ``session.get``) are
+patched, never called.
+
+Regression focus (issue #152): ``get_pages`` used to rewrite every CDN host
+to a stale ``bx1.mangapeak.me`` and enumerate by HEAD, which returned 0 pages
+against the current site. It must now use the API host verbatim.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import get_scraper
+from memanga.scrapers.mangataro import MangaTaroScraper
+
+
+CHAPTER_URL = "https://mangataro.org/read/koi-to-yobu-ni-wa-kimochi-warui/ch1-547229"
+
+# Shaped after the live /auth/chapter-content response: absolute CDN URLs
+# on a host that is NOT the site domain and NOT the old mangapeak CDN.
+API_PAYLOAD = {
+    "success": True,
+    "chapter_id": 547229,
+    "chapter_type": "media",
+    "images": [
+        "https://mangataro.yachts/storage/chapters/7689b1e6b813f55210c2eb9d714eddea/001.webp",
+        "https://mangataro.yachts/storage/chapters/7689b1e6b813f55210c2eb9d714eddea/002.webp",
+        "https://mangataro.yachts/storage/chapters/7689b1e6b813f55210c2eb9d714eddea/003.webp",
+    ],
+    "total": 3,
+}
+
+
+@pytest.fixture
+def mt():
+    return MangaTaroScraper()
+
+
+# Smoke
+
+
+def test_instantiates_and_has_required_api():
+    s = get_scraper("mangataro.org")
+    assert isinstance(s, MangaTaroScraper)
+    for method in ("search", "get_chapters", "get_pages", "download_image"):
+        assert callable(getattr(s, method))
+
+    # The stale, hard-coded CDN that broke page extraction is gone.
+    assert not hasattr(MangaTaroScraper, "cdn_base")
+
+
+# URL / id helpers
+
+
+class TestChapterId:
+    def test_extract_from_reader_url(self):
+        assert MangaTaroScraper._extract_chapter_id(CHAPTER_URL) == "547229"
+
+    def test_extract_decimal_chapter_with_query(self):
+        url = "https://mangataro.org/read/x/ch10.5-999888?page=2#top"
+        assert MangaTaroScraper._extract_chapter_id(url) == "999888"
+
+    def test_extract_dashed_point_chapter(self):
+        # Live URLs encode e.g. chapter 56.5 as "ch56-5-<id>"; the id is the
+        # final numeric segment, not the "5" in the number.
+        url = "https://mangataro.org/read/koi-to-yobu-ni-wa-kimochi-warui/ch56-5-547486"
+        assert MangaTaroScraper._extract_chapter_id(url) == "547486"
+
+    def test_extract_missing_returns_none(self):
+        assert MangaTaroScraper._extract_chapter_id(
+            "https://mangataro.org/manga/koi-to-yobu") is None
+        assert MangaTaroScraper._extract_chapter_id("") is None
+
+    def test_recover_id_from_body_markup(self):
+        html = '<body data-chapter-id="547229" data-manga-id="547225">x</body>'
+        assert MangaTaroScraper._chapter_id_from_html(html) == "547229"
+
+    def test_recover_id_from_markup_missing(self):
+        assert MangaTaroScraper._chapter_id_from_html("<body></body>") is None
+
+
+class TestPageNumber:
+    def test_zero_padded(self):
+        assert MangaTaroScraper._page_number("https://h/storage/chapters/ab/007.webp") == 7
+
+    def test_with_query(self):
+        assert MangaTaroScraper._page_number("https://h/storage/chapters/ab/012.jpg?v=1") == 12
+
+    def test_unparseable(self):
+        assert MangaTaroScraper._page_number("https://h/no-page-here") == 0
+
+
+# Pages via the API (the fix)
+
+
+class TestPagesFromApi:
+    def test_returns_urls_verbatim_in_order(self, mt):
+        assert mt._pages_from_api_payload(API_PAYLOAD) == API_PAYLOAD["images"]
+
+    def test_deduplicates_preserving_order(self, mt):
+        payload = {
+            "success": True,
+            "images": [
+                "https://mangataro.yachts/storage/chapters/ab/001.webp",
+                "https://mangataro.yachts/storage/chapters/ab/002.webp",
+                "https://mangataro.yachts/storage/chapters/ab/001.webp",  # dup
+            ],
+        }
+        assert mt._pages_from_api_payload(payload) == [
+            "https://mangataro.yachts/storage/chapters/ab/001.webp",
+            "https://mangataro.yachts/storage/chapters/ab/002.webp",
+        ]
+
+    @pytest.mark.parametrize("payload", [
+        {"success": False, "images": ["https://x/storage/chapters/ab/001.webp"]},
+        {"success": True},                       # no images key
+        {"success": True, "images": "nope"},     # images not a list
+        {"success": True, "images": []},         # text/empty chapter
+        {},
+        None,
+        "garbage",
+    ])
+    def test_bad_payloads_return_empty(self, mt, payload):
+        assert mt._pages_from_api_payload(payload) == []
+
+    def test_get_pages_calls_api_with_correct_id_no_rewrite(self, monkeypatch, mt):
+        captured = {}
+
+        def fake_get_json(url, *a, **k):
+            captured["url"] = url
+            captured["headers"] = k.get("headers")
+            return API_PAYLOAD
+
+        # If the API path works, the HTML fallback must never run.
+        def boom_html(url, *a, **k):
+            raise AssertionError("HTML fallback should not be reached")
+
+        monkeypatch.setattr(mt, "_get_json", fake_get_json)
+        monkeypatch.setattr(mt, "_get_html", boom_html)
+
+        pages = mt.get_pages(CHAPTER_URL)
+
+        assert "/auth/chapter-content?chapter_id=547229" in captured["url"]
+        assert captured["url"].startswith("https://mangataro.org/")
+        # URLs are returned exactly as served - no host rewriting.
+        assert pages == API_PAYLOAD["images"]
+        assert all(p.startswith("https://mangataro.yachts/") for p in pages)
+        # The bug: everything got rewritten to the dead mangapeak CDN.
+        assert not any("mangapeak" in p for p in pages)
+
+
+# Fallback: reader HTML when the API yields nothing
+
+
+FALLBACK_HTML = """
+<html><head>
+<meta property='og:image' content='https://mangataro.yachts/storage/chapters/abcdef/001.webp'>
+<script type="application/ld+json">
+{"@type":"ListItem","image":"https://mangataro.org/storage/chapters/abcdef/001.webp"}
+</script>
+</head><body data-chapter-id="547229">
+<img src="https://mangataro.yachts/storage/chapters/abcdef/002.webp">
+<img src="https://mangataro.yachts/storage/chapters/abcdef/003.webp">
+</body></html>
+"""
+
+
+class TestPagesFromHtmlFallback:
+    def test_prefers_cdn_host_and_orders(self, mt):
+        pages = mt._pages_from_html(FALLBACK_HTML)
+        # page 001 appears on both the (404-ing) site domain and the CDN;
+        # the CDN host wins, and pages come out in numeric order.
+        assert pages == [
+            "https://mangataro.yachts/storage/chapters/abcdef/001.webp",
+            "https://mangataro.yachts/storage/chapters/abcdef/002.webp",
+            "https://mangataro.yachts/storage/chapters/abcdef/003.webp",
+        ]
+        assert not any("mangapeak" in p for p in pages)
+
+    def test_get_pages_falls_back_when_api_empty(self, monkeypatch, mt):
+        monkeypatch.setattr(mt, "_get_json", lambda *a, **k: {"success": False})
+        monkeypatch.setattr(mt, "_get_html", lambda url, *a, **k: FALLBACK_HTML)
+
+        pages = mt.get_pages(CHAPTER_URL)
+        assert pages[0] == "https://mangataro.yachts/storage/chapters/abcdef/001.webp"
+        assert len(pages) == 3
+
+    def test_get_pages_recovers_id_from_html_then_uses_api(self, monkeypatch, mt):
+        calls = []
+
+        def fake_get_json(url, *a, **k):
+            calls.append(url)
+            if "chapter_id=547229" in url:
+                return API_PAYLOAD
+            return {"success": False}
+
+        # URL has no /chN-<id> segment, so the id must come from the markup.
+        monkeypatch.setattr(mt, "_get_json", fake_get_json)
+        monkeypatch.setattr(mt, "_get_html",
+                            lambda url, *a, **k: '<body data-chapter-id="547229"></body>')
+
+        pages = mt.get_pages("https://mangataro.org/read/no-id-here/")
+        assert pages == API_PAYLOAD["images"]
+        assert any("chapter_id=547229" in u for u in calls)
+
+    def test_get_pages_empty_when_nothing_anywhere(self, monkeypatch, mt):
+        monkeypatch.setattr(mt, "_get_json", lambda *a, **k: {"success": False})
+        monkeypatch.setattr(mt, "_get_html", lambda url, *a, **k: "<html></html>")
+        assert mt.get_pages(CHAPTER_URL) == []
+
+
+# Adjacent flow: chapter discovery (guards the reader dropdown parse)
+
+
+MANGA_HTML = """
+<html><body>
+<a href="/read/koi-to-yobu-ni-wa-kimochi-warui/ch1-547229">Read Chapter 1</a>
+</body></html>
+"""
+
+READER_HTML = """
+<html><body>
+<select class="chapter-select">
+  <option value="/read/koi-to-yobu-ni-wa-kimochi-warui/ch1-547229">Chapter 1</option>
+  <option value="/read/koi-to-yobu-ni-wa-kimochi-warui/ch2-547233">Chapter 2</option>
+</select>
+</body></html>
+"""
+
+# Live site encodes decimal chapters with a dash in the URL (ch7-5-<id> ==
+# chapter 7.5) while the option text shows a clean "Ch. 7.5".
+READER_HTML_DECIMAL = """
+<html><body>
+<select class="chapter-select">
+  <option value="/read/koi-to-yobu-ni-wa-kimochi-warui/ch7-547252">Ch. 7</option>
+  <option value="/read/koi-to-yobu-ni-wa-kimochi-warui/ch7-5-547254">Ch. 7.5</option>
+  <option value="/read/koi-to-yobu-ni-wa-kimochi-warui/ch14-5-547286">Ch. 14.5</option>
+  <option value="/read/koi-to-yobu-ni-wa-kimochi-warui/ch56-5-547486">Ch. 56.5</option>
+</select>
+</body></html>
+"""
+
+# Fallback path: bare chapter links on the manga page. Text here has no
+# decimal, so the number must come from the dashed-decimal URL shape.
+MANGA_HTML_DECIMAL = """
+<html><body>
+<a href="/read/koi-to-yobu-ni-wa-kimochi-warui/ch7-547252">Read</a>
+<a href="/read/koi-to-yobu-ni-wa-kimochi-warui/ch7-5-547254">Read</a>
+<a href="/read/koi-to-yobu-ni-wa-kimochi-warui/ch14-5-547286">Read</a>
+<a href="/read/koi-to-yobu-ni-wa-kimochi-warui/ch56-5-547486">Read</a>
+</body></html>
+"""
+
+
+class TestChapterNumber:
+    @pytest.mark.parametrize("url,expected", [
+        ("/read/x/ch1-547229", "1"),
+        ("/read/x/ch10-547229", "10"),
+        ("/read/x/ch10.5-999888", "10.5"),        # dotted decimal
+        ("/read/x/ch7-5-547254", "7.5"),          # dashed decimal
+        ("/read/x/ch14-5-547286", "14.5"),
+        ("/read/x/ch56-5-547486", "56.5"),
+        ("/read/x/ch10.5-999888?page=2#top", "10.5"),
+    ])
+    def test_number_from_url(self, url, expected):
+        assert MangaTaroScraper._chapter_number_from_url(url) == expected
+
+    def test_number_from_url_missing(self):
+        assert MangaTaroScraper._chapter_number_from_url(
+            "https://mangataro.org/manga/koi-to-yobu") is None
+
+    def test_prefers_clear_decimal_in_text(self):
+        # Even for a dashed URL, a clean "Ch. 7.5" in the text is honoured.
+        assert MangaTaroScraper._parse_chapter_number(
+            "/read/x/ch7-5-547254", "Ch. 7.5") == "7.5"
+
+    def test_falls_back_to_url_when_text_has_no_number(self):
+        assert MangaTaroScraper._parse_chapter_number(
+            "/read/x/ch56-5-547486", "Read") == "56.5"
+
+    def test_defaults_to_zero(self):
+        assert MangaTaroScraper._parse_chapter_number("/no-chapter", "Read") == "0"
+
+
+class TestChapters:
+    def test_parses_reader_dropdown(self, patch_html, mt):
+        patch_html(mt, {"/manga/": MANGA_HTML, "/read/": READER_HTML})
+        chapters = mt.get_chapters("https://mangataro.org/manga/koi-to-yobu")
+        assert [c.number for c in chapters] == ["1", "2"]
+        assert chapters[0].url == \
+            "https://mangataro.org/read/koi-to-yobu-ni-wa-kimochi-warui/ch1-547229"
+        # Chapter ids extracted here must feed get_pages' API call.
+        assert MangaTaroScraper._extract_chapter_id(chapters[1].url) == "547233"
+
+    def test_dropdown_parses_dashed_decimal_chapters(self, patch_html, mt):
+        # Regression: ch7-5-<id> used to parse as chapter 7 (the "5" was
+        # mistaken for the id), corrupting sort order and new-chapter checks.
+        patch_html(mt, {"/manga/": MANGA_HTML, "/read/": READER_HTML_DECIMAL})
+        chapters = mt.get_chapters("https://mangataro.org/manga/koi-to-yobu")
+        assert [c.number for c in chapters] == ["7", "7.5", "14.5", "56.5"]
+        # 7.5 sorts between 7 and 14.5, and the id is still the trailing segment.
+        assert [c.numeric for c in chapters] == [7.0, 7.5, 14.5, 56.5]
+        assert MangaTaroScraper._extract_chapter_id(chapters[1].url) == "547254"
+
+    def test_fallback_direct_links_parse_dashed_decimal(self, patch_html, mt):
+        # No <select> on the reader page -> direct-link fallback path.
+        patch_html(mt, {"/manga/": MANGA_HTML_DECIMAL,
+                        "/read/": "<html><body>no dropdown</body></html>"})
+        chapters = mt.get_chapters("https://mangataro.org/manga/koi-to-yobu")
+        assert [c.number for c in chapters] == ["7", "7.5", "14.5", "56.5"]
+
+
+# Adjacent flow: search title parsing (direct-URL construction path)
+
+
+class _FakeSearchResponse:
+    def __init__(self, text, url, status=200):
+        self.text = text
+        self.url = url
+        self.status_code = status
+
+
+class TestSearch:
+    def test_direct_url_parses_title(self, monkeypatch, mt):
+        title_html = (
+            "<html><head><title>Koi to Yobu ni wa Kimochi Warui "
+            "Manga | Read Online Free at MangaTaro</title></head>"
+            "<body><img src='https://mangataro.org/content/media/172533l.webp'></body></html>"
+        )
+
+        def fake_get(url, *a, **k):
+            # Direct-URL hit resolves to a /manga/ page; the browse API
+            # returns nothing extra here.
+            return _FakeSearchResponse(title_html, url)
+
+        monkeypatch.setattr(mt.session, "get", fake_get)
+        results = mt.search("koi to yobu")
+        assert results, "expected at least the direct-URL result"
+        assert results[0].title == "Koi to Yobu ni wa Kimochi Warui"
+        assert results[0].url == "https://mangataro.org/manga/koi-to-yobu"

--- a/tests/scrapers/test_playwright_scrapers.py
+++ b/tests/scrapers/test_playwright_scrapers.py
@@ -155,7 +155,6 @@ PLAYWRIGHT_DOMAINS = [
     "isekaiscan.com",
     "zinmanga.com",
     "zazamanga.com",
-    "mangaball.net",
     "mangaclash.com",
     "kunmanga.com",
     "manytoon.com",

--- a/tests/scrapers/test_vymanga.py
+++ b/tests/scrapers/test_vymanga.py
@@ -1,0 +1,222 @@
+"""HTML-fixture tests for VyMangaScraper."""
+
+from __future__ import annotations
+
+import pytest
+
+from memanga.scrapers import get_scraper
+from memanga.scrapers.vymanga import VyMangaScraper
+
+
+@pytest.fixture
+def scraper():
+    return VyMangaScraper()
+
+
+class TestSearch:
+    def test_extracts_dedupes_and_reads_cover(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "search.html"))
+        results = scraper.search("naruto")
+        # 2 unique manga after de-dup (duplicate /manga/naruto-bc8 collapsed)
+        assert len(results) == 2
+        first = results[0]
+        assert first.title == "Naruto"
+        assert first.url == "https://mangavyvy.net/manga/naruto-bc8"
+        assert first.cover_url == "https://cdnxyz.xyz/web/cover/841/thumbnail.png"
+
+    def test_relative_urls_are_absolutised(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "search.html"))
+        results = scraper.search("naruto")
+        assert all(r.url.startswith("https://mangavyvy.net/manga/") for r in results)
+
+    def test_title_falls_back_to_img_alt(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "search.html"))
+        results = scraper.search("naruto")
+        # The third fixture entry has no .comic-title, only img alt.
+        assert any(r.title == "Boruto: Naruto Next Generations" for r in results)
+
+    def test_no_results(self, scraper, patch_html):
+        patch_html(scraper, "<html><body></body></html>")
+        assert scraper.search("nothing") == []
+
+
+class TestGetChapters:
+    def test_numbers_from_id_sorted_ascending_and_deduped(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "manga.html"))
+        chapters = scraper.get_chapters("https://mangavyvy.net/manga/naruto-bc8")
+        # 3 unique chapters (the duplicate chapter-1 href is collapsed)
+        assert len(chapters) == 3
+        nums = [c.numeric for c in chapters]
+        assert nums == sorted(nums)
+        # Number comes from id="chapter-<num>", ignoring the "Vol.72" prefix text.
+        assert [c.number for c in chapters] == ["1", "700", "700.5"]
+
+    def test_decimal_chapter_detected(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "manga.html"))
+        chapters = scraper.get_chapters("https://mangavyvy.net/manga/naruto-bc8")
+        assert any(c.number == "700.5" for c in chapters)
+
+    def test_chapter_url_is_the_redirect_href(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "manga.html"))
+        chapters = scraper.get_chapters("https://mangavyvy.net/manga/naruto-bc8")
+        assert all("aovheroes.com" in c.url for c in chapters)
+
+    @pytest.mark.parametrize("legacy_url", [
+        "https://vymanga.net/manga/naruto-bc8",
+        "https://www.vymanga.net/manga/naruto-bc8",
+        "https://vyvymanga.net/manga/naruto-bc8",
+        "https://www.vyvymanga.net/manga/naruto-bc8",
+    ])
+    def test_legacy_host_urls_are_fetched_from_canonical_host(
+        self, scraper, load_fixture, monkeypatch, legacy_url
+    ):
+        # Direct old-domain manga URLs 403 upstream; get_chapters must fetch the
+        # identical path from the canonical host instead.
+        fetched = []
+
+        def fake_get_html(url):
+            fetched.append(url)
+            return load_fixture("vymanga", "manga.html")
+
+        monkeypatch.setattr(scraper, "_get_html", fake_get_html)
+        chapters = scraper.get_chapters(legacy_url)
+        assert fetched == ["https://mangavyvy.net/manga/naruto-bc8"]
+        assert len(chapters) == 3
+
+    def test_canonical_host_url_is_left_untouched(self, scraper, load_fixture, monkeypatch):
+        fetched = []
+
+        def fake_get_html(url):
+            fetched.append(url)
+            return load_fixture("vymanga", "manga.html")
+
+        monkeypatch.setattr(scraper, "_get_html", fake_get_html)
+        scraper.get_chapters("https://mangavyvy.net/manga/naruto-bc8?x=1")
+        assert fetched == ["https://mangavyvy.net/manga/naruto-bc8?x=1"]
+
+
+class TestGetPages:
+    def test_reads_carousel_and_skips_loading_and_related(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "chapter.html"))
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        # 3 reader pages; loading.gif skipped and the related-manga
+        # collection thumbnail excluded.
+        assert len(pages) == 3
+        assert all("drive-storage" in p for p in pages)
+        assert not any("loading" in p.lower() for p in pages)
+        assert not any("collections" in p for p in pages)
+
+    def test_excludes_same_author_recommendation_thumbnails(self, scraper, patch_html, load_fixture):
+        # The live reader embeds a "same author" recommendation table *inside*
+        # the page carousel; its cover thumbnails (img-recommend, served from
+        # the site's own cover CDN) must never be scraped as pages.
+        patch_html(scraper, load_fixture("vymanga", "chapter.html"))
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        assert len(pages) == 3
+        assert all("2.bp.blogspot.com" in p for p in pages)
+        assert not any("cdnxyz" in p for p in pages)
+        assert not any("/cover/" in p for p in pages)
+        assert not any("collections" in p for p in pages)
+
+    def test_preserves_page_order(self, scraper, patch_html, load_fixture):
+        patch_html(scraper, load_fixture("vymanga", "chapter.html"))
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        assert pages == [
+            "https://2.bp.blogspot.com/drive-storage/PAGE-001=w700",
+            "https://2.bp.blogspot.com/drive-storage/PAGE-002=w700",
+            "https://2.bp.blogspot.com/drive-storage/PAGE-003=w700",
+        ]
+
+    def test_keeps_pages_whose_cdn_id_contains_placeholder_words(self, scraper, patch_html):
+        # Reader page IDs are opaque base64 blobs that can coincidentally
+        # contain "icon"/"logo"/"blank" etc. Those pages must NOT be dropped.
+        html = """
+        <div id="carousel" class="carousel slide"><div class="vview carousel-inner">
+          <div class="carousel-item active">
+            <img class="d-block w-100" data-src="https://2.bp.blogspot.com/drive-storage/AAiconBBlogoCC=w700"
+                 src="https://mangavyvy.net/web/img/loading.gif">
+          </div>
+          <div class="carousel-item">
+            <img class="d-block w-100" data-src="https://2.bp.blogspot.com/drive-storage/blankXYloading=w700"
+                 src="https://mangavyvy.net/web/img/loading.gif">
+          </div>
+        </div></div>
+        """
+        patch_html(scraper, html)
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        assert pages == [
+            "https://2.bp.blogspot.com/drive-storage/AAiconBBlogoCC=w700",
+            "https://2.bp.blogspot.com/drive-storage/blankXYloading=w700",
+        ]
+
+    def test_skips_gif_placeholder_when_no_datasrc(self, scraper, patch_html):
+        # A slide that never lazy-loaded (only the loading.gif in src) is skipped
+        # rather than emitted as a bogus page.
+        html = """
+        <div id="carousel" class="carousel slide"><div class="vview carousel-inner">
+          <div class="carousel-item active">
+            <img class="d-block w-100" src="https://mangavyvy.net/web/img/loading.gif">
+          </div>
+          <div class="carousel-item">
+            <img class="d-block w-100" data-src="https://2.bp.blogspot.com/drive-storage/REAL=w700"
+                 src="https://mangavyvy.net/web/img/loading.gif">
+          </div>
+        </div></div>
+        """
+        patch_html(scraper, html)
+        pages = scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==")
+        assert pages == ["https://2.bp.blogspot.com/drive-storage/REAL=w700"]
+
+    def test_no_pages(self, scraper, patch_html):
+        patch_html(scraper, "<html><body><p>no reader here</p></body></html>")
+        assert scraper.get_pages("https://aovheroes.com/rds/br/rdsd?data=AAA==") == []
+
+
+class TestDownloadImage:
+    def test_success_writes_file(self, monkeypatch, scraper, tmp_path, fake_response):
+        monkeypatch.setattr(scraper.session, "get",
+                             lambda *a, **k: fake_response(content=b"data" * 100))
+        ok = scraper.download_image("https://x.com/p.jpg", tmp_path / "p.jpg")
+        assert ok is True
+        assert (tmp_path / "p.jpg").exists()
+
+    def test_failure_returns_false(self, monkeypatch, scraper, tmp_path):
+        def boom(*a, **k):
+            raise IOError("nope")
+        monkeypatch.setattr(scraper.session, "get", boom)
+        assert scraper.download_image("https://x", tmp_path / "p.jpg") is False
+
+
+class TestRegistry:
+    @pytest.mark.parametrize("domain", [
+        "mangavyvy.net",
+        "vymanga.net",
+        "vyvymanga.net",
+    ])
+    def test_domains_resolve(self, domain):
+        assert isinstance(get_scraper(domain), VyMangaScraper)
+
+    @pytest.mark.parametrize("domain", [
+        "www.mangavyvy.net",
+        "www.vymanga.net",
+        "www.vyvymanga.net",
+    ])
+    def test_www_prefix_resolves(self, domain):
+        # get_scraper strips the leading "www." before lookup.
+        assert isinstance(get_scraper(domain), VyMangaScraper)
+
+    @pytest.mark.parametrize("domain", [
+        "m.mangavyvy.net",
+        "read.vyvymanga.net",
+    ])
+    def test_subdomain_suffix_resolves(self, domain):
+        # Arbitrary subdomains suffix-match their registered base host.
+        assert isinstance(get_scraper(domain), VyMangaScraper)
+
+    def test_legacy_host_in_registry_matches_canonicaliser(self):
+        # Every host the scraper canonicalises must also resolve via the
+        # registry, so saved/manual entries reach a scraper before
+        # canonicalisation runs.
+        from memanga.scrapers.vymanga import _LEGACY_HOSTS
+        for host in _LEGACY_HOSTS:
+            assert isinstance(get_scraper(host), VyMangaScraper), host

--- a/tests/unit/test_search.py
+++ b/tests/unit/test_search.py
@@ -191,6 +191,15 @@ class TestComputeSearchSources:
         assert "mangasee123.com" not in sources
         assert "manganato.com" not in sources
 
+    def test_region_blocked_mangago_excluded(self):
+        # mangago.me is reachable globally but DNS/SNI-blocked in some
+        # regions, where every request stalls in connect() and hangs the
+        # sweep slot (issue #151). Both aliases must stay out of the sweep;
+        # the www one used to win the canonical de-dup and get probed.
+        sources = compute_search_sources(FakeConfig())
+        assert "mangago.me" not in sources
+        assert "www.mangago.me" not in sources
+
     def test_disabled_sources_removed(self):
         sources = compute_search_sources(FakeConfig({
             "sources.disabled": ["mangadex.org"],


### PR DESCRIPTION
## Summary

Sync the `cli` branch for the `v0.4.3` release by porting the CLI-relevant scraper fixes and additions from `main`, then bumping CLI version metadata and changelog notes.

Desktop-only release packaging changes stay on `main`.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behaviour change)
- [x] Docs
- [x] Scraper added or fixed
- [ ] Build / CI

## Checklist

- [x] `pytest` passes locally
- [x] New behaviour has tests (or notes saying why not)
- [x] No `print` debug noise left in production code
- [x] No secrets, `.env`, or personal config in the diff
- [x] If you touched a scraper, you ran the live probe at least once

## Related issues

Release sync for v0.4.3.

## Verification

- `venv/bin/python -m pytest tests/scrapers/test_mangaball_api.py tests/scrapers/test_mangataro.py tests/scrapers/test_vymanga.py tests/scrapers/test_mangago.py tests/scrapers/test_mangadot.py tests/scrapers/test_atsumaru_api.py tests/unit/test_search.py -q` passed locally: 168 passed.
- `venv/bin/python -m compileall -q memanga tests` passed locally.
- CLI release metadata check passed: `pyproject.toml`, `memanga.__version__`, and the CLI changelog point to `0.4.3` / `v0.4.3`.